### PR TITLE
Fix issues with long testing times on Windows caused by log rotation from multiple threads

### DIFF
--- a/flow360/log.py
+++ b/flow360/log.py
@@ -69,15 +69,16 @@ class LogHandler:
         self.level = _get_level_int(level)
         self.console = console
         self.backup_count = 10
-        self.max_bytes = 10000
+        self.max_bytes = 1000000
         self.fname = fname
         self.previous_logged_time = None
         self.previous_logged_version = None
+        self.is_rotating = True
 
     def handle(self, level, level_name, message, log_time=False):
         """Output log messages depending on log level"""
         try:
-            if self.fname is not None and self.should_roll_over(message):
+            if self.fname is not None and self.is_rotating and self.should_roll_over(message):
                 self.do_roll_over()
         except OSError as error:
             self.console.log(
@@ -289,7 +290,7 @@ def set_logging_file(
     filemode: str = "a",
     level: LogValue = DEFAULT_LEVEL,
     back_up_count: int = 10,
-    max_bytes: int = 10000,
+    max_bytes: int = 1000000,
 ) -> None:
     """Set a file to write log to, independently from the stdout and stderr
     output chosen using :meth:`set_logging_level`.
@@ -302,6 +303,10 @@ def set_logging_file(
     level : str
         One of ``{'DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'}``. This is set for the file
         independently of the console output level set by :meth:`set_logging_level`.
+    back_up_count : int
+        How many backup log files are preserved when rotating log files
+    max_bytes : int
+        Maximum log file size in bytes before a log rotation is performed
     """
     if filemode not in "wa":
         raise ValueError("filemode must be either 'w' or 'a'")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,32 @@
+import os
+import tempfile
+
+import pytest
+
+from flow360.file_path import flow360_dir
+from flow360.log import log, set_logging_file
+
+"""
+Before running all tests redirect all test logging to a temporary log file, turn off log rotation 
+due to multi-threaded rotation being unsupported at this time
+"""
+
+
+def pytest_configure():
+    fo = tempfile.NamedTemporaryFile()
+    pytest.tmp_log_file = fo.name
+    pytest.log_test_file = os.path.join(flow360_dir, "logs", "flow360_log_test.log")
+    if os.path.exists(pytest.log_test_file):
+        os.remove(pytest.log_test_file)
+    set_logging_file(fo.name, level="DEBUG")
+
+
+@pytest.fixture
+def before_log_test():
+    set_logging_file(pytest.log_test_file, level="DEBUG")
+
+
+@pytest.fixture
+def after_log_test():
+    yield
+    set_logging_file(pytest.tmp_log_file, level="DEBUG")

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,28 +1,33 @@
-import os
+import pytest
 
 from flow360.log import Logger, log, set_logging_level
 
 
+@pytest.mark.usefixtures("before_log_test", "after_log_test")
 def test_debug():
     log.debug("Debug log")
     log.debug("Debug log string %s, number %d", "arg", 1)
 
 
+@pytest.mark.usefixtures("before_log_test", "after_log_test")
 def test_info():
     log.info("Basic info")
     log.info("Basic info string %s, number %d", "arg", 1)
 
 
+@pytest.mark.usefixtures("before_log_test", "after_log_test")
 def test_warning():
     log.warning("Warning log")
     log.warning("Warning log string %s, number %d", "arg", 1)
 
 
+@pytest.mark.usefixtures("before_log_test", "after_log_test")
 def test_error():
     log.error("Error log")
     log.error("Error log string %s, number %d", "arg", 1)
 
 
+@pytest.mark.usefixtures("before_log_test", "after_log_test")
 def test_critical():
     log.critical("Critical log string %s, number %d", "arg", 1)
 


### PR DESCRIPTION
For the past two months testing times on Windows were excessively long - this was caused by OS-specific restrictions on file operations from multiple threads. Since this issue is test-specific a separate log file for test output has been created. Additionally the maximum file size before log rotation was small (10kB) and has been increased to 1MB. This brings Windows test performance in line with other systems.