### PR TITLE
Add unit test for checking the modification of turbulence coefficients

### DIFF
--- a/tests/simulation/translator/ref/Flow360_om6wing_SA_with_modified_C_w2.json
+++ b/tests/simulation/translator/ref/Flow360_om6wing_SA_with_modified_C_w2.json
@@ -1,0 +1,171 @@
+{
+    "boundaries": {
+        "1": {
+            "type": "NoSlipWall"
+        },
+        "2": {
+            "type": "SlipWall"
+        },
+        "3": {
+            "type": "Freestream"
+        }
+    },
+    "freestream": {
+        "Mach": 0.84,
+        "muRef": 5.326121165140212e-08,
+        "Temperature": 288.15,
+        "alphaAngle": 3.06,
+        "betaAngle": 0.0
+    },
+    "geometry": {
+        "momentCenter": [
+            0.0,
+            0.0,
+            0.0
+        ],
+        "momentLength": [
+            0.801672958512342,
+            0.801672958512342,
+            0.801672958512342
+        ],
+        "refArea": 1.1529999999999987
+    },
+    "navierStokesSolver": {
+        "CFLMultiplier": 1.0,
+        "absoluteTolerance": 1e-10,
+        "equationEvalFrequency": 1,
+        "kappaMUSCL": -1.0,
+        "limitPressureDensity": false,
+        "limitVelocity": false,
+        "linearSolver": {
+            "maxIterations": 25
+        },
+        "lowMachPreconditioner": false,
+        "maxForceJacUpdatePhysicalSteps": 0,
+        "modelType": "Compressible",
+        "numericalDissipationFactor": 1.0,
+        "orderOfAccuracy": 2,
+        "relativeTolerance": 0.0,
+        "updateJacobianFrequency": 4
+    },
+    "sliceOutput": {
+        "animationFrequency": -1,
+        "animationFrequencyOffset": 0,
+        "animationFrequencyTimeAverage": -1,
+        "animationFrequencyTimeAverageOffset": 0,
+        "computeTimeAverages": false,
+        "startAverageIntegrationStep": -1,
+        "outputFormat": "tecplot",
+        "outputFields": [],
+        "slices": {
+            "sliceName_1": {
+                "outputFields": [
+                    "primitiveVars",
+                    "vorticity",
+                    "T",
+                    "s",
+                    "Cp",
+                    "mut",
+                    "mutRatio",
+                    "Mach"
+                ],
+                "sliceNormal": [
+                    0.0,
+                    1.0,
+                    0.0
+                ],
+                "sliceOrigin": [
+                    0.0,
+                    0.7000000000000001,
+                    0.0
+                ]
+            }
+        }
+    },
+    "surfaceOutput": {
+        "animationFrequency": -1,
+        "animationFrequencyOffset": 0,
+        "animationFrequencyTimeAverage": -1,
+        "animationFrequencyTimeAverageOffset": 0,
+        "computeTimeAverages": false,
+        "outputFields": [],
+        "outputFormat": "paraview",
+        "startAverageIntegrationStep": -1,
+        "surfaces": {
+            "3": {
+                "outputFields": [
+                    "nuHat"
+                ]
+            },
+            "2": {
+                "outputFields": [
+                    "nuHat"
+                ]
+            },
+            "1": {
+                "outputFields": [
+                    "nuHat"
+                ]
+            }
+        },
+        "writeSingleFile": false
+    },
+    "timeStepping": {
+        "CFL": {
+            "final": 200.0,
+            "initial": 5.0,
+            "rampSteps": 40,
+            "type": "ramp"
+        },
+        "maxPseudoSteps": 2000,
+        "orderOfAccuracy": 2,
+        "physicalSteps": 1,
+        "timeStepSize": "inf"
+    },
+    "turbulenceModelSolver": {
+        "CFLMultiplier": 2.0,
+        "DDES": false,
+        "absoluteTolerance": 1e-08,
+        "equationEvalFrequency": 4,
+        "gridSizeForLES": "maxEdgeLength",
+        "linearSolver": {
+            "maxIterations": 15
+        },
+        "maxForceJacUpdatePhysicalSteps": 0,
+        "modelConstants": {
+            "C_DES": 0.72,
+            "C_d": 8.0,
+            "C_cb1": 0.1355,
+            "C_cb2": 0.622,
+            "C_sigma": 0.6666666666666666,
+            "C_v1": 7.1,
+            "C_vonKarman": 0.41,
+            "C_w2": 2.718,
+            "C_t3": 1.2,
+            "C_t4": 0.5,
+            "C_min_rd": 10.0
+        },
+        "modelType": "SpalartAllmaras",
+        "orderOfAccuracy": 2,
+        "quadraticConstitutiveRelation": false,
+        "reconstructionGradientLimiter": 0.5,
+        "relativeTolerance": 0.0,
+        "rotationCorrection": false,
+        "updateJacobianFrequency": 4
+    },
+    "volumeOutput": {
+        "animationFrequency": -1,
+        "animationFrequencyOffset": 0,
+        "animationFrequencyTimeAverage": -1,
+        "animationFrequencyTimeAverageOffset": 0,
+        "computeTimeAverages": false,
+        "outputFields": [
+            "primitiveVars",
+            "residualNavierStokes",
+            "residualTurbulence",
+            "Mach"
+        ],
+        "outputFormat": "paraview",
+        "startAverageIntegrationStep": -1
+    }
+}

--- a/tests/simulation/translator/ref/Flow360_om6wing_SST_with_modified_C_sigma_omega1.json
+++ b/tests/simulation/translator/ref/Flow360_om6wing_SST_with_modified_C_sigma_omega1.json
@@ -1,0 +1,171 @@
+{
+    "boundaries": {
+        "1": {
+            "type": "NoSlipWall"
+        },
+        "2": {
+            "type": "SlipWall"
+        },
+        "3": {
+            "type": "Freestream"
+        }
+    },
+    "freestream": {
+        "Mach": 0.84,
+        "muRef": 5.326121165140212e-08,
+        "Temperature": 288.15,
+        "alphaAngle": 3.06,
+        "betaAngle": 0.0
+    },
+    "geometry": {
+        "momentCenter": [
+            0.0,
+            0.0,
+            0.0
+        ],
+        "momentLength": [
+            0.801672958512342,
+            0.801672958512342,
+            0.801672958512342
+        ],
+        "refArea": 1.1529999999999987
+    },
+    "navierStokesSolver": {
+        "CFLMultiplier": 1.0,
+        "absoluteTolerance": 1e-10,
+        "equationEvalFrequency": 1,
+        "kappaMUSCL": -1.0,
+        "limitPressureDensity": false,
+        "limitVelocity": false,
+        "linearSolver": {
+            "maxIterations": 25
+        },
+        "lowMachPreconditioner": false,
+        "maxForceJacUpdatePhysicalSteps": 0,
+        "modelType": "Compressible",
+        "numericalDissipationFactor": 1.0,
+        "orderOfAccuracy": 2,
+        "relativeTolerance": 0.0,
+        "updateJacobianFrequency": 4
+    },
+    "sliceOutput": {
+        "animationFrequency": -1,
+        "animationFrequencyOffset": 0,
+        "animationFrequencyTimeAverage": -1,
+        "animationFrequencyTimeAverageOffset": 0,
+        "computeTimeAverages": false,
+        "startAverageIntegrationStep": -1,
+        "outputFormat": "tecplot",
+        "outputFields": [],
+        "slices": {
+            "sliceName_1": {
+                "outputFields": [
+                    "primitiveVars",
+                    "vorticity",
+                    "T",
+                    "s",
+                    "Cp",
+                    "mut",
+                    "mutRatio",
+                    "Mach"
+                ],
+                "sliceNormal": [
+                    0.0,
+                    1.0,
+                    0.0
+                ],
+                "sliceOrigin": [
+                    0.0,
+                    0.7000000000000001,
+                    0.0
+                ]
+            }
+        }
+    },
+    "surfaceOutput": {
+        "animationFrequency": -1,
+        "animationFrequencyOffset": 0,
+        "animationFrequencyTimeAverage": -1,
+        "animationFrequencyTimeAverageOffset": 0,
+        "computeTimeAverages": false,
+        "outputFields": [],
+        "outputFormat": "paraview",
+        "startAverageIntegrationStep": -1,
+        "surfaces": {
+            "3": {
+                "outputFields": [
+                    "nuHat"
+                ]
+            },
+            "2": {
+                "outputFields": [
+                    "nuHat"
+                ]
+            },
+            "1": {
+                "outputFields": [
+                    "nuHat"
+                ]
+            }
+        },
+        "writeSingleFile": false
+    },
+    "timeStepping": {
+        "CFL": {
+            "final": 200.0,
+            "initial": 5.0,
+            "rampSteps": 40,
+            "type": "ramp"
+        },
+        "maxPseudoSteps": 2000,
+        "orderOfAccuracy": 2,
+        "physicalSteps": 1,
+        "timeStepSize": "inf"
+    },
+    "turbulenceModelSolver": {
+        "CFLMultiplier": 2.0,
+        "DDES": false,
+        "absoluteTolerance": 1e-08,
+        "equationEvalFrequency": 4,
+        "gridSizeForLES": "maxEdgeLength",
+        "linearSolver": {
+            "maxIterations": 15
+        },
+        "maxForceJacUpdatePhysicalSteps": 0,
+        "modelConstants": {
+            "C_DES1": 0.78,
+            "C_DES2": 0.61,
+            "C_alpha1": 0.31,
+            "C_beta1": 0.075,
+            "C_beta2": 0.0828,
+            "C_beta_star": 0.09,
+            "C_d1": 20.0,
+            "C_d2": 3.0,
+            "C_sigma_k1": 0.85,
+            "C_sigma_k2": 1.0,
+            "C_sigma_omega1": 2.718,
+            "C_sigma_omega2": 0.856
+        },
+        "modelType": "kOmegaSST",
+        "orderOfAccuracy": 2,
+        "quadraticConstitutiveRelation": false,
+        "reconstructionGradientLimiter": 1.0,
+        "relativeTolerance": 0.0,
+        "updateJacobianFrequency": 4
+    },
+    "volumeOutput": {
+        "animationFrequency": -1,
+        "animationFrequencyOffset": 0,
+        "animationFrequencyTimeAverage": -1,
+        "animationFrequencyTimeAverageOffset": 0,
+        "computeTimeAverages": false,
+        "outputFields": [
+            "primitiveVars",
+            "residualNavierStokes",
+            "residualTurbulence",
+            "Mach"
+        ],
+        "outputFormat": "paraview",
+        "startAverageIntegrationStep": -1
+    }
+}

--- a/tests/simulation/translator/test_solver_translator.py
+++ b/tests/simulation/translator/test_solver_translator.py
@@ -5,9 +5,12 @@ import pytest
 
 import flow360.component.simulation.units as u
 from flow360.component.simulation.models.solver_numerics import (
+    KOmegaSST,
+    KOmegaSSTModelConstants,
     LinearSolver,
     NavierStokesSolver,
     SpalartAllmaras,
+    SpalartAllmarasModelConstants,
 )
 from flow360.component.simulation.models.surface_models import (
     Freestream,
@@ -192,6 +195,31 @@ def test_om6wing_with_specified_freestream_BC(get_om6Wing_tutorial_param):
         get_om6Wing_tutorial_param,
         mesh_unit=0.8059 * u.m,
         ref_json_file="Flow360_om6wing_FS_with_vel_expression.json",
+    )
+
+
+def test_om6wing_with_specified_turbulence_model_coefficient(get_om6Wing_tutorial_param):
+    params = get_om6Wing_tutorial_param
+    params.models[0].turbulence_model_solver.modeling_constants = SpalartAllmarasModelConstants(
+        C_w2=2.718
+    )
+    translate_and_compare(
+        get_om6Wing_tutorial_param,
+        mesh_unit=0.8059 * u.m,
+        ref_json_file="Flow360_om6wing_SA_with_modified_C_w2.json",
+    )
+
+    params.models[0].turbulence_model_solver = KOmegaSST(
+        absolute_tolerance=1e-8,
+        linear_solver=LinearSolver(max_iterations=15),
+    )
+    params.models[0].turbulence_model_solver.modeling_constants = KOmegaSSTModelConstants(
+        C_sigma_omega1=2.718
+    )
+    translate_and_compare(
+        get_om6Wing_tutorial_param,
+        mesh_unit=0.8059 * u.m,
+        ref_json_file="Flow360_om6wing_SST_with_modified_C_sigma_omega1.json",
     )
 
 


### PR DESCRIPTION
Remove the `checkJSONCustomCoefficient_SA() ` and `checkJSONCustomCoefficient_SST() ` checks in the om6wing local tests and add the corresponding python client unit tests.