### PR TITLE
Fixed allowed isosurface fields

### DIFF
--- a/flow360/component/flow360_params/flow360_fields.py
+++ b/flow360/component/flow360_params/flow360_fields.py
@@ -101,7 +101,6 @@ VolumeFieldNames = Literal[
 SliceFieldNames = VolumeFieldNames
 
 IsoSurfaceFieldNamesFull = Literal[
-    CommonFieldNamesFull,
     "Pressure",
     "Density",
     "Mach number",
@@ -114,7 +113,6 @@ IsoSurfaceFieldNamesFull = Literal[
 ]
 
 IsoSurfaceFieldNames = Literal[
-    CommonFieldNames,
     "p",
     "rho",
     "Mach",

--- a/tests/simulation/translator/test_output_translation.py
+++ b/tests/simulation/translator/test_output_translation.py
@@ -467,7 +467,7 @@ def isosurface_output_config_with_global_setting():
                     Isosurface(
                         name="isosurface 12",
                         iso_value=20.431,
-                        field="vorticity",
+                        field="qcriterion",
                     ),
                 ],
                 output_fields=["Cp"],
@@ -509,7 +509,7 @@ def isosurface_output_config_with_global_setting():
                 },
                 "isosurface 12": {
                     "outputFields": ["Cp", "primitiveVars", "wallDistance"],
-                    "surfaceField": "vorticity",
+                    "surfaceField": "qcriterion",
                     "surfaceFieldMagnitude": 20.431,
                 },
             },
@@ -533,7 +533,7 @@ def isosurface_output_config_with_no_global_setting():
                     Isosurface(
                         name="isosurface 14",
                         iso_value=20.431,
-                        field="vorticity",
+                        field="qcriterion",
                     ),
                 ],
                 output_fields=["Cp"],
@@ -581,7 +581,7 @@ def isosurface_output_config_with_no_global_setting():
                 },
                 "isosurface 14": {
                     "outputFields": ["Cp"],
-                    "surfaceField": "vorticity",
+                    "surfaceField": "qcriterion",
                     "surfaceFieldMagnitude": 20.431,
                 },
             },


### PR DESCRIPTION
Fixed allowed isosurface fields for one of "p", "rho", "Mach", "qcriterion", "s", "T", "Cp", "mut", "nuHat"