### PR TITLE
UnsteadyTimeStepping requires physical_steps and time_step_size

### DIFF
--- a/flow360/component/flow360_params/time_stepping.py
+++ b/flow360/component/flow360_params/time_stepping.py
@@ -138,8 +138,8 @@ class UnsteadyTimeStepping(BaseTimeStepping):
     """
 
     model_type: Literal["Unsteady"] = pd.Field("Unsteady", alias="modelType", const=True)
-    physical_steps: Optional[PositiveInt] = pd.Field(alias="physicalSteps")
-    time_step_size: Optional[TimeType.Positive] = pd.Field(alias="timeStepSize")
+    physical_steps: PositiveInt = pd.Field(alias="physicalSteps")
+    time_step_size: TimeType.Positive = pd.Field(alias="timeStepSize")
     CFL: Optional[Union[RampCFL, AdaptiveCFL]] = pd.Field(
         displayed="CFL",
         options=["Ramp CFL", "Adaptive CFL"],

--- a/tests/params/test_time_stepping.py
+++ b/tests/params/test_time_stepping.py
@@ -68,10 +68,10 @@ def test_time_stepping():
     exported_json = json.loads(params.flow360_json())
     assert "meshUnit" not in exported_json["geometry"]
 
-    ts = UnsteadyTimeStepping.parse_obj({"maxPhysicalSteps": 3, "timeStepSize":0.1*u.s})
+    ts = UnsteadyTimeStepping.parse_obj({"maxPhysicalSteps": 3, "timeStepSize": 0.1 * u.s})
     assert ts.physical_steps == 3
 
-    ts = UnsteadyTimeStepping.parse_obj({"physicalSteps": 2, "timeStepSize": 0.2*u.s})
+    ts = UnsteadyTimeStepping.parse_obj({"physicalSteps": 2, "timeStepSize": 0.2 * u.s})
     assert ts.physical_steps == 2
 
     with pytest.raises(ValueError):
@@ -98,19 +98,25 @@ def test_time_stepping():
         ts, fl.AdaptiveCFL(max=1e4, convergence_limiting_factor=0.25, max_relative_change=1000)
     )
 
-    ts = UnsteadyTimeStepping(physical_steps=20, time_step_size = 0.1*u.s)
+    ts = UnsteadyTimeStepping(physical_steps=20, time_step_size=0.1 * u.s)
     assert_CFL(ts, fl.AdaptiveCFL.default_unsteady())
-    ts = UnsteadyTimeStepping(CFL=fl.RampCFL(),physical_steps=20, time_step_size = 0.1*u.s)
+    ts = UnsteadyTimeStepping(CFL=fl.RampCFL(), physical_steps=20, time_step_size=0.1 * u.s)
     assert_CFL(ts, fl.RampCFL.default_unsteady())
-    ts = UnsteadyTimeStepping(CFL=fl.RampCFL(final=1000),physical_steps=20, time_step_size = 0.1*u.s)
+    ts = UnsteadyTimeStepping(
+        CFL=fl.RampCFL(final=1000), physical_steps=20, time_step_size=0.1 * u.s
+    )
     assert_CFL(ts, fl.RampCFL(initial=1, final=1000, ramp_steps=30))
-    ts = UnsteadyTimeStepping(CFL=fl.AdaptiveCFL(),physical_steps=20, time_step_size = 0.1*u.s)
+    ts = UnsteadyTimeStepping(CFL=fl.AdaptiveCFL(), physical_steps=20, time_step_size=0.1 * u.s)
     assert_CFL(ts, fl.AdaptiveCFL.default_unsteady())
-    ts = UnsteadyTimeStepping(CFL=fl.AdaptiveCFL(maxRelativeChange=1000),physical_steps=20, time_step_size = 0.1*u.s)
+    ts = UnsteadyTimeStepping(
+        CFL=fl.AdaptiveCFL(maxRelativeChange=1000), physical_steps=20, time_step_size=0.1 * u.s
+    )
     assert_CFL(
         ts, fl.AdaptiveCFL(max=1e6, convergence_limiting_factor=1.0, max_relative_change=1000)
     )
-    ts = UnsteadyTimeStepping(CFL=fl.AdaptiveCFL(maxRelativeChange=1000),physical_steps=20, time_step_size = 0.1*u.s)
+    ts = UnsteadyTimeStepping(
+        CFL=fl.AdaptiveCFL(maxRelativeChange=1000), physical_steps=20, time_step_size=0.1 * u.s
+    )
     assert_CFL(
         ts,
         fl.AdaptiveCFL(max=1e6, convergence_limiting_factor=1.0, max_relative_change=1000),

--- a/tests/params/test_time_stepping.py
+++ b/tests/params/test_time_stepping.py
@@ -68,10 +68,10 @@ def test_time_stepping():
     exported_json = json.loads(params.flow360_json())
     assert "meshUnit" not in exported_json["geometry"]
 
-    ts = UnsteadyTimeStepping.parse_obj({"maxPhysicalSteps": 3})
+    ts = UnsteadyTimeStepping.parse_obj({"maxPhysicalSteps": 3, "timeStepSize":0.1*u.s})
     assert ts.physical_steps == 3
 
-    ts = UnsteadyTimeStepping.parse_obj({"physicalSteps": 2})
+    ts = UnsteadyTimeStepping.parse_obj({"physicalSteps": 2, "timeStepSize": 0.2*u.s})
     assert ts.physical_steps == 2
 
     with pytest.raises(ValueError):
@@ -98,19 +98,19 @@ def test_time_stepping():
         ts, fl.AdaptiveCFL(max=1e4, convergence_limiting_factor=0.25, max_relative_change=1000)
     )
 
-    ts = UnsteadyTimeStepping()
+    ts = UnsteadyTimeStepping(physical_steps=20, time_step_size = 0.1*u.s)
     assert_CFL(ts, fl.AdaptiveCFL.default_unsteady())
-    ts = UnsteadyTimeStepping(CFL=fl.RampCFL())
+    ts = UnsteadyTimeStepping(CFL=fl.RampCFL(),physical_steps=20, time_step_size = 0.1*u.s)
     assert_CFL(ts, fl.RampCFL.default_unsteady())
-    ts = UnsteadyTimeStepping(CFL=fl.RampCFL(final=1000))
+    ts = UnsteadyTimeStepping(CFL=fl.RampCFL(final=1000),physical_steps=20, time_step_size = 0.1*u.s)
     assert_CFL(ts, fl.RampCFL(initial=1, final=1000, ramp_steps=30))
-    ts = UnsteadyTimeStepping(CFL=fl.AdaptiveCFL())
+    ts = UnsteadyTimeStepping(CFL=fl.AdaptiveCFL(),physical_steps=20, time_step_size = 0.1*u.s)
     assert_CFL(ts, fl.AdaptiveCFL.default_unsteady())
-    ts = UnsteadyTimeStepping(CFL=fl.AdaptiveCFL(maxRelativeChange=1000))
+    ts = UnsteadyTimeStepping(CFL=fl.AdaptiveCFL(maxRelativeChange=1000),physical_steps=20, time_step_size = 0.1*u.s)
     assert_CFL(
         ts, fl.AdaptiveCFL(max=1e6, convergence_limiting_factor=1.0, max_relative_change=1000)
     )
-    ts = UnsteadyTimeStepping(CFL=fl.AdaptiveCFL(maxRelativeChange=1000))
+    ts = UnsteadyTimeStepping(CFL=fl.AdaptiveCFL(maxRelativeChange=1000),physical_steps=20, time_step_size = 0.1*u.s)
     assert_CFL(
         ts,
         fl.AdaptiveCFL(max=1e6, convergence_limiting_factor=1.0, max_relative_change=1000),

--- a/tests/params/test_validator_cht_solver.py
+++ b/tests/params/test_validator_cht_solver.py
@@ -4,6 +4,7 @@ import unittest
 import pytest
 
 import flow360 as fl
+from flow360 import units as u
 from flow360.component.flow360_params.boundaries import (
     SolidAdiabaticWall,
     SolidIsothermalWall,
@@ -215,7 +216,7 @@ def test_cht_solver_has_heat_transfer_zone():
 
     with fl.SI_unit_system:
         param = Flow360Params(
-            time_stepping=UnsteadyTimeStepping(),
+            time_stepping=UnsteadyTimeStepping(physical_steps=10, time_step_size=0.1*u.s),
             volume_zones={
                 "blk-1": HeatTransferVolumeZone(
                     thermal_conductivity=0.1,
@@ -234,7 +235,7 @@ def test_cht_solver_has_heat_transfer_zone():
     ):
         with fl.SI_unit_system:
             param = Flow360Params(
-                time_stepping=UnsteadyTimeStepping(),
+                time_stepping=UnsteadyTimeStepping(physical_steps=10, time_step_size=0.1*u.s),
                 volume_zones={
                     "blk-1": HeatTransferVolumeZone(thermal_conductivity=0.1),
                     "blk-2": FluidDynamicsVolumeZone(),
@@ -248,7 +249,7 @@ def test_cht_solver_has_heat_transfer_zone():
     ):
         with fl.SI_unit_system:
             param = Flow360Params(
-                time_stepping=UnsteadyTimeStepping(),
+                time_stepping=UnsteadyTimeStepping(physical_steps=10, time_step_size=0.1*u.s),
                 volume_zones={
                     "blk-1": HeatTransferVolumeZone(thermal_conductivity=0.1, heat_capacity=0.1),
                     "blk-2": FluidDynamicsVolumeZone(),

--- a/tests/params/test_validator_cht_solver.py
+++ b/tests/params/test_validator_cht_solver.py
@@ -216,7 +216,7 @@ def test_cht_solver_has_heat_transfer_zone():
 
     with fl.SI_unit_system:
         param = Flow360Params(
-            time_stepping=UnsteadyTimeStepping(physical_steps=10, time_step_size=0.1*u.s),
+            time_stepping=UnsteadyTimeStepping(physical_steps=10, time_step_size=0.1 * u.s),
             volume_zones={
                 "blk-1": HeatTransferVolumeZone(
                     thermal_conductivity=0.1,
@@ -235,7 +235,7 @@ def test_cht_solver_has_heat_transfer_zone():
     ):
         with fl.SI_unit_system:
             param = Flow360Params(
-                time_stepping=UnsteadyTimeStepping(physical_steps=10, time_step_size=0.1*u.s),
+                time_stepping=UnsteadyTimeStepping(physical_steps=10, time_step_size=0.1 * u.s),
                 volume_zones={
                     "blk-1": HeatTransferVolumeZone(thermal_conductivity=0.1),
                     "blk-2": FluidDynamicsVolumeZone(),
@@ -249,7 +249,7 @@ def test_cht_solver_has_heat_transfer_zone():
     ):
         with fl.SI_unit_system:
             param = Flow360Params(
-                time_stepping=UnsteadyTimeStepping(physical_steps=10, time_step_size=0.1*u.s),
+                time_stepping=UnsteadyTimeStepping(physical_steps=10, time_step_size=0.1 * u.s),
                 volume_zones={
                     "blk-1": HeatTransferVolumeZone(thermal_conductivity=0.1, heat_capacity=0.1),
                     "blk-2": FluidDynamicsVolumeZone(),

--- a/tests/params/test_validator_consistency_ddes_unsteady.py
+++ b/tests/params/test_validator_consistency_ddes_unsteady.py
@@ -4,6 +4,7 @@ import unittest
 import pytest
 
 import flow360 as fl
+from flow360 import units as u
 from flow360.component.flow360_params.flow360_params import (
     Flow360Params,
     SteadyTimeStepping,
@@ -22,7 +23,7 @@ def change_test_dir(request, monkeypatch):
 def test_consistency_ddes_unsteady():
     with fl.SI_unit_system:
         param = Flow360Params(
-            time_stepping=UnsteadyTimeStepping(),
+            time_stepping=UnsteadyTimeStepping(physical_steps=20, time_step_size = 0.1*u.s),
             turbulence_model_solver=SpalartAllmaras(DDES=True),
             boundaries={},
             freestream=fl.FreestreamFromMach(Mach=1, temperature=1, mu_ref=1),

--- a/tests/params/test_validator_consistency_ddes_unsteady.py
+++ b/tests/params/test_validator_consistency_ddes_unsteady.py
@@ -23,7 +23,7 @@ def change_test_dir(request, monkeypatch):
 def test_consistency_ddes_unsteady():
     with fl.SI_unit_system:
         param = Flow360Params(
-            time_stepping=UnsteadyTimeStepping(physical_steps=20, time_step_size = 0.1*u.s),
+            time_stepping=UnsteadyTimeStepping(physical_steps=20, time_step_size=0.1 * u.s),
             turbulence_model_solver=SpalartAllmaras(DDES=True),
             boundaries={},
             freestream=fl.FreestreamFromMach(Mach=1, temperature=1, mu_ref=1),

--- a/tests/params/test_validator_equation_eval_frequency.py
+++ b/tests/params/test_validator_equation_eval_frequency.py
@@ -26,7 +26,9 @@ def change_test_dir(request, monkeypatch):
 def test_equation_eval_frequency_for_unsteady_simulations():
     with fl.SI_unit_system:
         param = Flow360Params(
-            time_stepping=UnsteadyTimeStepping(max_pseudo_steps=30,physical_steps=20, time_step_size = 0.1*u.s),
+            time_stepping=UnsteadyTimeStepping(
+                max_pseudo_steps=30, physical_steps=20, time_step_size=0.1 * u.s
+            ),
             turbulence_model_solver=SpalartAllmaras(equation_eval_frequency=2),
             transition_model_solver=TransitionModelSolver(equation_eval_frequency=4),
             boundaries={},
@@ -48,7 +50,9 @@ def test_equation_eval_frequency_for_unsteady_simulations():
     ):
         with fl.SI_unit_system:
             param = Flow360Params(
-                time_stepping=UnsteadyTimeStepping(max_pseudo_steps=2,physical_steps=20, time_step_size = 0.1*u.s),
+                time_stepping=UnsteadyTimeStepping(
+                    max_pseudo_steps=2, physical_steps=20, time_step_size=0.1 * u.s
+                ),
                 turbulence_model_solver=SpalartAllmaras(equation_eval_frequency=3),
                 boundaries={},
                 freestream=fl.FreestreamFromMach(Mach=1, temperature=1, mu_ref=1),
@@ -59,7 +63,9 @@ def test_equation_eval_frequency_for_unsteady_simulations():
     ):
         with fl.SI_unit_system:
             param = Flow360Params(
-                time_stepping=UnsteadyTimeStepping(max_pseudo_steps=2,physical_steps=20, time_step_size = 0.1*u.s),
+                time_stepping=UnsteadyTimeStepping(
+                    max_pseudo_steps=2, physical_steps=20, time_step_size=0.1 * u.s
+                ),
                 transition_model_solver=TransitionModelSolver(equation_eval_frequency=3),
                 boundaries={},
                 freestream=fl.FreestreamFromMach(Mach=1, temperature=1, mu_ref=1),

--- a/tests/params/test_validator_equation_eval_frequency.py
+++ b/tests/params/test_validator_equation_eval_frequency.py
@@ -4,6 +4,7 @@ import unittest
 import pytest
 
 import flow360 as fl
+from flow360 import units as u
 from flow360.component.flow360_params.flow360_params import (
     Flow360Params,
     SteadyTimeStepping,
@@ -25,7 +26,7 @@ def change_test_dir(request, monkeypatch):
 def test_equation_eval_frequency_for_unsteady_simulations():
     with fl.SI_unit_system:
         param = Flow360Params(
-            time_stepping=UnsteadyTimeStepping(max_pseudo_steps=30),
+            time_stepping=UnsteadyTimeStepping(max_pseudo_steps=30,physical_steps=20, time_step_size = 0.1*u.s),
             turbulence_model_solver=SpalartAllmaras(equation_eval_frequency=2),
             transition_model_solver=TransitionModelSolver(equation_eval_frequency=4),
             boundaries={},
@@ -47,7 +48,7 @@ def test_equation_eval_frequency_for_unsteady_simulations():
     ):
         with fl.SI_unit_system:
             param = Flow360Params(
-                time_stepping=UnsteadyTimeStepping(max_pseudo_steps=2),
+                time_stepping=UnsteadyTimeStepping(max_pseudo_steps=2,physical_steps=20, time_step_size = 0.1*u.s),
                 turbulence_model_solver=SpalartAllmaras(equation_eval_frequency=3),
                 boundaries={},
                 freestream=fl.FreestreamFromMach(Mach=1, temperature=1, mu_ref=1),
@@ -58,7 +59,7 @@ def test_equation_eval_frequency_for_unsteady_simulations():
     ):
         with fl.SI_unit_system:
             param = Flow360Params(
-                time_stepping=UnsteadyTimeStepping(max_pseudo_steps=2),
+                time_stepping=UnsteadyTimeStepping(max_pseudo_steps=2,physical_steps=20, time_step_size = 0.1*u.s),
                 transition_model_solver=TransitionModelSolver(equation_eval_frequency=3),
                 boundaries={},
                 freestream=fl.FreestreamFromMach(Mach=1, temperature=1, mu_ref=1),

--- a/tests/test_flow360_params.py
+++ b/tests/test_flow360_params.py
@@ -346,7 +346,7 @@ def test_params_with_units_consistency():
             fluid_properties=fl.air,
             freestream=fl.FreestreamFromVelocity(velocity=286),
             time_stepping=fl.UnsteadyTimeStepping(
-                max_pseudo_steps=500, CFL=fl.AdaptiveCFL(), time_step_size=1.2 * u.s
+                max_pseudo_steps=500, CFL=fl.AdaptiveCFL(), time_step_size=1.2 * u.s, physical_steps=20,
             ),
             boundaries={},
         )
@@ -365,7 +365,7 @@ def test_params_with_units_consistency():
             fluid_properties=fl.air,
             freestream=fl.FreestreamFromVelocity(velocity=286),
             time_stepping=fl.UnsteadyTimeStepping(
-                max_pseudo_steps=500, CFL=fl.AdaptiveCFL(), time_step_size=1.2 * u.s
+                max_pseudo_steps=500, CFL=fl.AdaptiveCFL(), time_step_size=1.2 * u.s, physical_steps=10
             ),
             boundaries={},
         )
@@ -399,7 +399,7 @@ def test_params_with_units_consistency():
             ),
             freestream=fl.FreestreamFromVelocity(velocity=286 * u.m / u.s),
             time_stepping=fl.UnsteadyTimeStepping(
-                max_pseudo_steps=500, CFL=fl.AdaptiveCFL(), time_step_size=1.2 * u.s
+                max_pseudo_steps=500, CFL=fl.AdaptiveCFL(), time_step_size=1.2 * u.s, physical_steps=10
             ),
             boundaries={},
         )

--- a/tests/test_flow360_params.py
+++ b/tests/test_flow360_params.py
@@ -346,7 +346,10 @@ def test_params_with_units_consistency():
             fluid_properties=fl.air,
             freestream=fl.FreestreamFromVelocity(velocity=286),
             time_stepping=fl.UnsteadyTimeStepping(
-                max_pseudo_steps=500, CFL=fl.AdaptiveCFL(), time_step_size=1.2 * u.s, physical_steps=20,
+                max_pseudo_steps=500,
+                CFL=fl.AdaptiveCFL(),
+                time_step_size=1.2 * u.s,
+                physical_steps=20,
             ),
             boundaries={},
         )
@@ -365,7 +368,10 @@ def test_params_with_units_consistency():
             fluid_properties=fl.air,
             freestream=fl.FreestreamFromVelocity(velocity=286),
             time_stepping=fl.UnsteadyTimeStepping(
-                max_pseudo_steps=500, CFL=fl.AdaptiveCFL(), time_step_size=1.2 * u.s, physical_steps=10
+                max_pseudo_steps=500,
+                CFL=fl.AdaptiveCFL(),
+                time_step_size=1.2 * u.s,
+                physical_steps=10,
             ),
             boundaries={},
         )
@@ -399,7 +405,10 @@ def test_params_with_units_consistency():
             ),
             freestream=fl.FreestreamFromVelocity(velocity=286 * u.m / u.s),
             time_stepping=fl.UnsteadyTimeStepping(
-                max_pseudo_steps=500, CFL=fl.AdaptiveCFL(), time_step_size=1.2 * u.s, physical_steps=10
+                max_pseudo_steps=500,
+                CFL=fl.AdaptiveCFL(),
+                time_step_size=1.2 * u.s,
+                physical_steps=10,
             ),
             boundaries={},
         )


### PR DESCRIPTION
since unsteady simulations run time accurate time marching, so physical_steps and time_step_size must be given.