### PR TITLE
Added environment-dependent apikeys

### DIFF
--- a/flow360/cli/app.py
+++ b/flow360/cli/app.py
@@ -7,6 +7,8 @@ from os.path import expanduser
 import click
 import toml
 
+from flow360.cli import dict_utils
+
 home = expanduser("~")
 config_file = f"{home}/.flow360/config.toml"
 
@@ -31,6 +33,9 @@ def flow360():
 )
 @click.option("--profile", prompt=False, default="default", help="Profile, e.g., default, dev.")
 @click.option(
+    "--dev", prompt=False, type=bool, is_flag=True, help="Only use this apikey in dev environment."
+)
+@click.option(
     "--suppress-submit-warning",
     type=bool,
     is_flag=True,
@@ -42,7 +47,7 @@ def flow360():
     is_flag=True,
     help='Whether to show warnings for "submit()" when creating new Case, new VolumeMesh etc.',
 )
-def configure(apikey, profile, suppress_submit_warning, show_submit_warning):
+def configure(apikey, profile, dev, suppress_submit_warning, show_submit_warning):
     """
     Configure flow360.
     """
@@ -56,7 +61,8 @@ def configure(apikey, profile, suppress_submit_warning, show_submit_warning):
             config = toml.loads(file_handler.read())
 
     if apikey is not None:
-        config.update({profile: {"apikey": apikey}})
+        entry = {profile: {"apikey": apikey}} if not dev else {profile: {"dev": {"apikey": apikey}}}
+        dict_utils.merge_overwrite(config, entry)
         changed = True
 
     if suppress_submit_warning and show_submit_warning:

--- a/flow360/cli/dict_utils.py
+++ b/flow360/cli/dict_utils.py
@@ -1,0 +1,20 @@
+"""
+Utility module for operating on dicts for the CLI
+"""
+
+
+def merge_overwrite(old: dict, new: dict, path=None):
+    """
+    Perform a deep merge of two dictionaries overwriting a with b in case of conflicts
+    """
+    if path is None:
+        path = []
+    for key in new:
+        if key in old:
+            if isinstance(old[key], dict) and isinstance(new[key], dict):
+                merge_overwrite(old[key], new[key], path + [str(key)])
+            elif old[key] != new[key]:
+                old[key] = new[key]
+        else:
+            old[key] = new[key]
+    return old

--- a/flow360/cloud/http_util.py
+++ b/flow360/cloud/http_util.py
@@ -22,6 +22,10 @@ def api_key_auth(request):
     """
     key = api_key()
     if not key:
+        if Env.current.name == "dev":
+            raise AuthorisationError(
+                "API key not found for env=dev, please set it by commandline: flow360 configure --dev."
+            )
         raise AuthorisationError(
             f"API key not found for profile={UserConfig.profile}, please set it by commandline: flow360 configure."
         )

--- a/flow360/cloud/security.py
+++ b/flow360/cloud/security.py
@@ -1,6 +1,7 @@
 """
 Security related functions.
 """
+from ..environment import Env
 from ..user_config import UserConfig
 
 
@@ -10,5 +11,5 @@ def api_key():
     :return:
     """
 
-    apikey = UserConfig.apikey()
+    apikey = UserConfig.apikey(Env.current)
     return apikey

--- a/flow360/environment.py
+++ b/flow360/environment.py
@@ -4,8 +4,6 @@ Environment Setup
 
 from pydantic import BaseModel
 
-from .user_config import UserConfig
-
 
 class EnvironmentConfig(BaseModel):
     """
@@ -24,7 +22,6 @@ class EnvironmentConfig(BaseModel):
         :return:
         """
         Env.set_current(self)
-        UserConfig.set_profile(self.apikey_profile)
 
     def get_real_url(self, path: str):
         """

--- a/flow360/user_config.py
+++ b/flow360/user_config.py
@@ -62,7 +62,7 @@ class BasicUserConfig:
             with open(config_file, "r", encoding="utf-8") as file_handler:
                 self.config = toml.loads(file_handler.read())
 
-    def apikey(self):
+    def apikey(self, env):
         """get apikey
 
         Returns
@@ -70,11 +70,16 @@ class BasicUserConfig:
         str
             apikey from config.toml file. If found env variable FLOW360_APIKEY, it will be returned
         """
+
         self._check_env_profile()
         self._check_env_apikey()
         if self._apikey is not None:
             return self._apikey
-        return self.config.get(self.profile, {}).get("apikey", "")
+        # Check if environment-specific apikey exists
+        key = self.config.get(self.profile, {})
+        if key and env.name == "dev":
+            key = key.get("dev")
+        return None if key is None else key.get("apikey", "")
 
     def suppress_submit_warning(self):
         """locally suppress submit warning"""


### PR DESCRIPTION
The user can now declare separate apikeys for the dev environment by calling configure with an additional dev flag
```
flow360 configure --profile <profile_name> --dev --apikey aAAa0000(...)
```
which will cause the provided apikey to be used for this profile when dev environment is activated. This is backwards-compatible with the current solution as the default apikey can be configured by calling
```
flow360 configure --profile <profile_name> --apikey aAAa0000(...)
```
same as before. Since dev apikey does not use a different profile anymore, we do not set the profile automatically when activating an environment.
