### PR TITLE
[SCFD-1323] Logging performance fixes

### DIFF
--- a/examples/dev/dev_logging_benchmark.py
+++ b/examples/dev/dev_logging_benchmark.py
@@ -1,0 +1,23 @@
+import os
+import datetime
+import flow360
+
+from flow360.log import log
+from flow360.file_path import flow360_dir
+
+N_LOGS = 10000
+
+print("Started logging")
+# get the start datetime
+st = datetime.datetime.now()
+
+for i in range(N_LOGS):
+    log.debug(f"Sample log {i}")
+
+# get the end datetime
+et = datetime.datetime.now()
+print("Finished logging")
+
+exec_time = et - st
+
+print(f'Log time for {N_LOGS} calls:', exec_time, 'seconds')

--- a/examples/dev/dev_logging_benchmark.py
+++ b/examples/dev/dev_logging_benchmark.py
@@ -17,4 +17,4 @@ print("Finished logging")
 
 exec_time = et - st
 
-print(f'Log time for {N_LOGS} calls:', exec_time, 'seconds')
+print(f"Log time for {N_LOGS} calls:", exec_time, "seconds")

--- a/examples/dev/dev_logging_benchmark.py
+++ b/examples/dev/dev_logging_benchmark.py
@@ -1,11 +1,8 @@
-import os
 import datetime
-import flow360
 
 from flow360.log import log
-from flow360.file_path import flow360_dir
 
-N_LOGS = 10000
+N_LOGS = 100000
 
 print("Started logging")
 # get the start datetime

--- a/flow360/log.py
+++ b/flow360/log.py
@@ -1,8 +1,6 @@
 """Logging for Flow360."""
 
 import os
-import platform
-import time
 from datetime import datetime
 from typing import Union
 
@@ -157,6 +155,7 @@ class LogHandler:
             if os.path.isfile(dfn):
                 os.remove(dfn)
             self.rotate(self.fname, dfn)
+            # pylint: disable=consider-using-with,unspecified-encoding
             self.console.file = open(self.fname, self.console.file.mode)
 
     def should_roll_over(self, message):
@@ -184,6 +183,7 @@ class LogHandler:
                     sep=": ",
                 )
         return False
+
 
 class Logger:
     """Custom logger to avoid the complexities of the logging module"""
@@ -298,11 +298,10 @@ def set_logging_file(
     # Close previous handler, if any
     if "file" in log.handlers:
         try:
-            c: Console = log.handlers["file"].console
-            c.file.close()
-        except Exception as e:  # pylint: disable=bare-except
+            log.handlers["file"].console.file.close()
+        except Exception as error:  # pylint: disable=broad-exception-caught
             del log.handlers["file"]
-            log.warning(f"Log file could not be closed: {e}")
+            log.warning(f"Log file could not be closed: {error}")
 
     try:
         # pylint: disable=consider-using-with,unspecified-encoding
@@ -317,6 +316,14 @@ def set_logging_file(
 
 
 def toggle_rotation(rotate: bool):
+    """Toggle log file rotation (without log rotation logging
+    is thread-safe on every platform, but this may generate
+    large file sizes)
+    Parameters
+    ----------
+    rotate : bool
+        Enable or disable log rotation
+    """
     if "file" in log.handlers:
         log.handlers["file"].is_rotating = rotate
 

--- a/flow360/log.py
+++ b/flow360/log.py
@@ -114,28 +114,7 @@ class LogHandler:
             None
         """
         if os.path.exists(source) and not os.path.exists(dest):
-            max_wait_time = 5
-            retry_delay = 0.1
-            start_time = time.time()
-            while time.time() - start_time < max_wait_time:
-                try:
-                    os.rename(source, dest)
-                    break
-                except (
-                    PermissionError,
-                    FileExistsError,
-                    IsADirectoryError,
-                    NotADirectoryError,
-                ) as error:
-                    if time.time() - start_time > max_wait_time:
-                        self.console.log(
-                            _level_print_style.get(_level_value["ERROR"], "unknown"),
-                            str(error),
-                            sep=": ",
-                        )
-                        break
-
-                    time.sleep(retry_delay)
+            os.rename(source, dest)
 
     def rotation_filename(self, name, counter):
         """
@@ -149,8 +128,9 @@ class LogHandler:
             str: Rotated filename with the format "{name}{formatted_time}.{counter}".
 
         """
+        root_ext = os.path.splitext(name)
 
-        return name + str(counter)
+        return f"{root_ext[0]}_{counter}{root_ext[1]}"
 
     def do_roll_over(self):
         """
@@ -162,9 +142,10 @@ class LogHandler:
 
         Returns:
             str: Rotated filename with the format "{name}{formatted_time}.{counter}".
-
         """
+
         if self.backup_count > 0:
+            self.console.file.close()
             for i in range(self.backup_count - 1, 0, -1):
                 sfn = self.rotation_filename(self.fname, i)
                 dfn = self.rotation_filename(self.fname, i + 1)
@@ -176,6 +157,7 @@ class LogHandler:
             if os.path.isfile(dfn):
                 os.remove(dfn)
             self.rotate(self.fname, dfn)
+            self.console.file = open(self.fname, self.console.file.mode)
 
     def should_roll_over(self, message):
         """
@@ -190,9 +172,10 @@ class LogHandler:
         # See bpo-45401: Never rollover anything other than regular files
         if not os.path.exists(self.fname) or not os.path.isfile(self.fname):
             return False
+        size = os.path.getsize(self.fname)
         if self.max_bytes > 0:  # are we rolling over?
             try:
-                if os.path.getsize(self.fname) + len(message) >= self.max_bytes:
+                if size + len(message) >= self.max_bytes:
                     return True
             except OSError as error:
                 self.console.log(

--- a/flow360/log.py
+++ b/flow360/log.py
@@ -316,10 +316,11 @@ def set_logging_file(
     # Close previous handler, if any
     if "file" in log.handlers:
         try:
-            log.handlers["file"].file.close()
-        except:  # pylint: disable=bare-except
+            c: Console = log.handlers["file"].console
+            c.file.close()
+        except Exception as e:  # pylint: disable=bare-except
             del log.handlers["file"]
-            log.warning("Log file could not be closed")
+            log.warning(f"Log file could not be closed: {e}")
 
     try:
         # pylint: disable=consider-using-with,unspecified-encoding
@@ -336,13 +337,12 @@ def set_logging_file(
 # Set default logging output
 set_logging_console()
 
-# Writing log files on Windows is currently very slow, toggled off until a fix is implemented
-if platform.system() != "Windows":
-    log_dir = flow360_dir + "logs"
-    try:
-        if not os.path.exists(log_dir):
-            os.makedirs(log_dir)
 
-        set_logging_file(os.path.join(log_dir, "flow360_python.log"), level="DEBUG")
-    except OSError as err:
-        log.warning(f"Could not setup file logging: {err}")
+log_dir = flow360_dir + "logs"
+try:
+    if not os.path.exists(log_dir):
+        os.makedirs(log_dir)
+
+    set_logging_file(os.path.join(log_dir, "flow360_python.log"), level="DEBUG")
+except OSError as err:
+    log.warning(f"Could not setup file logging: {err}")

--- a/flow360/log.py
+++ b/flow360/log.py
@@ -185,7 +185,6 @@ class LogHandler:
                 )
         return False
 
-
 class Logger:
     """Custom logger to avoid the complexities of the logging module"""
 
@@ -315,6 +314,11 @@ def set_logging_file(
     log.handlers["file"] = LogHandler(Console(file=file, log_path=False), level, fname)
     log.handlers["file"].back_up_count = back_up_count
     log.handlers["file"].max_bytes = max_bytes
+
+
+def toggle_rotation(rotate: bool):
+    if "file" in log.handlers:
+        log.handlers["file"].is_rotating = rotate
 
 
 # Set default logging output

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ import tempfile
 import pytest
 
 from flow360.file_path import flow360_dir
-from flow360.log import log, set_logging_file
+from flow360.log import log, set_logging_file, toggle_rotation
 
 """
 Before running all tests redirect all test logging to a temporary log file, turn off log rotation 
@@ -20,10 +20,11 @@ def pytest_configure():
     if os.path.exists(pytest.log_test_file):
         os.remove(pytest.log_test_file)
     set_logging_file(fo.name, level="DEBUG")
+    toggle_rotation(False)
 
 
 @pytest.fixture
-def before_log_test():
+def before_log_test(request):
     set_logging_file(pytest.log_test_file, level="DEBUG")
 
 


### PR DESCRIPTION
Flawed log rotation logic on Windows caused files to bloat beyond limit and due to a timeout routine each additional log call could end up taking about 5 seconds.

After fixes there is still a gap, but it is much smaller than before:

Thread-safety with rotation is lost so for multithreaded applications the user can disable log rotation temporarily (this is used for example in tests)

macOS:
Log time for 100000 calls: 0:00:39.198846 seconds

win10:
Log time for 100000 calls: 0:00:56.351816 seconds