### PR TITLE
Ben/fixing issues found in solver core unit test

### DIFF
--- a/flow360/__init__.py
+++ b/flow360/__init__.py
@@ -85,7 +85,7 @@ from .component.flow360_params.flow360_params import (
 )
 from .component.flow360_params.initial_condition import (
     ExpressionInitialCondition,
-    FreestreamInitialCondition,
+    ModifiedRestartSolution,
 )
 from .component.flow360_params.solvers import (
     IncompressibleNavierStokesSolver,

--- a/flow360/component/flow360_params/flow360_legacy.py
+++ b/flow360/component/flow360_params/flow360_legacy.py
@@ -11,7 +11,6 @@ from typing import Dict, Literal, Optional
 import pydantic as pd
 
 from flow360.component.flow360_params.params_base import (
-    Conflicts,
     DeprecatedAlias,
     Flow360BaseModel,
 )
@@ -34,6 +33,7 @@ class LinearSolverLegacy(LegacyModel):
     """:class:`LinearSolverLegacy` class"""
 
     max_level_limit: Optional[NonNegativeInt] = pd.Field(alias="maxLevelLimit")
+    # pylint: disable=duplicate-code
     max_iterations: Optional[PositiveInt] = pd.Field(alias="maxIterations", default=50)
     absolute_tolerance: Optional[PositiveFloat] = pd.Field(alias="absoluteTolerance")
     relative_tolerance: Optional[PositiveFloat] = pd.Field(alias="relativeTolerance")
@@ -115,11 +115,11 @@ def get_output_fields(instance: Flow360BaseModel, exclude, allowed=None):
     return fields
 
 
-def set_linear_solver_config_if_none(v, values):
+def set_linear_solver_config_if_none(linear_sovler_config, values):
     """Use to 'linear_solver' if linear_solver_config is not present and default if both are none"""
-    if v is None:
+    if linear_sovler_config is None:
         if values.get("linear_solver") is not None:
-            v = values.get("linear_solver").dict()
+            linear_sovler_config = values.get("linear_solver").dict()
         else:
-            v = LinearSolverLegacy().dict()
-    return v
+            linear_sovler_config = LinearSolverLegacy().dict()
+    return linear_sovler_config

--- a/flow360/component/flow360_params/flow360_output.py
+++ b/flow360/component/flow360_params/flow360_output.py
@@ -752,7 +752,7 @@ class SurfaceOutputLegacy(SurfaceOutput, LegacyOutputFormat, LegacyModel):
 
         if self.output_fields is not None:
             fields = list(set(fields + self.output_fields))
-
+        print(">>>>> DEBUG", self.surfaces)
         model = {
             "animationFrequency": self.animation_frequency,
             "animationFrequencyOffset": self.animation_frequency_offset,
@@ -762,6 +762,7 @@ class SurfaceOutputLegacy(SurfaceOutput, LegacyOutputFormat, LegacyModel):
             "outputFormat": self.output_format,
             "outputFields": fields,
             "startAverageIntegrationStep": self.start_average_integration_step,
+            "surfaces": self.surfaces,
         }
 
         return SurfaceOutput.parse_obj(model)

--- a/flow360/component/flow360_params/flow360_output.py
+++ b/flow360/component/flow360_params/flow360_output.py
@@ -752,7 +752,7 @@ class SurfaceOutputLegacy(SurfaceOutput, LegacyOutputFormat, LegacyModel):
 
         if self.output_fields is not None:
             fields = list(set(fields + self.output_fields))
-        print(">>>>> DEBUG", self.surfaces)
+
         model = {
             "animationFrequency": self.animation_frequency,
             "animationFrequencyOffset": self.animation_frequency_offset,

--- a/flow360/component/flow360_params/flow360_params.py
+++ b/flow360/component/flow360_params/flow360_params.py
@@ -52,13 +52,13 @@ from ..utils import _get_value_or_none, convert_legacy_names, process_expression
 from .boundaries import BoundaryType, WallFunction
 from .conversions import ExtraDimensionedProperty
 from .flow360_legacy import (
+    FreestreamInitialConditionLegacy,
     LegacyModel,
     get_output_fields,
     try_add_discriminator,
     try_add_unit,
     try_set,
     try_update,
-    FreestreamInitialConditionLegacy,
 )
 from .flow360_output import (
     AeroacousticOutput,
@@ -81,9 +81,9 @@ from .flow360_output import (
     VolumeOutputLegacy,
 )
 from .initial_condition import (
+    ExpressionInitialCondition,
     InitialConditions,
     ModifiedRestartSolution,
-    ExpressionInitialCondition,
 )
 from .params_base import (
     Conflicts,

--- a/flow360/component/flow360_params/flow360_params.py
+++ b/flow360/component/flow360_params/flow360_params.py
@@ -58,6 +58,7 @@ from .flow360_legacy import (
     try_add_unit,
     try_set,
     try_update,
+    FreestreamInitialConditionLegacy,
 )
 from .flow360_output import (
     AeroacousticOutput,
@@ -79,7 +80,11 @@ from .flow360_output import (
     VolumeOutput,
     VolumeOutputLegacy,
 )
-from .initial_condition import InitialConditions
+from .initial_condition import (
+    InitialConditions,
+    ModifiedRestartSolution,
+    ExpressionInitialCondition,
+)
 from .params_base import (
     Conflicts,
     DeprecatedAlias,
@@ -1879,6 +1884,11 @@ class VolumeZonesLegacy(VolumeZones):
             super().__init__(*args, **kwargs)
 
 
+InitialConditionsLegacy = Union[
+    FreestreamInitialConditionLegacy, ModifiedRestartSolution, ExpressionInitialCondition
+]
+
+
 class Flow360ParamsLegacy(LegacyModel):
     """:class: `Flow360ParamsLegacy` class"""
 
@@ -1901,7 +1911,7 @@ class Flow360ParamsLegacy(LegacyModel):
     iso_surface_output: Optional[IsoSurfaceOutputLegacy] = pd.Field(alias="isoSurfaceOutput")
     boundaries: Optional[BoundariesLegacy] = pd.Field()
     # Needs decoupling from current model
-    initial_condition: Optional[InitialConditions] = pd.Field(
+    initial_condition: Optional[InitialConditionsLegacy] = pd.Field(
         alias="initialCondition", discriminator="type"
     )
     # Needs decoupling from current model
@@ -1982,7 +1992,7 @@ class Flow360ParamsLegacy(LegacyModel):
                 {
                     "geometry": try_update(self.geometry),
                     "boundaries": self.boundaries,
-                    "initial_condition": self.initial_condition,
+                    "initial_condition": try_update(self.initial_condition),
                     "time_stepping": try_update(self.time_stepping),
                     "navier_stokes_solver": try_update(self.navier_stokes_solver),
                     "turbulence_model_solver": try_update(self.turbulence_model_solver),

--- a/flow360/component/flow360_params/initial_condition.py
+++ b/flow360/component/flow360_params/initial_condition.py
@@ -19,12 +19,6 @@ class InitialCondition(Flow360BaseModel):
     type: str
 
 
-class FreestreamInitialCondition(InitialCondition):
-    """:class:`FreestreamInitialCondition` class"""
-
-    type: Literal["freestream"] = pd.Field("freestream", const=True)
-
-
 class ExpressionInitialCondition(InitialCondition):
     """:class:`ExpressionInitialCondition` class"""
 
@@ -43,4 +37,12 @@ class ExpressionInitialCondition(InitialCondition):
     _processed_p = pd.validator("p", allow_reuse=True)(process_expressions)
 
 
-InitialConditions = Union[FreestreamInitialCondition, ExpressionInitialCondition]
+class ModifiedRestartSolution(ExpressionInitialCondition):
+    """:class:`ModifiedRestartSolution` class.
+    For forked (restart) cases, expressions will be applied  to manipulate the restart solution before it is applied.
+    """
+
+    type: Literal["restartManipulation"] = pd.Field("restartManipulation", const=True)
+
+
+InitialConditions = Union[ModifiedRestartSolution, ExpressionInitialCondition]

--- a/flow360/component/flow360_params/solvers.py
+++ b/flow360/component/flow360_params/solvers.py
@@ -12,7 +12,13 @@ import pydantic as pd
 from typing_extensions import Literal
 
 from ..types import NonNegativeFloat, NonNegativeInt, PositiveFloat, PositiveInt
-from .flow360_legacy import LegacyModel, try_set, try_update
+from .flow360_legacy import (
+    LegacyModel,
+    LinearSolverLegacy,
+    set_linear_solver_config_if_none,
+    try_set,
+    try_update,
+)
 from .params_base import Conflicts, DeprecatedAlias, Flow360BaseModel
 from .time_stepping import UnsteadyTimeStepping
 
@@ -523,23 +529,6 @@ class TransitionModelSolver(GenericFlowSolverSettings):
 
 
 # Legacy models for Flow360 updater, do not expose
-
-
-class LinearSolverLegacy(LinearSolver, LegacyModel):
-    """:class:`LinearSolverLegacy` class"""
-
-    max_level_limit: Optional[NonNegativeInt] = pd.Field(alias="maxLevelLimit")
-
-    def update_model(self):
-        model = {
-            "absoluteTolerance": self.absolute_tolerance,
-            "relativeTolerance": self.relative_tolerance,
-            "maxIterations": self.max_iterations,
-        }
-
-        return model
-
-
 class PressureCorrectionSolverLegacy(PressureCorrectionSolver, LegacyModel):
     """:class:`PressureCorrectionSolverLegacy` class"""
 
@@ -561,10 +550,12 @@ class NavierStokesSolverLegacy(NavierStokesSolver, LegacyModel):
     pressure_correction_solver: Optional[PressureCorrectionSolver] = pd.Field(
         alias="pressureCorrectionSolver"
     )
-    linear_solver_config: Optional[LinearSolverLegacy] = pd.Field(
-        alias="linearSolverConfig", default=LinearSolverLegacy()
-    )
+    linear_solver_config: Optional[LinearSolverLegacy] = pd.Field(alias="linearSolverConfig")
     linear_iterations: Optional[PositiveInt] = pd.Field(alias="linearIterations")
+
+    _processed_linear_solver_config = pd.validator(
+        "linear_solver_config", allow_reuse=True, pre=True
+    )(set_linear_solver_config_if_none)
 
     def update_model(self):
         model = {
@@ -593,10 +584,12 @@ class TurbulenceModelSolverLegacy(TurbulenceModelSolver, LegacyModel):
 
     kappa_MUSCL: Optional[pd.confloat(ge=-1, le=1)] = pd.Field(alias="kappaMUSCL")
     linear_iterations: Optional[PositiveInt] = pd.Field(alias="linearIterations")
-    linear_solver_config: Optional[LinearSolverLegacy] = pd.Field(
-        alias="linearSolverConfig", default=LinearSolverLegacy()
-    )
+    linear_solver_config: Optional[LinearSolverLegacy] = pd.Field(alias="linearSolverConfig")
     rotation_correction: Optional[bool] = pd.Field(alias="rotationCorrection")
+
+    _processed_linear_solver_config = pd.validator(
+        "linear_solver_config", allow_reuse=True, pre=True
+    )(set_linear_solver_config_if_none)
 
     # pylint: disable=no-self-argument
     @pd.root_validator(pre=True)
@@ -665,9 +658,11 @@ class HeatEquationSolverLegacy(HeatEquationSolver, LegacyModel):
     max_force_jac_update_physical_steps: Optional[NonNegativeInt] = pd.Field(
         alias="maxForceJacUpdatePhysicalSteps"
     )
-    linear_solver_config: Optional[LinearSolverLegacy] = pd.Field(
-        alias="linearSolverConfig", default=LinearSolverLegacy()
-    )
+    linear_solver_config: Optional[LinearSolverLegacy] = pd.Field(alias="linearSolverConfig")
+
+    _processed_linear_solver_config = pd.validator(
+        "linear_solver_config", allow_reuse=True, pre=True
+    )(set_linear_solver_config_if_none)
 
     def update_model(self) -> Flow360BaseModel:
         model = {
@@ -687,9 +682,11 @@ class TransitionModelSolverLegacy(TransitionModelSolver, LegacyModel):
     )
     CFL_multiplier: Optional[PositiveFloat] = pd.Field(alias="CFLMultiplier")
     linear_iterations: Optional[PositiveInt] = pd.Field(alias="linearIterations")
-    linear_solver_config: Optional[LinearSolverLegacy] = pd.Field(
-        alias="linearSolverConfig", default=LinearSolverLegacy()
-    )
+    linear_solver_config: Optional[LinearSolverLegacy] = pd.Field(alias="linearSolverConfig")
+
+    _processed_linear_solver_config = pd.validator(
+        "linear_solver_config", allow_reuse=True, pre=True
+    )(set_linear_solver_config_if_none)
 
     def update_model(self) -> Flow360BaseModel:
         model = {

--- a/tests/data/cases/case_20.json
+++ b/tests/data/cases/case_20.json
@@ -31,7 +31,7 @@
 		"Cp": true,
 		"Cf": false,
 		"CfVec": false,
-		"yPlus": false,
+		"yPlus": true,
 		"wallDistance": false,
 		"Mach": false
 	},

--- a/tests/data/cases/case_7.json
+++ b/tests/data/cases/case_7.json
@@ -33,18 +33,25 @@
       "startAverageIntegrationStep": 100000
    },
    "surfaceOutput": {
-      "outputFormat": "both",
-      "primitiveVars": true,
-      "Cp": true,
-      "Cf": true,
-      "CfTangent": true,
-      "CfNormal": true,
-      "CfVec": true,
-      "yPlus": true,
-      "wallDistance": true,
-      "Mach": true,
-      "nodeForcesPerUnitArea": true,
-      "animationFrequency": -1
+      "animationFrequency": -1,
+      "animationFrequencyOffset": 0,
+      "computeTimeAverages": false,
+      "startAverageIntegrationStep": 0,
+      "surfaces": {
+         "farfieldBlock/farfield": {
+            "outputFields": []
+         },
+         "outerBlock/Interface_innerBlock": {
+            "outputFields": [
+               "primitiveVars"
+            ]
+         },
+         "farfieldBlock/wing": {
+            "outputFields": []
+         }
+      },
+      "outputFormat": "paraview",
+      "writeSingleFile": false
    },
    "sliceOutput": {
       "outputFormat": "tecplot",
@@ -179,5 +186,8 @@
          "final": 10000000,
          "rampSteps": 33
       }
+   },
+   "initialCondition": {
+      "type": "freestream"
    }
 }

--- a/tests/data/cases/case_HeatTransfer.json
+++ b/tests/data/cases/case_HeatTransfer.json
@@ -37,7 +37,7 @@
     "heatEquationSolver": {
         "modelType": "HeatEquation",
         "linearSolver": {
-            "maxIterations": 100,
+            "maxIterations": 4,
             "absoluteTolerance": 1e-12
         },
         "equationEvalFrequency": 20

--- a/tests/data/cases/case_udd_legacy.json
+++ b/tests/data/cases/case_udd_legacy.json
@@ -51,7 +51,7 @@
         "quadraticConstitutiveRelation": false,
         "reconstructionGradientLimiter": 0.5,
         "linearSolverConfig": {
-            "maxIterations": 20,
+            "maxIterations": 2,
             "absoluteTolerance": 1e-10
         },
         "modelConstants": {
@@ -60,6 +60,15 @@
         },
         "rotationCorrection": false
     },
+    "transitionModelSolver": {
+		"modelType": "AmplificationFactorTransport",
+		"orderOfAccuracy": 2,
+		"Ncrit": 3,
+        "linearSolverConfig": {
+            "maxIterations": 3,
+            "absoluteTolerance": 1e-10
+        }
+	},
     "freestream": {
         "alphaAngle": 0,
         "betaAngle": 0,
@@ -173,7 +182,7 @@
         "limitVelocity": false,
         "limitPressureDensity": false,
         "linearSolverConfig": {
-            "maxIterations": 30,
+            "maxIterations": 1,
             "absoluteTolerance": 1e-10
         }
     },

--- a/tests/params/test_initial_condition.py
+++ b/tests/params/test_initial_condition.py
@@ -5,7 +5,6 @@ import pytest
 import flow360 as fl
 from flow360.component.flow360_params.initial_condition import (
     ExpressionInitialCondition,
-    FreestreamInitialCondition,
 )
 from tests.utils import to_file_from_file_test
 
@@ -18,9 +17,6 @@ def change_test_dir(request, monkeypatch):
 
 
 def test_initial_condition():
-    ic = FreestreamInitialCondition()
-    assert ic
-    assert ic.type == "freestream"
 
     ic = ExpressionInitialCondition(rho="x*y", u="x+y", v="x-y", w="z+x+y", p="x/y")
     assert ic

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -150,7 +150,6 @@ def test_updater_from_files():
     params = fl.Flow360Params(f"data/cases/case_7.json")
     assert params.turbulence_model_solver.reconstruction_gradient_limiter == 1.0
     assert params.initial_condition is None
-    print(">>>>>>", params.surface_output)
 
     # ##:: case_udd_legacy.json has linearSolver instead of linearSovlerConfig(legacy)
     params = fl.Flow360Params(f"data/cases/case_udd_legacy.json")

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -4,13 +4,14 @@ import tempfile
 import pytest
 
 import flow360 as fl
+from flow360.component.flow360_params.flow360_legacy import LinearSolverLegacy
 from flow360.component.flow360_params.updater import (
     UPDATE_MAP,
     _find_update_path,
     _no_update,
     _version_match,
 )
-from flow360.exceptions import Flow360NotImplementedError, Flow360RuntimeError
+from flow360.exceptions import Flow360NotImplementedError
 
 
 @pytest.fixture(autouse=True)
@@ -148,6 +149,22 @@ def test_updater_from_files():
     assert params.turbulence_model_solver.reconstruction_gradient_limiter == 0.5
     params = fl.Flow360Params(f"data/cases/case_7.json")
     assert params.turbulence_model_solver.reconstruction_gradient_limiter == 1.0
+    assert params.initial_condition is None
+    print(">>>>>>", params.surface_output)
+
+    # ##:: case_udd_legacy.json has linearSolver instead of linearSovlerConfig(legacy)
+    params = fl.Flow360Params(f"data/cases/case_udd_legacy.json")
+    assert params.navier_stokes_solver.linear_solver.max_iterations == 1
+    assert params.turbulence_model_solver.linear_solver.max_iterations == 2
+    assert params.transition_model_solver.linear_solver.max_iterations == 3
+
+    ##:: case_HeatTransfer.json has linearSolver instead of linearSovlerConfig(legacy)
+    params = fl.Flow360Params(f"data/cases/case_HeatTransfer.json")
+    assert params.heat_equation_solver.linear_solver.max_iterations == 4
+    assert (
+        params.navier_stokes_solver.linear_solver.max_iterations
+        == LinearSolverLegacy.__fields__["max_iterations"].default
+    )
 
 
 def test_version_update():

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -151,6 +151,9 @@ def test_updater_from_files():
     assert params.turbulence_model_solver.reconstruction_gradient_limiter == 1.0
     assert params.initial_condition is None
 
+    params = fl.Flow360Params(f"data/cases/case_20.json")
+    assert set(params.surface_output.output_fields) == set(["Cp", "yPlus"])
+
     # ##:: case_udd_legacy.json has linearSolver instead of linearSovlerConfig(legacy)
     params = fl.Flow360Params(f"data/cases/case_udd_legacy.json")
     assert params.navier_stokes_solver.linear_solver.max_iterations == 1

--- a/tools/integrations/schema_generation.py
+++ b/tools/integrations/schema_generation.py
@@ -12,7 +12,7 @@ from flow360.component.flow360_params.flow360_params import (
 )
 from flow360.component.flow360_params.initial_condition import (
     ExpressionInitialCondition,
-    FreestreamInitialCondition,
+    ModifiedRestartSolution,
 )
 from flow360.component.flow360_params.params_base import (
     Flow360BaseModel,
@@ -191,8 +191,8 @@ class _FluidProperties(Flow360BaseModel):
 
 
 class _InitialConditions(Flow360BaseModel):
-    initial_conditions: Union[FreestreamInitialCondition, ExpressionInitialCondition] = pd.Field(
-        alias="initialConditions", options=["Freestream", "Expression"]
+    initial_conditions: Union[ModifiedRestartSolution, ExpressionInitialCondition] = pd.Field(
+        alias="initialConditions", options=["ModifyRestart", "Expression"]
     )
 
     class SchemaConfig(Flow360BaseModel.SchemaConfig):


### PR DESCRIPTION
- [x] Added `ModifiedRestartSolution` for explicit restart manipulation [INTERNAL]
- [x] Decoupled `LinearSolverLegacy` from `LinearSolver`
- [x] Fix bug when LinearSolver is present but LinearSolverConfig is not. [Missing Legacy Pattern Found]
- [x] Deprecated and move `FreestreamInitialCondition` to legacy
- [x] Added surfaces to `surfaceOutputLegacy` [Missing Legacy Pattern Found]