### PR TITLE
Give warning that `velocityType` is no longer supported.

### DIFF
--- a/flow360/component/flow360_params/flow360_params.py
+++ b/flow360/component/flow360_params/flow360_params.py
@@ -125,6 +125,7 @@ from .validations import (
     _check_output_fields,
     _check_periodic_boundary_mapping,
     _check_tri_quad_boundaries,
+    _ignore_velocity_type_in_boundaries,
 )
 from .volume_zones import (
     FluidDynamicsVolumeZone,
@@ -404,6 +405,7 @@ class Boundaries(Flow360SortableBaseModel):
         ValidationError
             When boundary is incorrect
         """
+        values = _ignore_velocity_type_in_boundaries(values)
         return _self_named_property_validator(
             values, _GenericBoundaryWrapper, msg="is not any of supported boundary types."
         )

--- a/flow360/component/flow360_params/params_base.py
+++ b/flow360/component/flow360_params/params_base.py
@@ -94,6 +94,8 @@ def _self_named_property_validator(values: dict, validator: Type[BaseModel], msg
             continue
         try:
             values[key] = validator(v=v).v
+        except pd.ValidationError as exc:
+            raise exc
         except Exception as exc:
             raise ValueError(f"{v} (type={type(v)}) {msg}") from exc
     return values

--- a/flow360/component/flow360_params/validations.py
+++ b/flow360/component/flow360_params/validations.py
@@ -25,10 +25,12 @@ from .volume_zones import HeatTransferVolumeZone
 def _ignore_velocity_type_in_boundaries(values):
     """values here is actually json dict."""
     for boundary_name, obj in values.items():
+
         if "velocityType" in obj:
+            bcType = obj.get("type", "")
             log.warning(
-                f"In {boundary_name}: 'velocityType' is no longer supported and will be ignored."
-                "Inertial frame velocity is used."
+                f"Specifying velocityType for boundary condition {bcType} is no longer supported."
+                "The boundary velocity type must now always be prescribed relative to to the inertial reference frame."
             )
         if isinstance(obj, dict):
             obj.pop("velocityType", None)

--- a/flow360/component/flow360_params/validations.py
+++ b/flow360/component/flow360_params/validations.py
@@ -22,6 +22,18 @@ from .time_stepping import SteadyTimeStepping, UnsteadyTimeStepping
 from .volume_zones import HeatTransferVolumeZone
 
 
+def _ignore_velocity_type_in_boundaries(values):
+    """values here is actually json dict."""
+    for boundary_name, obj in values.items():
+        if "velocityType" in obj:
+            log.warning(
+                f"In {boundary_name}: 'velocityType' is no longer supported and will be ignored. Inertial frame velocity is used."
+            )
+        if isinstance(obj, dict):
+            obj.pop("velocityType", None)
+    return values
+
+
 def _check_tri_quad_boundaries(values):
     boundaries = values.get("boundaries")
     boundary_names = []

--- a/flow360/component/flow360_params/validations.py
+++ b/flow360/component/flow360_params/validations.py
@@ -24,12 +24,12 @@ from .volume_zones import HeatTransferVolumeZone
 
 def _ignore_velocity_type_in_boundaries(values):
     """values here is actually json dict."""
-    for boundary_name, obj in values.items():
+    for obj in values.values():
 
         if "velocityType" in obj:
-            bcType = obj.get("type", "")
+            bc_type = obj.get("type", "")
             log.warning(
-                f"Specifying velocityType for boundary condition {bcType} is no longer supported."
+                f"Specifying velocityType for boundary condition {bc_type} is no longer supported."
                 "The boundary velocity type must now always be prescribed relative to to the inertial reference frame."
             )
         if isinstance(obj, dict):

--- a/flow360/component/flow360_params/validations.py
+++ b/flow360/component/flow360_params/validations.py
@@ -27,7 +27,8 @@ def _ignore_velocity_type_in_boundaries(values):
     for boundary_name, obj in values.items():
         if "velocityType" in obj:
             log.warning(
-                f"In {boundary_name}: 'velocityType' is no longer supported and will be ignored. Inertial frame velocity is used."
+                f"In {boundary_name}: 'velocityType' is no longer supported and will be ignored."
+                "Inertial frame velocity is used."
             )
         if isinstance(obj, dict):
             obj.pop("velocityType", None)

--- a/tests/data/cases/case_10.json
+++ b/tests/data/cases/case_10.json
@@ -68,7 +68,8 @@
    },
    "boundaries": {
       "stationaryField/farfield": {
-         "type": "Freestream"
+         "type": "Freestream", 
+         "velocityType": "relative"
       },
       "stationaryField/rotationInterface": {
          "type": "SlidingInterface"


### PR DESCRIPTION
And also allow deseralization to continue instead of erroring out.

Also separated pd.ValidationError handling out of _self_named_property_validator to show more details on why validation failed.