### PR TITLE
[FLPY-37] Added client accounts to the shared account functionality

### DIFF
--- a/flow360/accounts_utils.py
+++ b/flow360/accounts_utils.py
@@ -53,14 +53,14 @@ class AccountsUtils:
                 print("Invalid input type, please input an integer value:")
                 continue
 
-    # Requires fixing from the backend side - support for portal webapi calls with apikey authentication
     @staticmethod
     def _get_supported_users():
         try:
-            response = http.portal_api_get("auth")
-            access = response.json()["data"]
-            keys = access["user"]
-            supported_users = keys["guestUsers"]
+            response = http.portal_api_get("auth/credential")
+            supported_users = response["guestUsers"]
+            for entry in supported_users:
+                entry["userEmail"] = entry.pop("email")
+                entry["userIdentity"] = entry.pop("identity")
             if supported_users:
                 return supported_users
             return []
@@ -108,7 +108,7 @@ class AccountsUtils:
            user email to impersonate (if email exists among shared accounts),
            if email is not provided user can select the account interactively
         """
-        shared_accounts = self._get_company_users()
+        shared_accounts = self._get_company_users() + self._get_supported_users()
 
         if len(shared_accounts) == 0:
             log.info("There are no accounts shared with the current user")
@@ -140,11 +140,6 @@ class AccountsUtils:
         retrieve current shared account name, if possible
         """
         self._check_state_consistency()
-
-        if self._current_email is not None:
-            log.info(f"Currently operating as {self._current_email}")
-        else:
-            log.info("Currently not logged into a shared account")
 
         return self._current_email
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ due to multi-threaded rotation being unsupported at this time
 
 def pytest_configure():
     fo = tempfile.NamedTemporaryFile()
+    fo.close()  # Windows workaround for shared files
     pytest.tmp_log_file = fo.name
     pytest.log_test_file = os.path.join(flow360_dir, "logs", "flow360_log_test.log")
     if os.path.exists(pytest.log_test_file):

--- a/tests/data/mock_webapi/client_accounts_resp.json
+++ b/tests/data/mock_webapi/client_accounts_resp.json
@@ -1,0 +1,19 @@
+{
+    "data": {
+        "guestUsers": [
+            {
+                "identity": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                "userId": "AAAAAAAAAAAAAAAAAAAAA",
+                "email": "user3@test.com"
+            },
+            {
+                "identity": "us-east-1:bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+                "userId": "BBBBBBBBBBBBBBBBBBBBB",
+                "email": "user4@test.com"
+            }
+
+        ]
+
+    }
+}
+

--- a/tests/data/mock_webapi/organization_accounts_resp.json
+++ b/tests/data/mock_webapi/organization_accounts_resp.json
@@ -17,8 +17,17 @@
     "allowanceAllCycleStartDate": null,
     "allowanceAllCycleEndDate": null,
     "tenantMembers": [
-      {"userIdentity": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "userId": "AAAAAAAAAAAAAAAAAAAAA", "userEmail": "user1@test.com"},
-      {"userIdentity": "us-east-1:bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", "userId": "BBBBBBBBBBBBBBBBBBBBB", "userEmail": "user2@test.com"}],
+        {
+            "userIdentity": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "userId": "AAAAAAAAAAAAAAAAAAAAA",
+            "userEmail": "user1@test.com"
+        },
+        {
+            "userIdentity": "us-east-1:bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+            "userId": "BBBBBBBBBBBBBBBBBBBBB",
+            "userEmail": "user2@test.com"
+        }
+    ],
     "intraCompanySharingEnabled": true,
     "taskDeInfo": null,
     "userId": "ABCDEFGHIJKLMNOPRSTUV",

--- a/tests/mock_server.py
+++ b/tests/mock_server.py
@@ -85,6 +85,16 @@ class MockResponseOrganizationAccounts(MockResponse):
         return res
 
 
+class MockResponseClientAccounts(MockResponse):
+    """response to retrieving shared account list"""
+
+    @staticmethod
+    def json():
+        with open(os.path.join(here, "data/mock_webapi/client_accounts_resp.json")) as fh:
+            res = json.load(fh)
+        return res
+
+
 class MockResponseCase(MockResponse):
     """response if Case(id="00000000-0000-0000-0000-000000000000")"""
 
@@ -171,6 +181,9 @@ def mock_webapi(url, params):
         if params["includeDeleted"]:
             return MockResponseVolumeMeshesWithDeleted()
         return MockResponseVolumeMeshes()
+
+    if method.endswith("auth/credential"):
+        return MockResponseClientAccounts()
 
     else:
         return MockResponseInfoNotFound()

--- a/tests/test_shared_accounts.py
+++ b/tests/test_shared_accounts.py
@@ -17,4 +17,4 @@ def test_shared_account(mock_response):
     assert Env.impersonate is None
 
     with pytest.raises(ValueError):
-        Accounts.choose_shared_account("user3@test.com")
+        Accounts.choose_shared_account("user5@test.com")


### PR DESCRIPTION
After feedback from Lei Dong client account support was added to the shared account functionality. Additionally, a small Windows workaround for creating temporary files for log tests was added to prevent warnings.