### PR TITLE
Fix(): Remove usage of unit_system_name from request

### DIFF
--- a/flow360/component/case.py
+++ b/flow360/component/case.py
@@ -429,22 +429,10 @@ class Case(CaseBase, Flow360Resource):
             # if the params come from GUI, it can contain data that is not conformal with SimulationParams thus cleaning
             with open(temp_file.name, "r", encoding="utf-8") as fh:
                 params_as_dict: dict = json.load(fh)
-                # >> Get the unit system stored in the params.
-                # We do not really need this because all values in params are dimensioned and should not depend
-                # on the unit system anymore.
-                unit_system_name = None
-                for unit_system_key in ["unitSystem", "unit_system"]:
-                    unit_system_dict = params_as_dict.get(unit_system_key, None)
-                    if unit_system_dict is not None:
-                        unit_system_name = unit_system_dict.get("name", None)
-                        break
 
-                if unit_system_name is None:
-                    raise KeyError(
-                        "Unit system not found in the simulation params. Corrupted file."
-                    )
-
-            param, errors, _ = services.validate_model(params_as_dict, unit_system_name, None)
+            param, errors, _ = services.validate_model(
+                params_as_dict=params_as_dict, root_item_type=None
+            )
 
             if errors is not None:
                 raise Flow360ValidationError(

--- a/flow360/component/simulation/meshing_param/volume_params.py
+++ b/flow360/component/simulation/meshing_param/volume_params.py
@@ -98,6 +98,22 @@ class RotationCylinder(CylindricalRefinementBase):
                 "Only single instance is allowed in entities for each RotationCylinder."
             )
         return values
+    
+    @pd.field_validator("entities", mode="after")
+    @classmethod
+    def _validate_cylinder_name_length(cls, values):
+        """
+        [CAPABILITY-LIMITATION]
+        Multiple instances in the entities is not allowed.
+        Because enclosed_entities will almost certain be different.
+        `enclosed_entities` is planned to be auto_populated in the future.
+        """
+        # pylint: disable=protected-access
+        if len(values._get_expanded_entities(expect_supplied_registry=False)) > 1:
+            raise ValueError(
+                "Only single instance is allowed in entities for each RotationCylinder."
+            )
+        return values
 
 
 class AutomatedFarfield(Flow360BaseModel):

--- a/flow360/component/simulation/meshing_param/volume_params.py
+++ b/flow360/component/simulation/meshing_param/volume_params.py
@@ -98,22 +98,6 @@ class RotationCylinder(CylindricalRefinementBase):
                 "Only single instance is allowed in entities for each RotationCylinder."
             )
         return values
-    
-    @pd.field_validator("entities", mode="after")
-    @classmethod
-    def _validate_cylinder_name_length(cls, values):
-        """
-        [CAPABILITY-LIMITATION]
-        Multiple instances in the entities is not allowed.
-        Because enclosed_entities will almost certain be different.
-        `enclosed_entities` is planned to be auto_populated in the future.
-        """
-        # pylint: disable=protected-access
-        if len(values._get_expanded_entities(expect_supplied_registry=False)) > 1:
-            raise ValueError(
-                "Only single instance is allowed in entities for each RotationCylinder."
-            )
-        return values
 
 
 class AutomatedFarfield(Flow360BaseModel):

--- a/flow360/component/simulation/services.py
+++ b/flow360/component/simulation/services.py
@@ -46,7 +46,10 @@ from flow360.component.simulation.unit_system import (
     imperial_unit_system,
     unit_system_manager,
 )
-from flow360.component.simulation.utils import model_attribute_unlock
+from flow360.component.simulation.utils import (
+    get_unit_system_name_from_simulation_params_dict,
+    model_attribute_unlock,
+)
 from flow360.component.simulation.validation.validation_context import (
     ALL,
     SURFACE_MESH,
@@ -207,7 +210,6 @@ def get_default_params(
 
 def validate_model(
     params_as_dict,
-    unit_system_name,
     root_item_type: Literal["Geometry", "VolumeMesh"],
     validation_level: Literal[
         "SurfaceMesh", "VolumeMesh", "Case", "All"
@@ -220,8 +222,6 @@ def validate_model(
     ----------
     params_as_dict : dict
         The parameters dictionary to validate.
-    unit_system_name : str
-        The unit system name to initialize.
     root_item_type : Literal["Geometry", "VolumeMesh"]
         The root item type for validation.
     validation_level : Literal["SurfaceMesh", "VolumeMesh", "Case", "All"], optional
@@ -236,6 +236,7 @@ def validate_model(
     validation_warnings : list or None
         A list of validation warnings if any occurred.
     """
+    unit_system_name = get_unit_system_name_from_simulation_params_dict(params_as_dict)
     unit_system = init_unit_system(
         unit_system_name
     )  # Initialize unit system (to be implemented when supported)
@@ -498,7 +499,6 @@ def _process_case(params: dict, mesh_unit: str, up_to: str) -> Optional[Dict[str
 
 def generate_process_json(
     simulation_json: str,
-    unit_system_name: Literal["SI", "CGS", "Imperial", "Flow360"],
     root_item_type: Literal["Geometry", "VolumeMesh"],
     up_to: Literal["SurfaceMesh", "VolumeMesh", "Case"],
 ):
@@ -512,8 +512,6 @@ def generate_process_json(
     ----------
     simulation_json : str
         The JSON string containing simulation parameters.
-    unit_system_name : Literal["SI", "CGS", "Imperial", "Flow360"]
-        The name of the unit system to be used (e.g., "SI", "CGS", "Imperial", "Flow360").
     root_item_type : Literal["Geometry", "VolumeMesh"]
         The root item type for the simulation (e.g., "Geometry", "VolumeMesh").
     up_to : Literal["SurfaceMesh", "VolumeMesh", "Case"]
@@ -536,7 +534,9 @@ def generate_process_json(
 
     # Note: There should not be any validation error for params_as_dict. Here is just a deserilization of the JSON
     params, errors, _ = validate_model(
-        params_as_dict, unit_system_name, root_item_type, validation_level=validation_level
+        params_as_dict=params_as_dict,
+        root_item_type=root_item_type,
+        validation_level=validation_level,
     )
 
     if errors is not None:

--- a/flow360/component/simulation/services.py
+++ b/flow360/component/simulation/services.py
@@ -209,6 +209,7 @@ def get_default_params(
 
 
 def validate_model(
+    *,
     params_as_dict,
     root_item_type: Literal["Geometry", "VolumeMesh"],
     validation_level: Literal[
@@ -498,6 +499,7 @@ def _process_case(params: dict, mesh_unit: str, up_to: str) -> Optional[Dict[str
 
 
 def generate_process_json(
+    *,
     simulation_json: str,
     root_item_type: Literal["Geometry", "VolumeMesh"],
     up_to: Literal["SurfaceMesh", "VolumeMesh", "Case"],

--- a/flow360/component/simulation/utils.py
+++ b/flow360/component/simulation/utils.py
@@ -29,6 +29,21 @@ def get_combined_subclasses(cls):
     return cls.__subclasses__()
 
 
+def get_unit_system_name_from_simulation_params_dict(params_dict: dict) -> str:
+    """Get unit system name from simulation params dict"""
+    unit_system_name = None
+    for unit_system_key in ["unitSystem", "unit_system"]:
+        unit_system_dict = params_dict.get(unit_system_key, None)
+        if unit_system_dict is not None:
+            unit_system_name = unit_system_dict.get("name", None)
+            break
+
+    if unit_system_name is None:
+        raise KeyError("Unit system not found in the simulation params. Corrupted file.")
+
+    return unit_system_name
+
+
 def is_exact_instance(obj, cls):
     """Check if an object is an instance of a class and not a subclass."""
     if isinstance(cls, tuple):

--- a/tests/simulation/performance.py
+++ b/tests/simulation/performance.py
@@ -18,9 +18,7 @@ data = services.get_default_params(
 
 
 def run_validation(data):
-    _, errors, _ = services.validate_model(
-        params_as_dict=data, unit_system_name="SI", root_item_type="Geometry"
-    )
+    _, errors, _ = services.validate_model(params_as_dict=data, root_item_type="Geometry")
 
 
 result = timeit(lambda: run_validation(data), number=10)

--- a/tests/simulation/service/test_services_v2.py
+++ b/tests/simulation/service/test_services_v2.py
@@ -99,13 +99,13 @@ def test_validate_service():
     }
 
     _, errors, _ = services.validate_model(
-        params_as_dict=params_data_from_geo, unit_system_name="SI", root_item_type="Geometry"
+        params_as_dict=params_data_from_geo, root_item_type="Geometry"
     )
 
     assert errors is None
 
     _, errors, _ = services.validate_model(
-        params_as_dict=params_data_from_vm, unit_system_name="SI", root_item_type="VolumeMesh"
+        params_as_dict=params_data_from_vm, root_item_type="VolumeMesh"
     )
 
     assert errors is None
@@ -213,9 +213,7 @@ def test_validate_multiple_errors():
         "user_defined_dynamics": [],
     }
 
-    _, errors, _ = services.validate_model(
-        params_as_dict=params_data, unit_system_name="SI", root_item_type="Geometry"
-    )
+    _, errors, _ = services.validate_model(params_as_dict=params_data, root_item_type="Geometry")
 
     excpected_errors = [
         {
@@ -278,9 +276,7 @@ def test_validate_errors():
         },
     }
 
-    _, errors, _ = services.validate_model(
-        params_as_dict=params_data, unit_system_name="SI", root_item_type="Geometry"
-    )
+    _, errors, _ = services.validate_model(params_as_dict=params_data, root_item_type="Geometry")
     json.dumps(errors)
 
 
@@ -311,9 +307,7 @@ def test_validate_init_data_errors():
     data = services.get_default_params(
         unit_system_name="SI", length_unit="m", root_item_type="Geometry"
     )
-    _, errors, _ = services.validate_model(
-        params_as_dict=data, unit_system_name="SI", root_item_type="Geometry"
-    )
+    _, errors, _ = services.validate_model(params_as_dict=data, root_item_type="Geometry")
 
     excpected_errors = [
         {
@@ -347,7 +341,6 @@ def test_validate_init_data_for_sm_and_vm_errors():
     )
     _, errors, _ = services.validate_model(
         params_as_dict=data,
-        unit_system_name="SI",
         root_item_type="Geometry",
         validation_level=[SURFACE_MESH, VOLUME_MESH],
     )
@@ -377,9 +370,7 @@ def test_validate_init_data_vm_workflow_errors():
     data = services.get_default_params(
         unit_system_name="SI", length_unit="m", root_item_type="VolumeMesh"
     )
-    _, errors, _ = services.validate_model(
-        params_as_dict=data, unit_system_name="SI", root_item_type="VolumeMesh"
-    )
+    _, errors, _ = services.validate_model(params_as_dict=data, root_item_type="VolumeMesh")
 
     excpected_errors = [
         {
@@ -531,13 +522,13 @@ def test_front_end_JSON_with_multi_constructor():
     }
 
     simulation_param, errors, _ = services.validate_model(
-        params_as_dict=params_data, unit_system_name="SI", root_item_type="Geometry"
+        params_as_dict=params_data, root_item_type="Geometry"
     )
     assert errors is None
     with open("../../ref/simulation/simulation_json_with_multi_constructor_used.json", "r") as f:
         ref_data = json.load(f)
         ref_param, err, _ = services.validate_model(
-            params_as_dict=ref_data, unit_system_name="SI", root_item_type="Geometry"
+            params_as_dict=ref_data, root_item_type="Geometry"
         )
         assert err is None
 
@@ -630,12 +621,12 @@ def test_generate_process_json():
         ),
     ):
         res1, res2, res3 = services.generate_process_json(
-            json.dumps(params_data), "SI", "Geometry", "SurfaceMesh"
+            simulation_json=json.dumps(params_data), root_item_type="Geometry", up_to="SurfaceMesh"
         )
 
     params_data["meshing"]["defaults"]["surface_max_edge_length"] = "1*m"
     res1, res2, res3 = services.generate_process_json(
-        json.dumps(params_data), "SI", "Geometry", "SurfaceMesh"
+        simulation_json=json.dumps(params_data), root_item_type="Geometry", up_to="SurfaceMesh"
     )
 
     assert res1 is not None
@@ -649,12 +640,12 @@ def test_generate_process_json():
         ),
     ):
         res1, res2, res3 = services.generate_process_json(
-            json.dumps(params_data), "SI", "Geometry", "VolumeMesh"
+            simulation_json=json.dumps(params_data), root_item_type="Geometry", up_to="VolumeMesh"
         )
 
     params_data["meshing"]["defaults"]["boundary_layer_first_layer_thickness"] = "1*m"
     res1, res2, res3 = services.generate_process_json(
-        json.dumps(params_data), "SI", "Geometry", "VolumeMesh"
+        simulation_json=json.dumps(params_data), root_item_type="Geometry", up_to="VolumeMesh"
     )
 
     assert res1 is not None
@@ -668,12 +659,12 @@ def test_generate_process_json():
         ),
     ):
         res1, res2, res3 = services.generate_process_json(
-            json.dumps(params_data), "SI", "Geometry", "Case"
+            simulation_json=json.dumps(params_data), root_item_type="Geometry", up_to="Case"
         )
 
     params_data["operating_condition"]["velocity_magnitude"] = {"value": 0.8, "units": "km/s"}
     res1, res2, res3 = services.generate_process_json(
-        json.dumps(params_data), "SI", "Geometry", "Case"
+        simulation_json=json.dumps(params_data), root_item_type="Geometry", up_to="Case"
     )
 
     assert res1 is not None

--- a/tests/simulation/service/test_services_v2.py
+++ b/tests/simulation/service/test_services_v2.py
@@ -70,6 +70,7 @@ def test_validate_service():
             }
         ],
         "user_defined_dynamics": [],
+        "unit_system": {"name": "SI"},
         "private_attribute_asset_cache": {
             "project_length_unit": None,
             "project_entity_info": {
@@ -144,11 +145,10 @@ def test_validate_error():
             "CFL": {"type": "ramp", "initial": 1.5, "final": 1.5, "ramp_steps": 5},
         },
         "user_defined_dynamics": [],
+        "unit_system": {"name": "SI"},
     }
 
-    _, errors, _ = services.validate_model(
-        params_as_dict=params_data, unit_system_name="SI", root_item_type="Geometry"
-    )
+    _, errors, _ = services.validate_model(params_as_dict=params_data, root_item_type="Geometry")
 
     excpected_errors = [
         {
@@ -211,6 +211,7 @@ def test_validate_multiple_errors():
             "CFL": {"type": "ramp", "initial": 1.5, "final": 1.5, "ramp_steps": 5},
         },
         "user_defined_dynamics": [],
+        "unit_system": {"name": "SI"},
     }
 
     _, errors, _ = services.validate_model(params_as_dict=params_data, root_item_type="Geometry")
@@ -274,6 +275,7 @@ def test_validate_errors():
             ],
             "defaults": {"surface_edge_growth_rate": 1.2},
         },
+        "unit_system": {"name": "SI"},
     }
 
     _, errors, _ = services.validate_model(params_as_dict=params_data, root_item_type="Geometry")

--- a/tests/simulation/service/test_translator_service.py
+++ b/tests/simulation/service/test_translator_service.py
@@ -611,6 +611,7 @@ def test_simulation_to_all_translation_2():
                 "use_wall_function": False,
             }
         ],
+        "unit_system": {"name": "SI"},
         "private_attribute_asset_cache": {
             "project_length_unit": "m",
             "project_entity_info": {

--- a/tests/simulation/service/test_translator_service.py
+++ b/tests/simulation/service/test_translator_service.py
@@ -75,7 +75,9 @@ def test_simulation_to_surface_meshing_json():
     }
 
     start_time = time.time()
-    params, _, _ = validate_model(param_data, "SI", "Geometry", SURFACE_MESH)
+    params, _, _ = validate_model(
+        params_as_dict=param_data, root_item_type="Geometry", validation_level=SURFACE_MESH
+    )
     simulation_to_surface_meshing_json(params, {"value": 100.0, "units": "cm"})
     end_time = time.time()
     execution_time = end_time - start_time
@@ -201,7 +203,9 @@ def test_simulation_to_volume_meshing_json():
         "version": "24.2.0",
     }
 
-    params, _, _ = validate_model(param_data, "SI", "Geometry", VOLUME_MESH)
+    params, _, _ = validate_model(
+        params_as_dict=param_data, root_item_type="Geometry", validation_level=VOLUME_MESH
+    )
 
     sm_json, hash = simulation_to_volume_meshing_json(params, {"value": 100.0, "units": "cm"})
     assert sm_json["farfield"]["type"] == "auto"
@@ -439,7 +443,7 @@ def test_simulation_to_case_json():
         },
     }
 
-    params, _, _ = validate_model(param_data, "SI", "Geometry")
+    params, _, _ = validate_model(params_as_dict=param_data, root_item_type="Geometry")
 
     simulation_to_case_json(params, {"value": 100.0, "units": "cm"})
 
@@ -539,13 +543,13 @@ def test_simulation_to_case_vm_workflow():
         },
     }
 
-    params, _, _ = validate_model(param_data, "SI", "Geometry")
+    params, _, _ = validate_model(params_as_dict=param_data, root_item_type="Geometry")
 
     with pytest.raises(ValueError):
         case_json, hash = simulation_to_case_json(params, {"value": 100.0, "units": "cm"})
         print(case_json)
 
-    params, errors, _ = validate_model(param_data, "SI", "VolumeMesh")
+    params, errors, _ = validate_model(params_as_dict=param_data, root_item_type="VolumeMesh")
     case_json, hash = simulation_to_case_json(params, {"value": 100.0, "units": "cm"})
     print(case_json)
 
@@ -633,7 +637,7 @@ def test_simulation_to_all_translation_2():
         },
     }
 
-    params, _, _ = validate_model(params_as_dict, "SI", "Geometry")
+    params, _, _ = validate_model(params_as_dict=params_as_dict, root_item_type="Geometry")
 
     surface_json, hash = simulation_to_surface_meshing_json(params, {"value": 100.0, "units": "cm"})
     print(surface_json)

--- a/tools/performance_profile/profiler.py
+++ b/tools/performance_profile/profiler.py
@@ -16,7 +16,7 @@ with open("./data/large_simulation.json", "r") as f:
 end_time = time.time()
 print(f"Execution time: {end_time - start_time} seconds [json.load()]")
 start_time = time.time()
-params, _, _ = validate_model(params_as_dict, "SI", "Geometry")
+params, _, _ = validate_model(params_as_dict=params_as_dict, root_item_type="Geometry")
 end_time = time.time()
 print(f"Execution time: {end_time - start_time} seconds [validate_model]")
 _, hash = simulation_to_surface_meshing_json(params, {"value": 100.0, "units": "cm"})
@@ -31,7 +31,7 @@ def translation_wrapper():
 
 
 def validation_wrapper():
-    _, _, _ = validate_model(params_as_dict, "SI", "Geometry")
+    _, _, _ = validate_model(params_as_dict=params_as_dict, root_item_type="Geometry")
 
 
 cProfile.run("translation_wrapper()", "profile_translator.prof")


### PR DESCRIPTION
The unit system name is obtained from simulation.json now when `WorkbenchValidateRequest` or `WorkbenchGenerateProcessJsonsRequest` received.