### PR TITLE
Lin/improve pydantic error

### DIFF
--- a/flow360/__init__.py
+++ b/flow360/__init__.py
@@ -1,6 +1,10 @@
 """
 This module is flow360.
 """
+
+
+from flow360 import global_exception_handler  # This sets the global exception handler
+
 from .cli import flow360
 from .cloud.s3_utils import ProgressCallbackInterface
 from .component import meshing

--- a/flow360/global_exception_handler.py
+++ b/flow360/global_exception_handler.py
@@ -1,0 +1,25 @@
+"""
+Module: custom_exception_wrapper for ValidationError
+"""
+import sys
+import traceback
+
+from pydantic import ValidationError as PydanticValidationError
+
+from flow360.exceptions import ValidationError
+
+
+def custom_exception_handler(exctype, value, trace_back):
+    """
+    handle global exceptions
+    """
+    if isinstance(value, PydanticValidationError):
+        error_messages = ", ".join(map(str, value.errors()))  # Convert list of errors to a string
+        error_traceback = "".join(
+            traceback.format_exception(exctype, value, trace_back)
+        )  # Get string representation of traceback
+        raise ValidationError(f"{error_messages}\n{error_traceback}")
+    sys.__excepthook__(exctype, value, trace_back)
+
+
+sys.excepthook = custom_exception_handler

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+from flow360 import global_exception_handler


### PR DESCRIPTION
[jira ticket](https://flow360.atlassian.net/browse/FLPY-19)
use sys.excepthook to globally catch and wrap pydantic ValidationError to custom defined ValidationError in flow360 exception.py in flow360 and tests folders

You can test that it indeed wraps a pydantic ValidationError by putting this code anywhere in flow360 and tests. This code raises a pydantic ValidationError
```
from pydantic import BaseModel, ValidationError, conint


class User(BaseModel):
    username: str
    age: int


# Attempt to validate data that doesn't meet the requirements
invalid_data = {
    "username": "john_doe",
    "age": "not_an_integer",  # age should be an integer, not a string
}
user = User(**invalid_data)

```