### PR TITLE
test(): add test to project

### DIFF
--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,0 +1,9 @@
+from flow360.component.project import Project, ProjectMeta
+
+
+def test_project(mock_id, mock_response):
+    Project(
+        metadata=ProjectMeta(
+            user_id="user_id",
+        )
+    )


### PR DESCRIPTION
@benflexcompute Project use model Case as function's parameter. It will raise the following errors. You can run the quick_start.py to reproduce the error either.

```
pydantic.errors.PydanticSchemaGenerationError: Unable to generate pydantic-core schema for <class 'flow360.component.case.Case'>. Set `arbitrary_types_allowed=True` in the model_config to ignore this error or implement ...
```

https://github.com/flexcompute/Flow360/blob/738dc74e08d6e2d00c1f83de28bb9737702a31b5/flow360/component/project.py#L680-L686