### PR TITLE
Fix Transition Solver Field and Add Conflict Fields Unit Test

### DIFF
--- a/flow360/component/simulation/models/solver_numerics.py
+++ b/flow360/component/simulation/models/solver_numerics.py
@@ -380,6 +380,10 @@ class TransitionModelSolver(GenericSolverSettings):
     >>> ts = TransitionModelSolver(absolute_tolerance=1e-10)
     """
 
+    model_config = pd.ConfigDict(
+        conflicting_fields=[Conflicts(field1="N_crit", field2="turbulence_intensity_percent")]
+    )
+
     type_name: Literal["AmplificationFactorTransport"] = pd.Field(
         "AmplificationFactorTransport", frozen=True
     )
@@ -397,7 +401,7 @@ class TransitionModelSolver(GenericSolverSettings):
         4, description="Frequency at which to update the transition equation."
     )
     turbulence_intensity_percent: Optional[pd.confloat(ge=0.03, le=2.5)] = pd.Field(
-        1.0,
+        None,
         description=":ref:`Turbulence Intensity <TurbI>`, Range from [0.03-2.5]. "
         + "Only valid when :paramref:`N_crit` is not specified.",
     )

--- a/tests/simulation/params/test_validators_params.py
+++ b/tests/simulation/params/test_validators_params.py
@@ -364,7 +364,7 @@ def test_transition_model_solver_settings_validator():
         assert params.models[0].transition_model_solver.N_crit == 2.3598473252999543
         assert params.models[0].transition_model_solver.turbulence_intensity_percent is None
 
-        
+
 def test_incomplete_BC():
     ##:: Construct a dummy asset cache
 

--- a/tests/simulation/params/test_validators_params.py
+++ b/tests/simulation/params/test_validators_params.py
@@ -309,7 +309,7 @@ def test_cht_solver_settings_validator(
         )
 
 
-def test_transition():
+def test_transition_model_solver_settings_validator():
     transition_model_solver = TransitionModelSolver()
     assert transition_model_solver
 


### PR DESCRIPTION
Remove default value for `turbulence_intensity_percent` in `TransitionModelSolver` class
Add validation test for conflict fields: `turbulence_intensity_percent` and `N_crit`
Add unit test for base_model to test the conflict fields.