### PR TITLE
Flpy 6 version check

### DIFF
--- a/flow360/solver_version.py
+++ b/flow360/solver_version.py
@@ -23,6 +23,9 @@ class Flow360Version:
         if self.head == "master":
             self.tail = [i * 100 for i in self.tail]
 
+    def __str__(self):
+        return self.full
+
     def __lt__(self, other):
         return self.tail < other.tail
 

--- a/flow360/version_check.py
+++ b/flow360/version_check.py
@@ -1,0 +1,95 @@
+"Client version check module"
+import re
+import sys
+from enum import Enum
+
+import requests
+from packaging.version import Version
+from requests import HTTPError
+
+from .cloud import http_util
+from .solver_version import Flow360Version as sv
+from .version import __version__
+
+
+class VersionSupported(Enum):
+    """
+    If version is supported
+    """
+
+    YES = 1
+    NO = 2
+    CAN_UPGRADE = 3
+
+
+def get_supported_server_versions(app_name):
+    """
+    fetch list of supported versions
+    """
+    try:
+        session = requests.Session()
+        http = http_util.Http(session)
+        response = http.get(f"versions?app_name={app_name}")
+    except HTTPError as exc:
+        raise HTTPError("Error in connecting server") from exc
+
+    versions = [re.sub(r".+-", "", item["version"]) for item in response]
+
+    if len(versions) == 0:
+        raise RuntimeError("Error in fetching supported versions")
+
+    return versions
+
+
+def check_client_version(app_name):
+    """
+    app_name: the app_name for filtering the versions
+    check the current version with available versions
+    if the current version is no loger supported, return VersionSupported.NO, current_version
+    if the current version can be upgraded, return VersionSupported.CAN_UPGRADE, latest_version
+    otherwise, return VersionSupported.YES, current_version
+    """
+    supported_versions = get_supported_server_versions(app_name)
+    latest_version = supported_versions[0]
+    current_version = __version__
+    if app_name == "flow360-python-client-v2":
+        current_version = Version(current_version)
+        is_supported = any(current_version == Version(v) for v in supported_versions)
+        can_upgrade = current_version < Version(latest_version)
+    else:
+        current_version = sv(current_version)
+        is_supported = any(current_version == sv(v) for v in supported_versions)
+        can_upgrade = current_version < sv(latest_version)
+
+    if not is_supported:
+        return VersionSupported.NO, current_version
+
+    if can_upgrade:
+        return VersionSupported.CAN_UPGRADE, latest_version
+
+    return VersionSupported.YES, current_version
+
+
+def client_version_get_info(app_name):
+    """
+    Get information on if the client version is 1)supported 2)the latest version
+    throw SystemExit 0 error if client version is not supported
+    """
+    version_status, version = check_client_version(app_name)
+
+    if version_status == VersionSupported.NO:
+        print(f"\nYour version of CLI ({version}) is no longer supported.")
+    elif version_status == VersionSupported.CAN_UPGRADE:
+        print(f"\nNew version of CLI ({version}) is now available.")
+    else:
+        return
+
+    msg = """
+    To upgrade run:
+        pip3 install -U flow360client
+
+    """
+    print(msg)
+
+    if version_status == VersionSupported.NO:
+        sys.exit(0)

--- a/tests/test_version_check.py
+++ b/tests/test_version_check.py
@@ -9,35 +9,30 @@ import flow360.version_check as vc
 def test_get_supported_server_versions():
     # Prepare mock data
     mock_response = MagicMock()
-    mock_response.__iter__.return_value = iter(
-        [{"version": "1.0.0"}, {"version": "2.0.3b5"}])
+    mock_response.__iter__.return_value = iter([{"version": "1.0.0"}, {"version": "2.0.3b5"}])
     # Mock the http_util.Http.get method
     with patch("flow360.version_check.http_util.Http.get") as mock_get:
         mock_get.return_value = mock_response
         # Test with a valid app_name
-        versions = vc.get_supported_server_versions(
-            "flow360-python-client-v2")
+        versions = vc.get_supported_server_versions("flow360-python-client-v2")
         # Add appropriate assertions based on the expected behavior
         assert versions == ["1.0.0", "2.0.3b5"]
 
         # Test with an HTTPError
         mock_get.side_effect = requests.exceptions.HTTPError()
         with pytest.raises(requests.exceptions.HTTPError):
-            vc.get_supported_server_versions(
-                "invalid-app_name")
+            vc.get_supported_server_versions("invalid-app_name")
 
         # Check if the expected error message is raised
         with pytest.raises(requests.exceptions.HTTPError) as exc_info:
-            vc.get_supported_server_versions(
-                "flow360-python-client-v2")
+            vc.get_supported_server_versions("flow360-python-client-v2")
         assert str(exc_info.value) == "Error in connecting server"
 
     # Test with no version
     mock_response.__iter__.return_value = iter([])
     with patch("flow360.version_check.http_util.Http.get") as mock_get:
         with pytest.raises(RuntimeError) as exc_info:
-            vc.get_supported_server_versions(
-                "flow360-python-client-v2")
+            vc.get_supported_server_versions("flow360-python-client-v2")
         assert str(exc_info.value) == "Error in fetching supported versions"
 
 
@@ -64,8 +59,7 @@ def test_check_client_version():
         with patch(
             "flow360.version_check.get_supported_server_versions", return_value=supported_versions
         ):
-            version_status, version = vc.check_client_version(
-                "flow360-python-client-v2")
+            version_status, version = vc.check_client_version("flow360-python-client-v2")
             assert version_status == vc.VersionSupported.YES
             assert str(version) == current_version
 
@@ -75,8 +69,7 @@ def test_check_client_version():
         with patch(
             "flow360.version_check.get_supported_server_versions", return_value=supported_versions
         ):
-            version_status, version = vc.check_client_version(
-                "flow360-python-client-v2")
+            version_status, version = vc.check_client_version("flow360-python-client-v2")
             assert version_status == vc.VersionSupported.NO
             assert str(version) == current_version
 
@@ -86,8 +79,7 @@ def test_check_client_version():
         with patch(
             "flow360.version_check.get_supported_server_versions", return_value=supported_versions
         ):
-            version_status, version = vc.check_client_version(
-                "flow360-python-client-v2")
+            version_status, version = vc.check_client_version("flow360-python-client-v2")
             assert version_status == vc.VersionSupported.CAN_UPGRADE
             assert str(version) == latest_version
 
@@ -139,24 +131,21 @@ def test_client_version_get_info(capsys):
     # Test VersionSupported.NO
     with patch("flow360.version_check.check_client_version") as mock_check_client_version:
         with pytest.raises(SystemExit) as exc_info:
-            mock_check_client_version.return_value = (
-                vc.VersionSupported.NO, "1.0")
+            mock_check_client_version.return_value = (vc.VersionSupported.NO, "1.0")
             vc.client_version_get_info("solver")
             captured = capsys.readouterr()
             assert "Your version of CLI (1.0) is no longer supported." in captured.out
 
     # Test VersionSupported.CAN_UPGRADE
     with patch("flow360.version_check.check_client_version") as mock_check_client_version:
-        mock_check_client_version.return_value = (
-            vc.VersionSupported.CAN_UPGRADE, "2.0")
+        mock_check_client_version.return_value = (vc.VersionSupported.CAN_UPGRADE, "2.0")
         vc.client_version_get_info("app_name")
         captured = capsys.readouterr()
         assert "New version of CLI (2.0) is now available." in captured.out
 
     # Test VersionSupported.YES
     with patch("flow360.version_check.check_client_version") as mock_check_client_version:
-        mock_check_client_version.return_value = (
-            vc.VersionSupported.YES, "1.0")
+        mock_check_client_version.return_value = (vc.VersionSupported.YES, "1.0")
         vc.client_version_get_info("app_name")
         captured = capsys.readouterr()
         assert captured.out == ""

--- a/tests/test_version_check.py
+++ b/tests/test_version_check.py
@@ -1,0 +1,156 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+import flow360.version_check
+from flow360.version_check import *
+
+
+def test_get_supported_server_versions():
+    # Prepare mock data
+    mock_response = MagicMock()
+    mock_response.__iter__.return_value = iter([{"version": "1.0.0"}, {"version": "2.0.3b5"}])
+    # Mock the http_util.Http.get method
+    with patch("flow360.version_check.http_util.Http.get") as mock_get:
+        mock_get.return_value = mock_response
+        # Test with a valid app_name
+        versions = flow360.version_check.get_supported_server_versions("flow360-python-client-v2")
+        # Add appropriate assertions based on the expected behavior
+        assert versions == ["1.0.0", "2.0.3b5"]
+
+        # Test with an HTTPError
+        mock_get.side_effect = requests.exceptions.HTTPError()
+        with pytest.raises(requests.exceptions.HTTPError):
+            flow360.version_check.get_supported_server_versions("invalid-app_name")
+
+        # Check if the expected error message is raised
+        with pytest.raises(requests.exceptions.HTTPError) as exc_info:
+            flow360.version_check.get_supported_server_versions("flow360-python-client-v2")
+        assert str(exc_info.value) == "Error in connecting server"
+
+    # Test with no version
+    mock_response.__iter__.return_value = iter([])
+    with patch("flow360.version_check.http_util.Http.get") as mock_get:
+        with pytest.raises(RuntimeError) as exc_info:
+            flow360.version_check.get_supported_server_versions("flow360-python-client-v2")
+        assert str(exc_info.value) == "Error in fetching supported versions"
+
+
+def test_check_client_version():
+    # Test with PEP440 version naming semantics
+    supported_versions = [
+        "2.1.0",
+        "2.1.0b3",
+        "2.1.0b2",
+        "2.1.0b1",
+        "2.0.0",
+        "2.0.0rc1",
+        "2.0.0b2",
+        "2.0.0b1",
+        "1.0.0",
+        "1.0.0a1",
+    ]
+    latest_version = supported_versions[0]
+
+    # Test with supported app_name and current version in supported versions
+    current_version = "2.1.0"
+
+    with patch("flow360.version_check.__version__", current_version):
+        with patch(
+            "flow360.version_check.get_supported_server_versions", return_value=supported_versions
+        ):
+            version_status, version = check_client_version("flow360-python-client-v2")
+            assert version_status == VersionSupported.YES
+            assert str(version) == current_version
+
+    # Test with supported app_name and current version not in supported versions
+    current_version = "2.2.0"
+    with patch("flow360.version_check.__version__", current_version):
+        with patch(
+            "flow360.version_check.get_supported_server_versions", return_value=supported_versions
+        ):
+            version_status, version = check_client_version("flow360-python-client-v2")
+            assert version_status == VersionSupported.NO
+            assert str(version) == current_version
+
+    # Test with supported app_name and current version that can be upgraded
+    current_version = "2.0.0b1"
+    with patch("flow360.version_check.__version__", current_version):
+        with patch(
+            "flow360.version_check.get_supported_server_versions", return_value=supported_versions
+        ):
+            version_status, version = check_client_version("flow360-python-client-v2")
+            assert version_status == VersionSupported.CAN_UPGRADE
+            assert str(version) == latest_version
+
+    # Test with solver version semantics
+    supported_versions = [
+        "release-22.3.4.0",
+        "release-22.1.1.0",
+        "release-0.3.0",
+        "beta-22.3.4.100",
+        "beta-22.1.3.0",
+        "beta-0.3.0",
+        "dummy-22.1.3.0",
+        "du-1m-m2y3-22.1.3.0",
+    ]
+    latest_version = supported_versions[0]
+    # Test with supported app_name and current version in supported versions
+    current_version = "release-22.3.4.0"
+
+    with patch("flow360.version_check.__version__", current_version):
+        with patch(
+            "flow360.version_check.get_supported_server_versions", return_value=supported_versions
+        ):
+            version_status, version = check_client_version("solver")
+            assert version_status == VersionSupported.YES
+            assert str(version) == current_version
+
+    # Test with supported app_name and current version not in supported versions
+    current_version = "beta-22.3.1.100"
+    with patch("flow360.version_check.__version__", current_version):
+        with patch(
+            "flow360.version_check.get_supported_server_versions", return_value=supported_versions
+        ):
+            version_status, version = check_client_version("solver")
+            assert version_status == VersionSupported.NO
+            assert str(version) == current_version
+
+    # Test with supported app_name and current version that can be upgraded
+    current_version = "release-22.1.1.0"
+    with patch("flow360.version_check.__version__", current_version):
+        with patch(
+            "flow360.version_check.get_supported_server_versions", return_value=supported_versions
+        ):
+            version_status, version = check_client_version("solver")
+            assert version_status == VersionSupported.CAN_UPGRADE
+            assert str(version) == latest_version
+
+
+def test_client_version_get_info(capsys):
+    # Test VersionSupported.NO
+    with patch("flow360.version_check.check_client_version") as mock_check_client_version:
+        with pytest.raises(SystemExit) as exc_info:
+            mock_check_client_version.return_value = (VersionSupported.NO, "1.0")
+            client_version_get_info("solver")
+            captured = capsys.readouterr()
+            assert "Your version of CLI (1.0) is no longer supported." in captured.out
+
+    # Test VersionSupported.CAN_UPGRADE
+    with patch("flow360.version_check.check_client_version") as mock_check_client_version:
+        mock_check_client_version.return_value = (VersionSupported.CAN_UPGRADE, "2.0")
+        client_version_get_info("app_name")
+        captured = capsys.readouterr()
+        assert "New version of CLI (2.0) is now available." in captured.out
+
+    # Test VersionSupported.YES
+    with patch("flow360.version_check.check_client_version") as mock_check_client_version:
+        mock_check_client_version.return_value = (VersionSupported.YES, "1.0")
+        client_version_get_info("app_name")
+        captured = capsys.readouterr()
+        assert captured.out == ""
+
+
+# Run the tests
+pytest.main()


### PR DESCRIPTION
[Jira Ticket](https://flow360.atlassian.net/browse/FLPY-6?atlOrigin=eyJpIjoiOTc5YjAxOTFlNzg4NGM2ZDhlYzYzYTM4MzI4N2Q3YzgiLCJwIjoiaiJ9)

Summary:
Implement version check to get information on if the client version is 
1)supported 
2)the latest version
3)throw SystemExit 0 error if client version is not supported

Coverage:
flow360/solver_version.py                                                                                 27      5    81%
flow360/version_check.py                                                                                  51      0   100%

Note:
python client version follows [PEP440](https://peps.python.org/pep-0440/) semantics
other app versions follow solver_version.py semantics

Future TODO:
Use standard python version format [PEP440](https://peps.python.org/pep-0440/) semantics for all version naming