### PR TITLE
Configuration setting to use system SSL certificates

### DIFF
--- a/flow360/cloud/http_util.py
+++ b/flow360/cloud/http_util.py
@@ -3,12 +3,12 @@ http utils. Example:
 http.get(path)
 """
 
+import ssl
 from functools import wraps
 
 import requests
-import ssl
-from urllib3.poolmanager import PoolManager
 from requests.adapters import HTTPAdapter
+from urllib3.poolmanager import PoolManager
 
 from ..environment import Env
 from ..exceptions import (
@@ -79,8 +79,9 @@ def http_interceptor(func):
 
     return wrapper
 
+
 class SystemHttpsAdapter(HTTPAdapter):
-    """"Transport adapter" that allows us to validate SSL certs against the system store."""
+    """ "Transport adapter" that allows us to validate SSL certs against the system store."""
 
     def init_poolmanager(self, connections, maxsize, block=False, **pool_kwargs):
         self._pool_connections = connections
@@ -94,16 +95,17 @@ class SystemHttpsAdapter(HTTPAdapter):
             ssl_context=self._init_ssl_context(),
             **pool_kwargs,
         )
-    
+
     def cert_verify(self, conn, url, verify, cert):
         super().cert_verify(conn, url, verify, cert)
         conn.ca_certs = None
         conn.conn_kw["ssl_context"].check_hostname = bool(verify)
-    
+
     def _init_ssl_context(self):
         ssl_context = ssl.create_default_context()
         ssl_context.load_default_certs()
         return ssl_context
+
 
 class Http:
     """
@@ -165,6 +167,7 @@ class Http:
         :return:
         """
         return self.session.delete(Env.current.get_real_url(path), auth=api_key_auth)
+
 
 _session = requests.Session()
 if use_system_certs():

--- a/flow360/cloud/security.py
+++ b/flow360/cloud/security.py
@@ -15,6 +15,11 @@ def api_key():
     apikey = UserConfig.apikey(Env.current)
     return apikey
 
+
 def use_system_certs() -> bool:
+    """
+    Get the use_system_certs configuration option for the current environment
+    :return:
+    """
     setting = UserConfig.use_system_certs
     return setting

--- a/flow360/cloud/security.py
+++ b/flow360/cloud/security.py
@@ -14,3 +14,7 @@ def api_key():
 
     apikey = UserConfig.apikey(Env.current)
     return apikey
+
+def use_system_certs() -> bool:
+    setting = UserConfig.use_system_certs
+    return setting

--- a/flow360/user_config.py
+++ b/flow360/user_config.py
@@ -123,6 +123,11 @@ class BasicUserConfig:
     def enable_validation(self):
         """enable user side validation (pydantic)"""
         self._do_validation = True
-
+    
+    @property
+    def use_system_certs(self) -> bool:
+        map = self.config.get(self.profile, {})
+        setting = map.get("usesystemcerts", False)
+        return setting
 
 UserConfig = BasicUserConfig()

--- a/flow360/user_config.py
+++ b/flow360/user_config.py
@@ -23,6 +23,7 @@ class BasicUserConfig:
         self.set_profile(DEFAULT_PROFILE)
         self._check_env_profile()
         self._apikey = None
+        self._use_system_certs = None
         self._check_env_apikey()
         self._do_validation = True
         self._suppress_submit_warning = None
@@ -38,6 +39,12 @@ class BasicUserConfig:
         if self._apikey != apikey:
             log.info("Found env variable FLOW360_APIKEY, using as apikey")
             self._apikey = apikey
+
+    def _check_env_usessytemcerts(self):
+        use_system_certs = os.environ.get("FLOW360_USE_SYSTEM_CERTS", None)
+        if use_system_certs:
+            log.info("Found env variable ,, using as use_system_certs")
+            self._use_system_certs = use_system_certs.toLowerCase() in ['true', 'yes', '1']
 
     @property
     def profile(self):
@@ -126,6 +133,11 @@ class BasicUserConfig:
     
     @property
     def use_system_certs(self) -> bool:
+        self._check_env_profile()
+        self._check_env_usessytemcerts()
+        if self._use_system_certs is not None:
+            return self._use_system_certs
+        
         map = self.config.get(self.profile, {})
         setting = map.get("usesystemcerts", False)
         return setting

--- a/flow360/user_config.py
+++ b/flow360/user_config.py
@@ -44,7 +44,7 @@ class BasicUserConfig:
         use_system_certs = os.environ.get("FLOW360_USE_SYSTEM_CERTS", None)
         if use_system_certs:
             log.info("Found env variable ,, using as use_system_certs")
-            self._use_system_certs = use_system_certs.toLowerCase() in ['true', 'yes', '1']
+            self._use_system_certs = use_system_certs.toLowerCase() in ["true", "yes", "1"]
 
     @property
     def profile(self):
@@ -130,16 +130,23 @@ class BasicUserConfig:
     def enable_validation(self):
         """enable user side validation (pydantic)"""
         self._do_validation = True
-    
+
     @property
     def use_system_certs(self) -> bool:
+        """retrieve the current value of the use_system_certs configuration option
+
+        Returns
+        -------
+        bool
+            whether to use the OS system certificate store for SSL validation"""
         self._check_env_profile()
         self._check_env_usessytemcerts()
         if self._use_system_certs is not None:
             return self._use_system_certs
-        
-        map = self.config.get(self.profile, {})
-        setting = map.get("usesystemcerts", False)
+
+        config_map = self.config.get(self.profile, {})
+        setting = config_map.get("usesystemcerts", False)
         return setting
+
 
 UserConfig = BasicUserConfig()


### PR DESCRIPTION
This is an in-progress patch to support using the OS certificate store (e.g. Windows certificate store) for Flow360 requests, when given a configuration option to change this behavior. Not expected to alter existing default behavior. Further testing is required before taking the "draft" mark off this.

We have a customer who is experiencing SSL-related errors, likely related to an SSL intercepting proxy. The certificates for these are usually distributed to the OS certificate store, but will not be copied to the certipy default bundle. This may resolve such issues, by allowing the OS store which the organisation is managing to be used.

Any advice on testing approach would be welcome. The current unit tests don't make any real HTTP requests, which would be needed to test this functionality. Making those requests would require Internet connectivity where tests are run. In the draft tests I ran, there were issues connecting to the Flow360 API (even public endpoints), because the client is not designed to connect without an access key.