### PR TITLE
feat(): `EntityList` Discriminator and removal of string input.

### DIFF
--- a/flow360/component/simulation/framework/base_model.py
+++ b/flow360/component/simulation/framework/base_model.py
@@ -611,7 +611,8 @@ class Flow360BaseModel(pd.BaseModel):
 
     def preprocess(
         self,
-        params,
+        *,
+        params=None,
         mesh_unit=None,
         exclude: List[str] = None,
         required_by: List[str] = None,
@@ -654,7 +655,7 @@ class Flow360BaseModel(pd.BaseModel):
                 loc_name = field.alias
             if isinstance(value, Flow360BaseModel):
                 solver_values[property_name] = value.preprocess(
-                    params,
+                    params=params,
                     mesh_unit=mesh_unit,
                     required_by=[*required_by, loc_name],
                     exclude=exclude,
@@ -663,7 +664,7 @@ class Flow360BaseModel(pd.BaseModel):
                 for i, item in enumerate(value):
                     if isinstance(item, Flow360BaseModel):
                         solver_values[property_name][i] = item.preprocess(
-                            params,
+                            params=params,
                             mesh_unit=mesh_unit,
                             required_by=[*required_by, loc_name, f"{i}"],
                             exclude=exclude,

--- a/flow360/component/simulation/framework/param_utils.py
+++ b/flow360/component/simulation/framework/param_utils.py
@@ -64,9 +64,7 @@ def register_entity_list(model: Flow360BaseModel, registry: EntityRegistry) -> N
 
         if isinstance(field, EntityList):
             # pylint: disable=protected-access
-            expanded_entities = field._get_expanded_entities(
-                supplied_registry=None, expect_supplied_registry=False, create_hard_copy=False
-            )
+            expanded_entities = field._get_expanded_entities(create_hard_copy=False)
             for entity in expanded_entities if expanded_entities else []:
                 registry.register(entity)
 
@@ -95,9 +93,7 @@ def _update_entity_full_name(
 
         if isinstance(field, EntityList):
             # pylint: disable=protected-access
-            expanded_entities = field._get_expanded_entities(
-                supplied_registry=None, expect_supplied_registry=False, create_hard_copy=False
-            )
+            expanded_entities = field._get_expanded_entities(create_hard_copy=False)
             for entity in expanded_entities if expanded_entities else []:
                 if isinstance(entity, target_entity_type):
                     entity._update_entity_info_with_metadata(volume_mesh_meta_data)

--- a/flow360/component/simulation/meshing_param/volume_params.py
+++ b/flow360/component/simulation/meshing_param/volume_params.py
@@ -93,7 +93,7 @@ class RotationCylinder(CylindricalRefinementBase):
         `enclosed_entities` is planned to be auto_populated in the future.
         """
         # pylint: disable=protected-access
-        if len(values._get_expanded_entities(expect_supplied_registry=False)) > 1:
+        if len(values._get_expanded_entities(create_hard_copy=False)) > 1:
             raise ValueError(
                 "Only single instance is allowed in entities for each RotationCylinder."
             )

--- a/flow360/component/simulation/simulation_params.py
+++ b/flow360/component/simulation/simulation_params.py
@@ -229,7 +229,7 @@ class SimulationParams(_ParamModelBase):
     private_attribute_asset_cache: AssetCache = pd.Field(AssetCache(), frozen=True)
 
     # pylint: disable=arguments-differ
-    def preprocess(self, mesh_unit, exclude: list = None) -> SimulationParams:
+    def preprocess(self, mesh_unit=None, exclude: list = None) -> SimulationParams:
         """Internal function for non-dimensionalizing the simulation parameters"""
         if exclude is None:
             exclude = []
@@ -239,8 +239,8 @@ class SimulationParams(_ParamModelBase):
         if unit_system_manager.current is None:
             # pylint: disable=not-context-manager
             with self.unit_system:
-                return super().preprocess(self, mesh_unit=mesh_unit, exclude=exclude)
-        return super().preprocess(self, mesh_unit=mesh_unit, exclude=exclude)
+                return super().preprocess(params=self, mesh_unit=mesh_unit, exclude=exclude)
+        return super().preprocess(params=self, mesh_unit=mesh_unit, exclude=exclude)
 
     # pylint: disable=no-self-argument
     @pd.field_validator("models", mode="after")

--- a/tests/simulation/framework/test_base_model_v2.py
+++ b/tests/simulation/framework/test_base_model_v2.py
@@ -22,17 +22,17 @@ class BaseModelTestModel(Flow360BaseModel):
 
     model_config = pd.ConfigDict(include_hash=True)
 
-    def preprocess(self, params, **kwargs):
+    def preprocess(self, **kwargs):
         self.some_value *= 2
-        return super().preprocess(self, **kwargs)
+        return super().preprocess(**kwargs)
 
 
 class TempParams(Flow360BaseModel):
     some_value: pd.StrictFloat
     pseudo_field: BaseModelTestModel
 
-    def preprocess(self, params, **kwargs):
-        return super().preprocess(self, mesh_unit=1 * u.cm, **kwargs)
+    def preprocess(self, **kwargs):
+        return super().preprocess(mesh_unit=1 * u.cm, **kwargs)
 
 
 class BaseModelWithConflictFields(Flow360BaseModel):
@@ -43,7 +43,7 @@ class BaseModelWithConflictFields(Flow360BaseModel):
         conflicting_fields=[Conflicts(field1="some_value1", field2="some_value2")]
     )
 
-    def preprocess(self, params, **kwargs):
+    def preprocess(self, **kwargs):
         self.some_value1 *= 2
         return super().preprocess(self, **kwargs)
 
@@ -202,6 +202,6 @@ def test_from_json_yaml():
 def test_preprocess():
     value = 123
     test_params = TempParams(pseudo_field=BaseModelTestModel(some_value=value), some_value=value)
-    test_params = test_params.preprocess(test_params)
+    test_params = test_params.preprocess(params=test_params)
     assert test_params.some_value == value
     assert test_params.pseudo_field.some_value == value * 2

--- a/tests/simulation/service/test_translator_service.py
+++ b/tests/simulation/service/test_translator_service.py
@@ -46,8 +46,20 @@ def test_simulation_to_surface_meshing_json():
                 {
                     "entities": {
                         "stored_entities": [
-                            {"name": "wingLeadingEdge"},
-                            {"name": "wingTrailingEdge"},
+                            {
+                                "private_attribute_registry_bucket_name": "EdgeEntityType",
+                                "private_attribute_entity_type_name": "Edge",
+                                "name": "wingLeadingEdge",
+                                "private_attribute_tag_key": "edgeId",
+                                "private_attribute_sub_components": ["body0001_edge0001"],
+                            },
+                            {
+                                "private_attribute_registry_bucket_name": "EdgeEntityType",
+                                "private_attribute_entity_type_name": "Edge",
+                                "name": "wingTrailingEdge",
+                                "private_attribute_tag_key": "edgeId",
+                                "private_attribute_sub_components": ["body0001_edge0002"],
+                            },
                         ]
                     },
                     "method": {"type": "height", "value": {"units": "cm", "value": 0.03}},
@@ -55,7 +67,22 @@ def test_simulation_to_surface_meshing_json():
                 },
                 {
                     "entities": {
-                        "stored_entities": [{"name": "rootAirfoilEdge"}, {"name": "tipAirfoilEdge"}]
+                        "stored_entities": [
+                            {
+                                "private_attribute_registry_bucket_name": "EdgeEntityType",
+                                "private_attribute_entity_type_name": "Edge",
+                                "name": "rootAirfoilEdge",
+                                "private_attribute_tag_key": "edgeId",
+                                "private_attribute_sub_components": ["body0001_edge0003"],
+                            },
+                            {
+                                "private_attribute_registry_bucket_name": "EdgeEntityType",
+                                "private_attribute_entity_type_name": "Edge",
+                                "name": "tipAirfoilEdge",
+                                "private_attribute_tag_key": "edgeId",
+                                "private_attribute_sub_components": ["body0001_edge0004"],
+                            },
+                        ]
                     },
                     "method": {"type": "projectAnisoSpacing"},
                     "refinement_type": "SurfaceEdgeRefinement",
@@ -118,6 +145,7 @@ def test_simulation_to_volume_meshing_json():
                                 "center": {"units": "m", "value": [0.7, -1.0, 0.0]},
                                 "height": {"units": "m", "value": 2.0},
                                 "name": "cylinder_1",
+                                "private_attribute_entity_type_name": "Cylinder",
                                 "outer_radius": {"units": "m", "value": 1.1},
                             }
                         ]
@@ -133,6 +161,7 @@ def test_simulation_to_volume_meshing_json():
                                 "center": {"units": "m", "value": [0.7, -1.0, 0.0]},
                                 "height": {"units": "m", "value": 2.0},
                                 "name": "cylinder_2",
+                                "private_attribute_entity_type_name": "Cylinder",
                                 "outer_radius": {"units": "m", "value": 2.2},
                             }
                         ]
@@ -148,6 +177,7 @@ def test_simulation_to_volume_meshing_json():
                                 "center": {"units": "m", "value": [0.7, -1.0, 0.0]},
                                 "height": {"units": "m", "value": 2.0},
                                 "name": "cylinder_3",
+                                "private_attribute_entity_type_name": "Cylinder",
                                 "outer_radius": {"units": "m", "value": 3.3},
                             }
                         ]
@@ -163,6 +193,7 @@ def test_simulation_to_volume_meshing_json():
                                 "center": {"units": "m", "value": [0.7, -1.0, 0.0]},
                                 "height": {"units": "m", "value": 2.0},
                                 "name": "cylinder_4",
+                                "private_attribute_entity_type_name": "Cylinder",
                                 "outer_radius": {"units": "m", "value": 4.5},
                             }
                         ]
@@ -178,6 +209,7 @@ def test_simulation_to_volume_meshing_json():
                                 "center": {"units": "m", "value": [2.0, -1.0, 0.0]},
                                 "height": {"units": "m", "value": 14.5},
                                 "name": "outter_cylinder",
+                                "private_attribute_entity_type_name": "Cylinder",
                                 "outer_radius": {"units": "m", "value": 6.5},
                             }
                         ]
@@ -267,14 +299,41 @@ def test_simulation_to_case_json():
                 },
             },
             {
-                "entities": {"stored_entities": [{"name": "1"}]},
+                "entities": {
+                    "stored_entities": [
+                        {
+                            "private_attribute_registry_bucket_name": "SurfaceEntityType",
+                            "private_attribute_entity_type_name": "Surface",
+                            "name": "1",
+                        },
+                    ]
+                },
                 "type": "Wall",
                 "use_wall_function": False,
                 "velocity": {"value": [0, 1, 2], "units": "m/s"},
             },
-            {"entities": {"stored_entities": [{"name": "2"}]}, "type": "SlipWall"},
             {
-                "entities": {"stored_entities": [{"name": "3"}]},
+                "entities": {
+                    "stored_entities": [
+                        {
+                            "private_attribute_registry_bucket_name": "SurfaceEntityType",
+                            "private_attribute_entity_type_name": "Surface",
+                            "name": "2",
+                        },
+                    ]
+                },
+                "type": "SlipWall",
+            },
+            {
+                "entities": {
+                    "stored_entities": [
+                        {
+                            "private_attribute_registry_bucket_name": "SurfaceEntityType",
+                            "private_attribute_entity_type_name": "Surface",
+                            "name": "3",
+                        },
+                    ]
+                },
                 "type": "Freestream",
             },
         ],
@@ -312,6 +371,7 @@ def test_simulation_to_case_json():
                     "stored_entities": [
                         {
                             "name": "sliceName_1",
+                            "private_attribute_entity_type_name": "Slice",
                             "normal": [0.0, 1.0, 0.0],
                             "origin": {"units": "m", "value": [0.0, 0.56413, 0.0]},
                         }
@@ -335,7 +395,25 @@ def test_simulation_to_case_json():
                 "output_type": "SliceOutput",
             },
             {
-                "entities": {"stored_entities": [{"name": "1"}, {"name": "2"}, {"name": "3"}]},
+                "entities": {
+                    "stored_entities": [
+                        {
+                            "private_attribute_registry_bucket_name": "SurfaceEntityType",
+                            "private_attribute_entity_type_name": "Surface",
+                            "name": "1",
+                        },
+                        {
+                            "private_attribute_registry_bucket_name": "SurfaceEntityType",
+                            "private_attribute_entity_type_name": "Surface",
+                            "name": "2",
+                        },
+                        {
+                            "private_attribute_registry_bucket_name": "SurfaceEntityType",
+                            "private_attribute_entity_type_name": "Surface",
+                            "name": "3",
+                        },
+                    ]
+                },
                 "frequency": -1,
                 "frequency_offset": 0,
                 "output_fields": {"items": ["nuHat"]},
@@ -443,8 +521,8 @@ def test_simulation_to_case_json():
         },
     }
 
-    params, _, _ = validate_model(params_as_dict=param_data, root_item_type="Geometry")
-
+    params, err, _ = validate_model(params_as_dict=param_data, root_item_type="Geometry")
+    print("errors: ", err)
     simulation_to_case_json(params, {"value": 100.0, "units": "cm"})
 
     with pytest.raises(ValueError, match="Mesh unit is required for translation."):


### PR DESCRIPTION
- [x] fix(): Disallowed string as `EntityList` input (deprecated design) and therefore removed supplied entity registry.
- [x] feat(): Added discriminator for ALL `EntityList`. This avoids errors emitting from all candidate models when we should be validating against just one of them. See example screenshot below.

For:
![image](https://github.com/user-attachments/assets/ab5ad090-349f-42a5-a272-4d5e08e4134e)

![image](https://github.com/user-attachments/assets/0e0f83cd-e577-4091-b447-8f626069e1e9)
