### PR TITLE
Support volume zones and aeroacoustic output

### DIFF
--- a/flow360/__init__.py
+++ b/flow360/__init__.py
@@ -25,6 +25,7 @@ from .component.flow360_params.flow360_params import (
     NoSlipWall,
     SlidingInterface,
     SlidingInterfaceBoundary,
+    ReferenceFrame,
     SlipWall,
     SubsonicInflow,
     SubsonicOutflowMach,
@@ -34,6 +35,9 @@ from .component.flow360_params.flow360_params import (
     TurbulenceModelSolver,
     UnvalidatedFlow360Params,
     WallFunction,
+    FluidDynamicsVolumeZone,
+    HeatTransferVolumeZone,
+    VolumeZones,
 )
 from .component.meshing.params import SurfaceMeshingParams, VolumeMeshingParams
 from .component.surface_mesh import SurfaceMesh

--- a/flow360/__init__.py
+++ b/flow360/__init__.py
@@ -11,21 +11,24 @@ from .component.case import Case
 from .component.case import CaseList as MyCases
 from .component.flow360_params import solvers
 from .component.flow360_params.flow360_params import (
+    AeroacousticOutput,
     Boundaries,
     Flow360MeshParams,
     Flow360Params,
+    FluidDynamicsVolumeZone,
     Freestream,
     FreestreamBoundary,
     Geometry,
+    HeatTransferVolumeZone,
     IsothermalWall,
     MassInflow,
     MassOutflow,
     MeshBoundary,
     NavierStokesSolver,
     NoSlipWall,
+    ReferenceFrame,
     SlidingInterface,
     SlidingInterfaceBoundary,
-    ReferenceFrame,
     SlipWall,
     SubsonicInflow,
     SubsonicOutflowMach,
@@ -34,10 +37,8 @@ from .component.flow360_params.flow360_params import (
     TimeSteppingCFL,
     TurbulenceModelSolver,
     UnvalidatedFlow360Params,
-    WallFunction,
-    FluidDynamicsVolumeZone,
-    HeatTransferVolumeZone,
     VolumeZones,
+    WallFunction,
 )
 from .component.meshing.params import SurfaceMeshingParams, VolumeMeshingParams
 from .component.surface_mesh import SurfaceMesh

--- a/flow360/component/flow360_params/flow360_params.py
+++ b/flow360/component/flow360_params/flow360_params.py
@@ -585,19 +585,24 @@ class VolumeZoneType(ABC, Flow360BaseModel):
 
     model_type: str
 
+
 class InitialConditionHeatTransfer(Flow360BaseModel):
     """InitialConditionHeatTransfer"""
 
     T_solid: Union[PositiveFloat, str]
+
 
 class HeatTransferVolumeZone(VolumeZoneType):
     """HeatTransferVolumeZone type"""
 
     model_type = pd.Field("HeatTransfer", const=True)
     thermal_conductivity: PositiveFloat = pd.Field(alias="thermalConductivity")
-    volumetric_heat_source: Optional[Union[NonNegativeFloat, str]] = pd.Field(alias="volumetricHeatSource")
+    volumetric_heat_source: Optional[Union[NonNegativeFloat, str]] = pd.Field(
+        alias="volumetricHeatSource"
+    )
     heat_capacity: Optional[PositiveFloat] = pd.Field(alias="heatCapacity")
-    initial_condition: Optional[InitialConditionHeatTransfer] =  pd.Field(alias="initialCondition")
+    initial_condition: Optional[InitialConditionHeatTransfer] = pd.Field(alias="initialCondition")
+
 
 class ReferenceFrame(Flow360BaseModel):
     """:class:`ReferenceFrame` class for setting up reference frame
@@ -644,7 +649,6 @@ class ReferenceFrame(Flow360BaseModel):
         )
     """
 
-
     theta_radians: Optional[str] = pd.Field(alias="thetaRadians")
     theta_degrees: Optional[str] = pd.Field(alias="thetaDegrees")
     omega_radians: Optional[float] = pd.Field(alias="omegaRadians")
@@ -669,9 +673,7 @@ class FluidDynamicsVolumeZone(VolumeZoneType):
     """FluidDynamicsVolumeZone type"""
 
     model_type = pd.Field("FluidDynamics", const=True)
-    reference_frame: Optional[ReferenceFrame] =  pd.Field(alias="ReferenceFrame")
-
-
+    reference_frame: Optional[ReferenceFrame] = pd.Field(alias="ReferenceFrame")
 
 
 class _GenericVolumeZonesWrapper(Flow360BaseModel):
@@ -698,7 +700,6 @@ class VolumeZones(Flow360SortableBaseModel):
         )
     """
 
-
     @pd.root_validator(pre=True)
     def validate_zone(cls, values):
         """Validator for zone list section
@@ -708,8 +709,35 @@ class VolumeZones(Flow360SortableBaseModel):
         ValidationError
             When zone is incorrect
         """
-        return _self_named_property_validator(values, _GenericVolumeZonesWrapper, msg="is not any of supported volume zone types.")
+        return _self_named_property_validator(
+            values, _GenericVolumeZonesWrapper, msg="is not any of supported volume zone types."
+        )
 
+
+class AeroacousticOutput(Flow360BaseModel):
+    """:class:`AeroacousticOutput` class for configuring output data about acoustic pressure signals
+
+    Parameters
+    ----------
+    observers : List[Coordinate]
+        List of observer locations at which time history of acoustic pressure signal is stored in aeroacoustic output
+        file. The observer locations can be outside the simulation domain, but cannot be inside the solid surfaces of
+        the simulation domain.
+
+    Returns
+    -------
+    :class:`AeroacousticOutput`
+        An instance of the component class AeroacousticOutput.
+
+    Example
+    -------
+    >>> aeroacoustics = AeroacousticOutput()
+    """
+
+    animation_frequency: Optional[PositiveInt] = pd.Field(alias="animationFrequency")
+    animation_frequency_offset: Optional[int] = pd.Field(alias="animationFrequencyOffset")
+    patch_type: Optional[str] = pd.Field("solid", const=True)
+    observers: List[Coordinate] = pd.Field(alias="observers")
 
 
 class Geometry(Flow360BaseModel):
@@ -890,7 +918,7 @@ class Flow360Params(Flow360BaseModel):
     iso_surface_output: Optional[Dict] = pd.Field(alias="isoSurfaceOutput")
     monitor_output: Optional[Dict] = pd.Field(alias="monitorOutput")
     volume_zones: Optional[VolumeZones] = pd.Field(alias="volumeZones")
-
+    aeroacoustic_output: Optional[AeroacousticOutput] = pd.Field(alias="aeroacousticOutput")
 
     # pylint: disable=invalid-name
     def _get_non_dimensionalisation(self):

--- a/flow360/component/flow360_params/flow360_params.py
+++ b/flow360/component/flow360_params/flow360_params.py
@@ -8,6 +8,7 @@ from abc import ABC
 from typing import Dict, List, Optional, Union
 
 import pydantic as pd
+from pydantic import StrictStr
 from typing_extensions import Literal
 
 from ...exceptions import ConfigError, Flow360NotImplementedError, ValidationError
@@ -589,7 +590,7 @@ class VolumeZoneType(ABC, Flow360BaseModel):
 class InitialConditionHeatTransfer(Flow360BaseModel):
     """InitialConditionHeatTransfer"""
 
-    T_solid: Union[PositiveFloat, str]
+    T_solid: Union[PositiveFloat, StrictStr]
 
 
 class HeatTransferVolumeZone(VolumeZoneType):
@@ -597,7 +598,7 @@ class HeatTransferVolumeZone(VolumeZoneType):
 
     model_type = pd.Field("HeatTransfer", const=True)
     thermal_conductivity: PositiveFloat = pd.Field(alias="thermalConductivity")
-    volumetric_heat_source: Optional[Union[NonNegativeFloat, str]] = pd.Field(
+    volumetric_heat_source: Optional[Union[NonNegativeFloat, StrictStr]] = pd.Field(
         alias="volumetricHeatSource"
     )
     heat_capacity: Optional[PositiveFloat] = pd.Field(alias="heatCapacity")

--- a/flow360/component/flow360_params/flow360_params.py
+++ b/flow360/component/flow360_params/flow360_params.py
@@ -724,6 +724,10 @@ class AeroacousticOutput(Flow360BaseModel):
         List of observer locations at which time history of acoustic pressure signal is stored in aeroacoustic output
         file. The observer locations can be outside the simulation domain, but cannot be inside the solid surfaces of
         the simulation domain.
+    animation_frequency: Union[PositiveInt, Literal[-1]], optional
+        Frame frequency in the animation
+    animation_frequency_offset: int, optional
+        Animation frequency offset
 
     Returns
     -------
@@ -732,13 +736,15 @@ class AeroacousticOutput(Flow360BaseModel):
 
     Example
     -------
-    >>> aeroacoustics = AeroacousticOutput()
+    >>> aeroacoustics = AeroacousticOutput(observers=[(0, 0, 0), (1, 1, 1)], animation_frequency=1)
     """
 
-    animation_frequency: Optional[PositiveInt] = pd.Field(alias="animationFrequency")
+    animation_frequency: Optional[Union[PositiveInt, Literal[-1]]] = pd.Field(
+        alias="animationFrequency"
+    )
     animation_frequency_offset: Optional[int] = pd.Field(alias="animationFrequencyOffset")
-    patch_type: Optional[str] = pd.Field("solid", const=True)
-    observers: List[Coordinate] = pd.Field(alias="observers")
+    patch_type: Optional[str] = pd.Field("solid", const=True, alias="patchType")
+    observers: List[Coordinate] = pd.Field()
 
 
 class Geometry(Flow360BaseModel):

--- a/flow360/log.py
+++ b/flow360/log.py
@@ -1,7 +1,7 @@
 """Logging for Flow360."""
 import os
-import time
 import platform
+import time
 from datetime import datetime
 from typing import Union
 
@@ -332,7 +332,7 @@ set_logging_console()
 log_dir = flow360_dir + "logs"
 if not os.path.exists(log_dir):
     os.makedirs(log_dir)
-# TODO: Fix Windows log file write performance
+
 # Writing log files on Windows is currently very slow, toggled off until a fix is implemented
 if platform.system() != "Windows":
     set_logging_file(os.path.join(log_dir, "flow360_python.log"), level="DEBUG")

--- a/flow360/log.py
+++ b/flow360/log.py
@@ -1,6 +1,7 @@
 """Logging for Flow360."""
 import os
 import time
+import platform
 from datetime import datetime
 from typing import Union
 
@@ -331,4 +332,7 @@ set_logging_console()
 log_dir = flow360_dir + "logs"
 if not os.path.exists(log_dir):
     os.makedirs(log_dir)
-set_logging_file(os.path.join(log_dir, "flow360_python.log"), level="DEBUG")
+# TODO: Fix Windows log file write performance
+# Writing log files on Windows is currently very slow, toggled off until a fix is implemented
+if platform.system() != "Windows":
+    set_logging_file(os.path.join(log_dir, "flow360_python.log"), level="DEBUG")

--- a/tests/test_flow360_params.py
+++ b/tests/test_flow360_params.py
@@ -777,7 +777,18 @@ def test_aeroacoustic_output():
 
     assert output
 
+    output = AeroacousticOutput(
+        observers=[(0, 0, 0), (0, 1, 1)], animation_frequency=-1, animation_frequency_offset=0
+    )
+
+    assert output
+
     to_file_from_file_test(output)
+
+    with pytest.raises(pd.ValidationError):
+        output = AeroacousticOutput(
+            observers=[(0, 0, 0), (0, 1, 1)], animation_frequency=-2, animation_frequency_offset=0
+        )
 
     output = AeroacousticOutput(
         observers=[(0, 0, 0), (0, 1, 1)],

--- a/tests/test_flow360_params.py
+++ b/tests/test_flow360_params.py
@@ -706,13 +706,23 @@ def test_volume_zones():
 
     zone = HeatTransferVolumeZone(thermal_conductivity=1, volumetric_heat_source=1)
 
-    assert zone.volumetric_heat_source == 1
+    assert zone
+
+    zone = HeatTransferVolumeZone(thermal_conductivity=1, volumetric_heat_source="1")
+
+    assert zone
+
+    with pytest.raises(pd.ValidationError):
+        zone = HeatTransferVolumeZone(thermal_conductivity=1, volumetric_heat_source=-1)
 
     zones = VolumeZones(
         zone1=FluidDynamicsVolumeZone(), zone2=HeatTransferVolumeZone(thermal_conductivity=1)
     )
 
     assert zones
+
+    with pytest.raises(pd.ValidationError):
+        zone = HeatTransferVolumeZone(thermal_conductivity=-1)
 
     to_file_from_file_test(zones)
 


### PR DESCRIPTION
More complete volume zone tests were added, aeroacoustic output has been defined based on the JSON Schema.

Also incorporates a temporary fix causing extremely long test running times on Windows caused by log file writes - this issue needs to be addressed separately.