### PR TITLE
Update input for MassInflow boundary condition 

### DIFF
--- a/flow360/component/flow360_params/boundaries.py
+++ b/flow360/component/flow360_params/boundaries.py
@@ -234,6 +234,7 @@ class MassInflow(BoundaryWithTurbulenceQuantities):
 
     type: Literal["MassInflow"] = pd.Field("MassInflow", const=True)
     mass_flow_rate: PositiveFloat = pd.Field(alias="massFlowRate")
+    total_temperature_ratio: PositiveFloat = pd.Field(alias="totalTemperatureRatio")
     ramp_steps: Optional[PositiveInt] = pd.Field(alias="rampSteps")
 
 

--- a/tests/data/cases/case_boundaries.json
+++ b/tests/data/cases/case_boundaries.json
@@ -116,7 +116,8 @@
       },
       "5":{
         "type":"MassInflow",
-        "massFlowRate":2.0
+        "massFlowRate":2.0,
+        "totalTemperatureRatio":1.0
       }
    }
 }

--- a/tests/params/test_params_boundary.py
+++ b/tests/params/test_params_boundary.py
@@ -253,9 +253,11 @@ def test_boundary_types():
     )
     assert SlidingInterfaceBoundary().type == "SlidingInterface"
     assert WallFunction().type == "WallFunction"
-    assert MassInflow(massFlowRate=1).type == "MassInflow"
+    assert MassInflow(massFlowRate=1, totalTemperatureRatio=1).type == "MassInflow"
     with pytest.raises(pd.ValidationError):
         MassInflow(massFlowRate=-1)
+    with pytest.raises(pd.ValidationError):
+        MassInflow(totalTemperatureRatio=-1)
     assert MassOutflow(massFlowRate=1).type == "MassOutflow"
     with pytest.raises(pd.ValidationError):
         MassOutflow(massFlowRate=-1)
@@ -320,6 +322,7 @@ def test_boundary_types():
     bc = MassInflow(
         name="SomeBC",
         mass_flow_rate=0.2,
+        total_temperature_ratio=0.43,
         turbulence_quantities=TurbulenceQuantities(modified_viscosity_ratio=1.2),
     )
 
@@ -328,6 +331,7 @@ def test_boundary_types():
     bc = MassInflow(
         name="SomeBC",
         mass_flow_rate=0.2,
+        total_temperature_ratio=0.43,
         turbulence_quantities=TurbulenceQuantities(turbulent_intensity=0.2),
     )
 
@@ -336,6 +340,7 @@ def test_boundary_types():
     bc = MassInflow(
         name="SomeBC",
         mass_flow_rate=0.2,
+        total_temperature_ratio=0.43,
         turbulence_quantities=TurbulenceQuantities(turbulent_kinetic_energy=12.2),
     )
 
@@ -344,6 +349,7 @@ def test_boundary_types():
     bc = MassInflow(
         name="SomeBC",
         mass_flow_rate=0.2,
+        total_temperature_ratio=0.43,
         turbulence_quantities=TurbulenceQuantities(turbulent_length_scale=1.23),
     )
 

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -137,6 +137,7 @@ def test_updater_from_files():
         "case_customDynamics1.json",
         "case_HeatTransfer.json",
         "case_20.json",
+        "case_boundaries.json",
     ]
 
     for file in files:
@@ -172,6 +173,15 @@ def test_updater_from_files():
     params = fl.Flow360Params("data/cases/case_18.json")
     assert params.heat_equation_solver is None
     assert params.transition_model_solver is None
+
+    params = fl.Flow360Params("data/cases/case_boundaries.json")
+    assert params.boundaries["1"].static_pressure_ratio == 0.4
+    assert params.boundaries["2"].Mach == 1.0
+    assert params.boundaries["3"].total_pressure_ratio == 1.0
+    assert params.boundaries["3"].total_temperature_ratio == 1.0
+    assert params.boundaries["4"].mass_flow_rate == 1.0
+    assert params.boundaries["5"].mass_flow_rate == 2.0
+    assert params.boundaries["5"].total_temperature_ratio == 1.0
 
 
 def test_version_update():


### PR DESCRIPTION
* Currently, the `MassInflow` boundary condition requires `totalTemperatureRatio` in the calculations, but it is not set as required input in the Python API. 
* Hence, it has been added as a required input for this boundary condition, and the corresponding tests have been updated as part of this PR. 