### PR TITLE
Fix the reference json for CHTThreeCylinders case

### DIFF
--- a/tests/simulation/translator/ref/Flow360_CHT_three_cylinders.json
+++ b/tests/simulation/translator/ref/Flow360_CHT_three_cylinders.json
@@ -154,20 +154,20 @@
     "volumeZones": {
         "solid-1": {
             "modelType": "HeatTransfer",
-            "thermalConductivity": 0.00239367
+            "thermalConductivity": 0.003472
         },
         "solid-2": {
             "modelType": "HeatTransfer",
-            "thermalConductivity": 0.00239367
+            "thermalConductivity": 0.003472
         },
         "solid-3": {
             "modelType": "HeatTransfer",
-            "thermalConductivity": 0.00239367,
+            "thermalConductivity": 0.003472,
             "volumetricHeatSource": 0.001
         },
         "solid-4": {
             "modelType": "HeatTransfer",
-            "thermalConductivity": 0.0239367,
+            "thermalConductivity": 0.03472,
             "volumetricHeatSource": 0.001
         }
     }

--- a/tests/simulation/translator/utils/CHTThreeCylinders_param_generator.py
+++ b/tests/simulation/translator/utils/CHTThreeCylinders_param_generator.py
@@ -82,7 +82,7 @@ def create_conjugate_heat_transfer_param():
         surface_adiabatic_4 = Surface(
             name="adiabatic-4", private_attribute_full_name="solid-4/adiabatic-4"
         )
-        copper = SolidMaterial(name="copper", thermal_conductivity=401)
+        copper = SolidMaterial(name="copper", thermal_conductivity=581.65)
         params = SimulationParams(
             operating_condition=AerospaceCondition.from_mach(
                 mach=0.01,
@@ -121,7 +121,7 @@ def create_conjugate_heat_transfer_param():
                     entities=solid_zone_4,
                     heat_equation_solver=heat_equation_solver,
                     material=SolidMaterial(
-                        name="super_conductive", thermal_conductivity=4010
+                        name="super_conductive", thermal_conductivity=5816.5
                     ),  # unrealistic value for testing
                     volumetric_heat_source=volumetric_heat_source,
                 ),


### PR DESCRIPTION
The reference Flow360.json file used in the unit test has the different thermalConductivity values from the original localTest parameter settings. This leads assertion errors when converting the local test to use the simulationParams-based inputs.