### PR TITLE
Self named schema fixes

### DIFF
--- a/flow360/component/flow360_params/params_base.py
+++ b/flow360/component/flow360_params/params_base.py
@@ -1179,6 +1179,8 @@ class Flow360SortableBaseModel(Flow360BaseModel, metaclass=ABCMeta):
         if definitions:
             root_schema["definitions"] = definitions
 
+        root_schema["type"] = "object"
+
         return root_schema
 
     # pylint: disable=missing-class-docstring,too-few-public-methods

--- a/flow360/component/flow360_params/params_base.py
+++ b/flow360/component/flow360_params/params_base.py
@@ -574,8 +574,6 @@ class Flow360BaseModel(BaseModel):
         cls._schema_format_titles(schema)
         cls._schema_apply_option_names(schema)
         cls._schema_apply_root_property(schema)
-        for item in cls.SchemaConfig.exclude_fields:
-            cls._schema_remove(schema, item.split("/"))
         cls._schema_fix_single_allof(schema)
         cls._schema_fix_single_value_enum(schema)
         for item in cls.SchemaConfig.optional_objects:
@@ -587,6 +585,8 @@ class Flow360BaseModel(BaseModel):
                 if displayed is not None:
                     value["displayed"] = displayed
                 schema["properties"][key] = value
+        for item in cls.SchemaConfig.exclude_fields:
+            cls._schema_remove(schema, item.split("/"))
         cls._schema_swap_key(schema, "title", "displayed")
         cls._schema_clean(schema)
         return schema
@@ -1176,7 +1176,8 @@ class Flow360SortableBaseModel(Flow360BaseModel, metaclass=ABCMeta):
 
         cls._collect_all_definitions(root_schema, definitions)
 
-        root_schema["definitions"] = definitions
+        if definitions:
+            root_schema["definitions"] = definitions
 
         return root_schema
 

--- a/flow360/component/flow360_params/validations.py
+++ b/flow360/component/flow360_params/validations.py
@@ -238,7 +238,11 @@ def _check_equation_eval_frequency_for_unsteady_simulations(values):
 def _check_aero_acoustics(values):
     aeroacoustic_output = values.get("aeroacoustic_output")
     boundaries = values.get("boundaries")
-    if aeroacoustic_output is not None and len(aeroacoustic_output.observers) > 0:
+    if (
+        boundaries is not None
+        and aeroacoustic_output is not None
+        and len(aeroacoustic_output.observers) > 0
+    ):
         for boundary_name in boundaries.names():
             boundary_prop = boundaries[boundary_name]
             if isinstance(boundary_prop, (TranslationallyPeriodic, RotationallyPeriodic, SlipWall)):

--- a/tools/integrations/data/boundaries/json-schema.json
+++ b/tools/integrations/data/boundaries/json-schema.json
@@ -572,5 +572,6 @@
         "additionalProperties": false
       }
     ]
-  }
+  },
+  "type": "object"
 }

--- a/tools/integrations/data/boundaries/json-schema.json
+++ b/tools/integrations/data/boundaries/json-schema.json
@@ -572,6 +572,5 @@
         "additionalProperties": false
       }
     ]
-  },
-  "definitions": {}
+  }
 }

--- a/tools/integrations/data/heat-equation/json-schema.json
+++ b/tools/integrations/data/heat-equation/json-schema.json
@@ -33,6 +33,11 @@
             },
             "linearSolverConfig": {
               "title": "Linear solver config",
+              "default": {
+                "max_iterations": 50,
+                "absolute_tolerance": 1e-10,
+                "relative_tolerance": null
+              },
               "type": "object",
               "properties": {
                 "maxIterations": {

--- a/tools/integrations/data/iso-surface-output/json-schema.json
+++ b/tools/integrations/data/iso-surface-output/json-schema.json
@@ -101,6 +101,7 @@
         },
         "additionalProperties": false
       },
+      "type": "object",
       "title": "Iso surfaces"
     }
   },

--- a/tools/integrations/data/iso-surface-output/json-schema.json
+++ b/tools/integrations/data/iso-surface-output/json-schema.json
@@ -32,7 +32,6 @@
     },
     "isoSurfaces": {
       "additionalProperties": {
-        "title": "Iso surface",
         "type": "object",
         "properties": {
           "surfaceField": {
@@ -102,7 +101,6 @@
         },
         "additionalProperties": false
       },
-      "definitions": {},
       "title": "Iso surfaces"
     }
   },

--- a/tools/integrations/data/monitor-output/json-schema.json
+++ b/tools/integrations/data/monitor-output/json-schema.json
@@ -122,7 +122,6 @@
           }
         ]
       },
-      "definitions": {},
       "title": "Monitors"
     },
     "outputFields": {

--- a/tools/integrations/data/monitor-output/json-schema.json
+++ b/tools/integrations/data/monitor-output/json-schema.json
@@ -122,6 +122,7 @@
           }
         ]
       },
+      "type": "object",
       "title": "Monitors"
     },
     "outputFields": {

--- a/tools/integrations/data/navier-stokes/json-schema.json
+++ b/tools/integrations/data/navier-stokes/json-schema.json
@@ -90,6 +90,11 @@
             },
             "linearSolverConfig": {
               "title": "Linear solver config",
+              "default": {
+                "max_iterations": 30,
+                "absolute_tolerance": 1e-10,
+                "relative_tolerance": null
+              },
               "type": "object",
               "properties": {
                 "maxIterations": {

--- a/tools/integrations/data/slice-output/json-schema.json
+++ b/tools/integrations/data/slice-output/json-schema.json
@@ -65,7 +65,6 @@
     },
     "slices": {
       "additionalProperties": {
-        "title": "Slice",
         "type": "object",
         "properties": {
           "sliceNormal": {
@@ -140,7 +139,6 @@
         ],
         "additionalProperties": false
       },
-      "definitions": {},
       "title": "Slices"
     }
   },

--- a/tools/integrations/data/slice-output/json-schema.json
+++ b/tools/integrations/data/slice-output/json-schema.json
@@ -139,6 +139,7 @@
         ],
         "additionalProperties": false
       },
+      "type": "object",
       "title": "Slices"
     }
   },

--- a/tools/integrations/data/surface-output/json-schema.json
+++ b/tools/integrations/data/surface-output/json-schema.json
@@ -104,7 +104,6 @@
     },
     "surfaces": {
       "additionalProperties": {
-        "title": "Surface",
         "type": "object",
         "properties": {
           "outputFields": {
@@ -151,7 +150,6 @@
         },
         "additionalProperties": false
       },
-      "definitions": {},
       "title": "Surfaces"
     }
   },

--- a/tools/integrations/data/surface-output/json-schema.json
+++ b/tools/integrations/data/surface-output/json-schema.json
@@ -150,6 +150,7 @@
         },
         "additionalProperties": false
       },
+      "type": "object",
       "title": "Surfaces"
     }
   },

--- a/tools/integrations/data/transition-model/json-schema.json
+++ b/tools/integrations/data/transition-model/json-schema.json
@@ -75,6 +75,11 @@
             },
             "linearSolverConfig": {
               "title": "Linear solver config",
+              "default": {
+                "max_iterations": 20,
+                "absolute_tolerance": 1e-10,
+                "relative_tolerance": null
+              },
               "type": "object",
               "properties": {
                 "maxIterations": {

--- a/tools/integrations/data/turbulence-model/json-schema.json
+++ b/tools/integrations/data/turbulence-model/json-schema.json
@@ -125,6 +125,11 @@
                 },
                 "linearSolverConfig": {
                   "title": "Linear solver config",
+                  "default": {
+                    "max_iterations": 20,
+                    "absolute_tolerance": 1e-10,
+                    "relative_tolerance": null
+                  },
                   "type": "object",
                   "properties": {
                     "maxIterations": {
@@ -291,6 +296,11 @@
                 },
                 "linearSolverConfig": {
                   "title": "Linear solver config",
+                  "default": {
+                    "max_iterations": 20,
+                    "absolute_tolerance": 1e-10,
+                    "relative_tolerance": null
+                  },
                   "type": "object",
                   "properties": {
                     "maxIterations": {

--- a/tools/integrations/data/volume-zones/json-schema.json
+++ b/tools/integrations/data/volume-zones/json-schema.json
@@ -316,5 +316,6 @@
         "additionalProperties": false
       }
     ]
-  }
+  },
+  "type": "object"
 }

--- a/tools/integrations/data/volume-zones/json-schema.json
+++ b/tools/integrations/data/volume-zones/json-schema.json
@@ -316,6 +316,5 @@
         "additionalProperties": false
       }
     ]
-  },
-  "definitions": {}
+  }
 }

--- a/tools/integrations/schema_generation.py
+++ b/tools/integrations/schema_generation.py
@@ -267,6 +267,7 @@ class _SliceOutput(fl.SliceOutput):
             "slices/additionalProperties/sliceOrigin": ("widget", "vector3"),
         }
         swap_fields = {"slices": fl.Slices.flow360_schema()}
+        exclude_fields = ["properties/slices/additionalProperties/title"]
 
 
 class _MonitorOutput(fl.MonitorOutput):
@@ -276,18 +277,21 @@ class _MonitorOutput(fl.MonitorOutput):
             "monitors/additionalProperties/monitorLocations/items": ("widget", "vector3")
         }
         swap_fields = {"monitors": fl.Monitors.flow360_schema()}
+        exclude_fields = ["properties/monitors/additionalProperties/title"]
 
 
 class _SurfaceOutput(fl.SurfaceOutput):
     class SchemaConfig(Flow360BaseModel.SchemaConfig):
         field_order = ["outputFormat", "outputFields", "*", "surfaces"]
         swap_fields = {"surfaces": fl.Surfaces.flow360_schema()}
+        exclude_fields = ["properties/surfaces/additionalProperties/title"]
 
 
 class _IsoSurfaceOutput(fl.IsoSurfaceOutput):
     class SchemaConfig(Flow360BaseModel.SchemaConfig):
         field_order = ["outputFormat", "*", "isoSurfaces"]
         swap_fields = {"isoSurfaces": fl.IsoSurfaces.flow360_schema()}
+        exclude_fields = ["properties/isoSurfaces/additionalProperties/title"]
 
 
 class _Boundaries(fl.Boundaries):


### PR DESCRIPTION
- Remove titles from self-named schema items
- Add type: object in self-named schema root
- Remove empty definitions fields
- Fix 500 error on aeroacoustic validator when no boundaries are present