### PR TITLE
Removed meshing default value and added multi-context ConditionalField

### DIFF
--- a/examples/tutorials/quick_start.py
+++ b/examples/tutorials/quick_start.py
@@ -1,67 +1,50 @@
 # Import necessary modules from the Flow360 library
 import flow360 as fl
 from flow360 import SI_unit_system, u
-from flow360.examples import Airplane
 
-# Activate the pre-production environment because of beta testing status
-fl.Env.preprod.active()
+# project = fl.Project.from_file("volumeMesh.cgns", name="VM")
+# vm = project.volume_mesh
 
-# Step 1: Create a new project from a predefined geometry file in the Airplane example
-# This initializes a project with the specified geometry and assigns it a name.
-project = fl.Project.from_file(Airplane.geometry, name="Python Project (Geometry, from file)")
-geo = project.geometry  # Access the geometry of the project
+# # Step 4: Define simulation parameters within a specific unit system
+# with SI_unit_system:
+#     # Define an automated far-field boundary condition for the simulation
+#     far_field_zone = fl.AutomatedFarfield()
 
-# Step 2: Display available groupings in the geometry (helpful for identifying group names)
-geo.show_available_groupings(verbose_mode=True)
+#     # Set up the main simulation parameters
+#     params = fl.SimulationParams(
+#         # Reference geometry parameters for the simulation (e.g., center of pressure)
+#         reference_geometry=fl.ReferenceGeometry(),
+#         # Operating conditions: setting speed and angle of attack for the simulation
+#         operating_condition=fl.AerospaceCondition(
+#             velocity_magnitude=100,  # Velocity of 100 m/s
+#             alpha=5 * u.deg,  # Angle of attack of 5 degrees
+#         ),
+#         # Time-stepping configuration: specifying steady-state with a maximum step limit
+#         time_stepping=fl.Steady(max_steps=1000),
+#         # Define models for the simulation, such as walls and freestream conditions
+#         models=[
+#             fl.Wall(
+#                 surfaces=[vm["*"]],  # Apply wall boundary conditions to all surfaces in geometry
+#                 name="Wall",
+#             ),
+#             fl.Freestream(
+#                 surfaces=[
+#                     far_field_zone.farfield
+#                 ],  # Apply freestream boundary to the far-field zone
+#                 name="Freestream",
+#             ),
+#         ],
+#         # Define output parameters for the simulation
+#         outputs=[
+#             fl.SurfaceOutput(
+#                 surfaces=vm["*"],  # Select all surfaces for output
+#                 output_fields=["Cp", "Cf", "yPlus", "CfVec"],  # Output fields for post-processing
+#             )
+#         ],
+#     )
 
-# Step 3: Group faces by a specific tag for easier reference in defining `Surface` objects
-geo.group_faces_by_tag("groupName")
+# # Step 5: Run the simulation case with the specified parameters
+# project.run_case(params=params, name="1")
 
-# Step 4: Define simulation parameters within a specific unit system
-with SI_unit_system:
-    # Define an automated far-field boundary condition for the simulation
-    far_field_zone = fl.AutomatedFarfield()
 
-    # Set up the main simulation parameters
-    params = fl.SimulationParams(
-        # Meshing parameters, including boundary layer and maximum edge length
-        meshing=fl.MeshingParams(
-            defaults=fl.MeshingDefaults(
-                boundary_layer_first_layer_thickness=0.001,  # Boundary layer thickness
-                surface_max_edge_length=1,  # Maximum edge length on surfaces
-            ),
-            volume_zones=[far_field_zone],  # Apply the automated far-field boundary condition
-        ),
-        # Reference geometry parameters for the simulation (e.g., center of pressure)
-        reference_geometry=fl.ReferenceGeometry(),
-        # Operating conditions: setting speed and angle of attack for the simulation
-        operating_condition=fl.AerospaceCondition(
-            velocity_magnitude=100,  # Velocity of 100 m/s
-            alpha=5 * u.deg,  # Angle of attack of 5 degrees
-        ),
-        # Time-stepping configuration: specifying steady-state with a maximum step limit
-        time_stepping=fl.Steady(max_steps=1000),
-        # Define models for the simulation, such as walls and freestream conditions
-        models=[
-            fl.Wall(
-                surfaces=[geo["*"]],  # Apply wall boundary conditions to all surfaces in geometry
-                name="Wall",
-            ),
-            fl.Freestream(
-                surfaces=[
-                    far_field_zone.farfield
-                ],  # Apply freestream boundary to the far-field zone
-                name="Freestream",
-            ),
-        ],
-        # Define output parameters for the simulation
-        outputs=[
-            fl.SurfaceOutput(
-                surfaces=geo["*"],  # Select all surfaces for output
-                output_fields=["Cp", "Cf", "yPlus", "CfVec"],  # Output fields for post-processing
-            )
-        ],
-    )
-
-# Step 5: Run the simulation case with the specified parameters
-project.run_case(params=params, name="Case of Simple Airplane from Python")
+case_params = fl.Case.from_cloud("case-b889f655-155c-4df8-bc9c-54de4dff2a63").params

--- a/examples/tutorials/quick_start.py
+++ b/examples/tutorials/quick_start.py
@@ -2,49 +2,49 @@
 import flow360 as fl
 from flow360 import SI_unit_system, u
 
-# project = fl.Project.from_file("volumeMesh.cgns", name="VM")
-# vm = project.volume_mesh
+project = fl.Project.from_file("volumeMesh.cgns", name="VM")
+vm = project.volume_mesh
 
-# # Step 4: Define simulation parameters within a specific unit system
-# with SI_unit_system:
-#     # Define an automated far-field boundary condition for the simulation
-#     far_field_zone = fl.AutomatedFarfield()
+# Step 4: Define simulation parameters within a specific unit system
+with SI_unit_system:
+    # Define an automated far-field boundary condition for the simulation
+    far_field_zone = fl.AutomatedFarfield()
 
-#     # Set up the main simulation parameters
-#     params = fl.SimulationParams(
-#         # Reference geometry parameters for the simulation (e.g., center of pressure)
-#         reference_geometry=fl.ReferenceGeometry(),
-#         # Operating conditions: setting speed and angle of attack for the simulation
-#         operating_condition=fl.AerospaceCondition(
-#             velocity_magnitude=100,  # Velocity of 100 m/s
-#             alpha=5 * u.deg,  # Angle of attack of 5 degrees
-#         ),
-#         # Time-stepping configuration: specifying steady-state with a maximum step limit
-#         time_stepping=fl.Steady(max_steps=1000),
-#         # Define models for the simulation, such as walls and freestream conditions
-#         models=[
-#             fl.Wall(
-#                 surfaces=[vm["*"]],  # Apply wall boundary conditions to all surfaces in geometry
-#                 name="Wall",
-#             ),
-#             fl.Freestream(
-#                 surfaces=[
-#                     far_field_zone.farfield
-#                 ],  # Apply freestream boundary to the far-field zone
-#                 name="Freestream",
-#             ),
-#         ],
-#         # Define output parameters for the simulation
-#         outputs=[
-#             fl.SurfaceOutput(
-#                 surfaces=vm["*"],  # Select all surfaces for output
-#                 output_fields=["Cp", "Cf", "yPlus", "CfVec"],  # Output fields for post-processing
-#             )
-#         ],
-#     )
+    # Set up the main simulation parameters
+    params = fl.SimulationParams(
+        # Reference geometry parameters for the simulation (e.g., center of pressure)
+        reference_geometry=fl.ReferenceGeometry(),
+        # Operating conditions: setting speed and angle of attack for the simulation
+        operating_condition=fl.AerospaceCondition(
+            velocity_magnitude=100,  # Velocity of 100 m/s
+            alpha=5 * u.deg,  # Angle of attack of 5 degrees
+        ),
+        # Time-stepping configuration: specifying steady-state with a maximum step limit
+        time_stepping=fl.Steady(max_steps=1000),
+        # Define models for the simulation, such as walls and freestream conditions
+        models=[
+            fl.Wall(
+                surfaces=[vm["*"]],  # Apply wall boundary conditions to all surfaces in geometry
+                name="Wall",
+            ),
+            fl.Freestream(
+                surfaces=[
+                    far_field_zone.farfield
+                ],  # Apply freestream boundary to the far-field zone
+                name="Freestream",
+            ),
+        ],
+        # Define output parameters for the simulation
+        outputs=[
+            fl.SurfaceOutput(
+                surfaces=vm["*"],  # Select all surfaces for output
+                output_fields=["Cp", "Cf", "yPlus", "CfVec"],  # Output fields for post-processing
+            )
+        ],
+    )
 
-# # Step 5: Run the simulation case with the specified parameters
-# project.run_case(params=params, name="1")
+# Step 5: Run the simulation case with the specified parameters
+project.run_case(params=params, name="1")
 
 
-case_params = fl.Case.from_cloud("case-b889f655-155c-4df8-bc9c-54de4dff2a63").params
+# case_params = fl.Case.from_cloud("case-b889f655-155c-4df8-bc9c-54de4dff2a63").params

--- a/examples/tutorials/quick_start.py
+++ b/examples/tutorials/quick_start.py
@@ -1,9 +1,21 @@
 # Import necessary modules from the Flow360 library
 import flow360 as fl
 from flow360 import SI_unit_system, u
+from flow360.examples import Airplane
 
-project = fl.Project.from_file("volumeMesh.cgns", name="VM")
-vm = project.volume_mesh
+# Activate the pre-production environment because of beta testing status
+fl.Env.preprod.active()
+
+# Step 1: Create a new project from a predefined geometry file in the Airplane example
+# This initializes a project with the specified geometry and assigns it a name.
+project = fl.Project.from_file(Airplane.geometry, name="Python Project (Geometry, from file)")
+geo = project.geometry  # Access the geometry of the project
+
+# Step 2: Display available groupings in the geometry (helpful for identifying group names)
+geo.show_available_groupings(verbose_mode=True)
+
+# Step 3: Group faces by a specific tag for easier reference in defining `Surface` objects
+geo.group_faces_by_tag("groupName")
 
 # Step 4: Define simulation parameters within a specific unit system
 with SI_unit_system:
@@ -12,6 +24,14 @@ with SI_unit_system:
 
     # Set up the main simulation parameters
     params = fl.SimulationParams(
+        # Meshing parameters, including boundary layer and maximum edge length
+        meshing=fl.MeshingParams(
+            defaults=fl.MeshingDefaults(
+                boundary_layer_first_layer_thickness=0.001,  # Boundary layer thickness
+                surface_max_edge_length=1,  # Maximum edge length on surfaces
+            ),
+            volume_zones=[far_field_zone],  # Apply the automated far-field boundary condition
+        ),
         # Reference geometry parameters for the simulation (e.g., center of pressure)
         reference_geometry=fl.ReferenceGeometry(),
         # Operating conditions: setting speed and angle of attack for the simulation
@@ -24,7 +44,7 @@ with SI_unit_system:
         # Define models for the simulation, such as walls and freestream conditions
         models=[
             fl.Wall(
-                surfaces=[vm["*"]],  # Apply wall boundary conditions to all surfaces in geometry
+                surfaces=[geo["*"]],  # Apply wall boundary conditions to all surfaces in geometry
                 name="Wall",
             ),
             fl.Freestream(
@@ -37,14 +57,11 @@ with SI_unit_system:
         # Define output parameters for the simulation
         outputs=[
             fl.SurfaceOutput(
-                surfaces=vm["*"],  # Select all surfaces for output
+                surfaces=geo["*"],  # Select all surfaces for output
                 output_fields=["Cp", "Cf", "yPlus", "CfVec"],  # Output fields for post-processing
             )
         ],
     )
 
 # Step 5: Run the simulation case with the specified parameters
-project.run_case(params=params, name="1")
-
-
-# case_params = fl.Case.from_cloud("case-b889f655-155c-4df8-bc9c-54de4dff2a63").params
+project.run_case(params=params, name="Case of Simple Airplane from Python")

--- a/flow360/component/case.py
+++ b/flow360/component/case.py
@@ -431,7 +431,7 @@ class Case(CaseBase, Flow360Resource):
                 params_as_dict: dict = json.load(fh)
 
             param, errors, _ = services.validate_model(
-                params_as_dict=params_as_dict, root_item_type=None
+                params_as_dict=params_as_dict, root_item_type=None, validation_level=None
             )
 
             if errors is not None:

--- a/flow360/component/simulation/services.py
+++ b/flow360/component/simulation/services.py
@@ -380,9 +380,11 @@ def _populate_error_context(error: dict):
     """
     ctx = error.get("ctx")
     if isinstance(ctx, dict):
-        for field_name, field in ctx.items():
+        for field_name, context in ctx.items():
             try:
-                error["ctx"][field_name] = str(field)
+                error["ctx"][field_name] = (
+                    [str(item) for item in context] if isinstance(context, list) else str(context)
+                )
             except Exception:  # pylint: disable=broad-exception-caught
                 error["ctx"][field_name] = "<couldn't stringify>"
     else:

--- a/flow360/component/simulation/simulation_params.py
+++ b/flow360/component/simulation/simulation_params.py
@@ -80,8 +80,9 @@ from flow360.version import __version__
 from .validation.validation_context import (
     CASE,
     SURFACE_MESH,
+    VOLUME_MESH,
     CaseField,
-    ContextField,
+    ConditionalField,
     context_validator,
 )
 
@@ -173,11 +174,12 @@ class _ParamModelBase(Flow360BaseModel):
 class SimulationParams(_ParamModelBase):
     """All-in-one class for surface meshing + volume meshing + case configurations"""
 
-    meshing: Optional[MeshingParams] = ContextField(
-        MeshingParams(),
-        context=SURFACE_MESH,
-        description="Meshing parameters. See :class:`MeshingParams` for more details.",
+    meshing: Optional[MeshingParams] = ConditionalField(
+        None,
+        context=[SURFACE_MESH, VOLUME_MESH],
+        description="Surface and volume meshing parameters. See :class:`MeshingParams` for more details.",
     )
+
     reference_geometry: Optional[ReferenceGeometry] = CaseField(
         None,
         description="Global geometric reference values. See :class:`ReferenceGeometry` for more details.",

--- a/flow360/component/simulation/validation/validation_context.py
+++ b/flow360/component/simulation/validation/validation_context.py
@@ -103,7 +103,14 @@ def ContextField(
 
 # pylint: disable=invalid-name
 def ConditionalField(
-    default=None, *, context: Literal["SurfaceMesh", "VolumeMesh", "Case"] = None, **kwargs
+    default=None,
+    *,
+    context: Union[
+        None,
+        Literal["SurfaceMesh", "VolumeMesh", "Case"],
+        List[Literal["SurfaceMesh", "VolumeMesh", "Case"]],
+    ] = None,
+    **kwargs,
 ):
     """
     Creates a field with conditional context validation requirements.
@@ -112,8 +119,12 @@ def ConditionalField(
     ----------
     default : any, optional
         The default value for the field.
-    context : str, optional
-        Specifies the scenario for which this field is relevant. The relevant_for=context is included in error->ctx
+    context : Union[
+        None, Literal['SurfaceMesh', 'VolumeMesh', 'Case'],
+        List[Literal['SurfaceMesh', 'VolumeMesh', 'Case']]
+    ], optional
+        Specifies the context(s) in which this field is relevant. This value is
+        included in the validation error context (`ctx`) as `relevant_for`.
     **kwargs : dict
         Additional keyword arguments passed to Pydantic's Field.
 

--- a/flow360/component/volume_mesh.py
+++ b/flow360/component/volume_mesh.py
@@ -932,6 +932,8 @@ class VolumeMeshDraftV2(ResourceDraft):
         req_dict = req.dict()
         resp = RestApi(VolumeMeshInterfaceV2.endpoint).post(req_dict)
         info = VolumeMeshMetaV2(**resp)
+        # setting _id will disable "WARNING: You have not submitted..." warning message
+        self._id = info.id
         renamed_file_on_remote = info.file_name
 
         volume_mesh = VolumeMeshV2(info.id)

--- a/tests/simulation/framework/test_context_validators.py
+++ b/tests/simulation/framework/test_context_validators.py
@@ -70,8 +70,8 @@ def _test_with_given_context_and_data(context, data: dict, expected_errors):
 def test_no_context_validate():
     excpected_errors = [
         {"loc": ("m", "a"), "type": "missing"},
-        {"loc": ("d",), "type": "model_type", "ctx": {"relevant_for": "Case"}},
-        {"loc": ("e",), "type": "model_attributes_type", "ctx": {"relevant_for": "Case"}},
+        {"loc": ("d",), "type": "model_type", "ctx": {"relevant_for": ["Case"]}},
+        {"loc": ("e",), "type": "model_attributes_type", "ctx": {"relevant_for": ["Case"]}},
     ]
     _test_with_given_context_and_data(None, test_data1, excpected_errors)
 
@@ -79,9 +79,9 @@ def test_no_context_validate():
 def test_with_sm_context_validate():
     excpected_errors = [
         {"loc": ("m", "a"), "type": "missing"},
-        {"loc": ("m", "b"), "type": "missing", "ctx": {"relevant_for": "SurfaceMesh"}},
-        {"loc": ("d",), "type": "model_type", "ctx": {"relevant_for": "Case"}},
-        {"loc": ("e",), "type": "model_attributes_type", "ctx": {"relevant_for": "Case"}},
+        {"loc": ("m", "b"), "type": "missing", "ctx": {"relevant_for": ["SurfaceMesh"]}},
+        {"loc": ("d",), "type": "model_type", "ctx": {"relevant_for": ["Case"]}},
+        {"loc": ("e",), "type": "model_attributes_type", "ctx": {"relevant_for": ["Case"]}},
     ]
 
     _test_with_given_context_and_data(validation_context.SURFACE_MESH, test_data1, excpected_errors)
@@ -90,9 +90,9 @@ def test_with_sm_context_validate():
 def test_with_vm_context_validate():
     excpected_errors = [
         {"loc": ("m", "a"), "type": "missing"},
-        {"loc": ("m", "c"), "type": "missing", "ctx": {"relevant_for": "VolumeMesh"}},
-        {"loc": ("d",), "type": "model_type", "ctx": {"relevant_for": "Case"}},
-        {"loc": ("e",), "type": "model_attributes_type", "ctx": {"relevant_for": "Case"}},
+        {"loc": ("m", "c"), "type": "missing", "ctx": {"relevant_for": ["VolumeMesh"]}},
+        {"loc": ("d",), "type": "model_type", "ctx": {"relevant_for": ["Case"]}},
+        {"loc": ("e",), "type": "model_attributes_type", "ctx": {"relevant_for": ["Case"]}},
     ]
 
     _test_with_given_context_and_data(validation_context.VOLUME_MESH, test_data1, excpected_errors)
@@ -101,10 +101,10 @@ def test_with_vm_context_validate():
 def test_with_case_context_validate():
     excpected_errors = [
         {"loc": ("m", "a"), "type": "missing"},
-        {"loc": ("m", "d"), "type": "missing", "ctx": {"relevant_for": "Case"}},
-        {"loc": ("c",), "type": "missing", "ctx": {"relevant_for": "Case"}},
-        {"loc": ("d",), "type": "model_type", "ctx": {"relevant_for": "Case"}},
-        {"loc": ("e",), "type": "model_attributes_type", "ctx": {"relevant_for": "Case"}},
+        {"loc": ("m", "d"), "type": "missing", "ctx": {"relevant_for": ["Case"]}},
+        {"loc": ("c",), "type": "missing", "ctx": {"relevant_for": ["Case"]}},
+        {"loc": ("d",), "type": "model_type", "ctx": {"relevant_for": ["Case"]}},
+        {"loc": ("e",), "type": "model_attributes_type", "ctx": {"relevant_for": ["Case"]}},
     ]
 
     _test_with_given_context_and_data(validation_context.CASE, test_data1, excpected_errors)
@@ -113,12 +113,12 @@ def test_with_case_context_validate():
 def test_with_all_context_validate():
     excpected_errors = [
         {"loc": ("m", "a"), "type": "missing"},
-        {"loc": ("m", "b"), "type": "missing", "ctx": {"relevant_for": "SurfaceMesh"}},
-        {"loc": ("m", "c"), "type": "missing", "ctx": {"relevant_for": "VolumeMesh"}},
-        {"loc": ("m", "d"), "type": "missing", "ctx": {"relevant_for": "Case"}},
-        {"loc": ("c",), "type": "missing", "ctx": {"relevant_for": "Case"}},
-        {"loc": ("d",), "type": "model_type", "ctx": {"relevant_for": "Case"}},
-        {"loc": ("e",), "type": "model_attributes_type", "ctx": {"relevant_for": "Case"}},
+        {"loc": ("m", "b"), "type": "missing", "ctx": {"relevant_for": ["SurfaceMesh"]}},
+        {"loc": ("m", "c"), "type": "missing", "ctx": {"relevant_for": ["VolumeMesh"]}},
+        {"loc": ("m", "d"), "type": "missing", "ctx": {"relevant_for": ["Case"]}},
+        {"loc": ("c",), "type": "missing", "ctx": {"relevant_for": ["Case"]}},
+        {"loc": ("d",), "type": "model_type", "ctx": {"relevant_for": ["Case"]}},
+        {"loc": ("e",), "type": "model_attributes_type", "ctx": {"relevant_for": ["Case"]}},
     ]
 
     _test_with_given_context_and_data(validation_context.ALL, test_data1, excpected_errors)
@@ -127,10 +127,10 @@ def test_with_all_context_validate():
 def test_with_sm_and_vm_context_validate():
     excpected_errors = [
         {"loc": ("m", "a"), "type": "missing"},
-        {"loc": ("m", "b"), "type": "missing", "ctx": {"relevant_for": "SurfaceMesh"}},
-        {"loc": ("m", "c"), "type": "missing", "ctx": {"relevant_for": "VolumeMesh"}},
-        {"loc": ("d",), "type": "model_type", "ctx": {"relevant_for": "Case"}},
-        {"loc": ("e",), "type": "model_attributes_type", "ctx": {"relevant_for": "Case"}},
+        {"loc": ("m", "b"), "type": "missing", "ctx": {"relevant_for": ["SurfaceMesh"]}},
+        {"loc": ("m", "c"), "type": "missing", "ctx": {"relevant_for": ["VolumeMesh"]}},
+        {"loc": ("d",), "type": "model_type", "ctx": {"relevant_for": ["Case"]}},
+        {"loc": ("e",), "type": "model_attributes_type", "ctx": {"relevant_for": ["Case"]}},
     ]
 
     try:
@@ -151,12 +151,12 @@ def test_with_sm_and_vm_context_validate():
 def test_with_sm_and_vm_and_case_context_validate():
     excpected_errors = [
         {"loc": ("m", "a"), "type": "missing"},
-        {"loc": ("m", "b"), "type": "missing", "ctx": {"relevant_for": "SurfaceMesh"}},
-        {"loc": ("m", "c"), "type": "missing", "ctx": {"relevant_for": "VolumeMesh"}},
-        {"loc": ("m", "d"), "type": "missing", "ctx": {"relevant_for": "Case"}},
-        {"loc": ("c",), "type": "missing", "ctx": {"relevant_for": "Case"}},
-        {"loc": ("d",), "type": "model_type", "ctx": {"relevant_for": "Case"}},
-        {"loc": ("e",), "type": "model_attributes_type", "ctx": {"relevant_for": "Case"}},
+        {"loc": ("m", "b"), "type": "missing", "ctx": {"relevant_for": ["SurfaceMesh"]}},
+        {"loc": ("m", "c"), "type": "missing", "ctx": {"relevant_for": ["VolumeMesh"]}},
+        {"loc": ("m", "d"), "type": "missing", "ctx": {"relevant_for": ["Case"]}},
+        {"loc": ("c",), "type": "missing", "ctx": {"relevant_for": ["Case"]}},
+        {"loc": ("d",), "type": "model_type", "ctx": {"relevant_for": ["Case"]}},
+        {"loc": ("e",), "type": "model_attributes_type", "ctx": {"relevant_for": ["Case"]}},
     ]
 
     try:
@@ -196,7 +196,7 @@ def test_correct_context_validate():
 
 def test_without_context_validate_not_required():
     excpected_errors = [
-        {"loc": ("e",), "type": "float_parsing", "ctx": {"relevant_for": "Case"}},
+        {"loc": ("e",), "type": "float_parsing", "ctx": {"relevant_for": ["Case"]}},
     ]
 
     try:
@@ -213,8 +213,8 @@ def test_without_context_validate_not_required():
 
 def test_without_context_validate_not_required_2():
     excpected_errors = [
-        {"loc": ("d", "a"), "type": "string_type", "ctx": {"relevant_for": "Case"}},
-        {"loc": ("d", "c"), "type": "string_type", "ctx": {"relevant_for": "VolumeMesh"}},
+        {"loc": ("d", "a"), "type": "string_type", "ctx": {"relevant_for": ["Case"]}},
+        {"loc": ("d", "c"), "type": "string_type", "ctx": {"relevant_for": ["VolumeMesh"]}},
     ]
     _test_with_given_context_and_data(None, test_data3, excpected_errors)
 
@@ -226,7 +226,7 @@ def test_with_context_validate_required():
 
     # Become invalid when validating against VOLUME_MESH
     excpected_errors = [
-        {"loc": ("c",), "type": "missing", "ctx": {"relevant_for": "VolumeMesh"}},
+        {"loc": ("c",), "type": "missing", "ctx": {"relevant_for": ["VolumeMesh"]}},
     ]
     try:
         with validation_context.ValidationLevelContext(validation_context.VOLUME_MESH):

--- a/tests/simulation/params/test_validators_params.py
+++ b/tests/simulation/params/test_validators_params.py
@@ -648,3 +648,17 @@ def test_rotation_parent_volumes():
                     project_entity_info=VolumeMeshEntityInfo(boundaries=[my_wall]),
                 ),
             )
+
+
+def test_meshing_validator_dual_context():
+    errors = None
+    try:
+        with SI_unit_system:
+            with ValidationLevelContext(VOLUME_MESH):
+                SimulationParams(meshing=None)
+    except pd.ValidationError as err:
+        errors = err.errors()
+    assert len(errors) == 1
+    assert errors[0]["type"] == "missing"
+    assert errors[0]["ctx"] == {"relevant_for": ["SurfaceMesh", "VolumeMesh"]}
+    assert errors[0]["loc"] == ("meshing",)

--- a/tests/simulation/params/test_validators_params.py
+++ b/tests/simulation/params/test_validators_params.py
@@ -9,6 +9,10 @@ import pytest
 import flow360.component.simulation.units as u
 from flow360.component.simulation.entity_info import VolumeMeshEntityInfo
 from flow360.component.simulation.framework.param_utils import AssetCache
+from flow360.component.simulation.meshing_param.params import (
+    MeshingDefaults,
+    MeshingParams,
+)
 from flow360.component.simulation.meshing_param.volume_params import AutomatedFarfield
 from flow360.component.simulation.models.material import SolidMaterial, aluminum
 from flow360.component.simulation.models.solver_numerics import TransitionModelSolver
@@ -419,6 +423,12 @@ def test_incomplete_BC():
         with ValidationLevelContext(ALL):
             with SI_unit_system:
                 SimulationParams(
+                    meshing=MeshingParams(
+                        defaults=MeshingDefaults(
+                            boundary_layer_first_layer_thickness=1e-10,
+                            surface_max_edge_length=1e-10,
+                        )
+                    ),
                     models=[
                         Fluid(),
                         Wall(entities=wall_1),
@@ -437,6 +447,12 @@ def test_incomplete_BC():
         with ValidationLevelContext(ALL):
             with SI_unit_system:
                 SimulationParams(
+                    meshing=MeshingParams(
+                        defaults=MeshingDefaults(
+                            boundary_layer_first_layer_thickness=1e-10,
+                            surface_max_edge_length=1e-10,
+                        )
+                    ),
                     models=[
                         Fluid(),
                         Wall(entities=[wall_1]),

--- a/tests/simulation/service/test_services_v2.py
+++ b/tests/simulation/service/test_services_v2.py
@@ -154,17 +154,17 @@ def test_validate_error():
         {
             "loc": ("meshing", "defaults", "boundary_layer_first_layer_thickness"),
             "type": "missing",
-            "ctx": {"relevant_for": "VolumeMesh"},
+            "ctx": {"relevant_for": ["VolumeMesh"]},
         },
         {
             "loc": ("meshing", "defaults", "surface_max_edge_length"),
             "type": "missing",
-            "ctx": {"relevant_for": "SurfaceMesh"},
+            "ctx": {"relevant_for": ["SurfaceMesh"]},
         },
         {
             "loc": ("meshing", "farfield"),
             "type": "extra_forbidden",
-            "ctx": {"relevant_for": "SurfaceMesh"},
+            "ctx": {"relevant_for": ["SurfaceMesh"]},
         },
     ]
     assert len(errors) == len(excpected_errors)
@@ -220,17 +220,17 @@ def test_validate_multiple_errors():
         {
             "loc": ("meshing", "defaults", "surface_max_edge_length"),
             "type": "value_error",
-            "ctx": {"relevant_for": "SurfaceMesh"},
+            "ctx": {"relevant_for": ["SurfaceMesh"]},
         },
         {
             "loc": ("meshing", "farfield"),
             "type": "extra_forbidden",
-            "ctx": {"relevant_for": "SurfaceMesh"},
+            "ctx": {"relevant_for": ["SurfaceMesh"]},
         },
         {
             "loc": ("reference_geometry", "area", "value"),
             "type": "greater_than",
-            "ctx": {"relevant_for": "Case"},
+            "ctx": {"relevant_for": ["Case"]},
         },
     ]
     assert len(errors) == len(excpected_errors)
@@ -315,17 +315,17 @@ def test_validate_init_data_errors():
         {
             "loc": ("meshing", "defaults", "boundary_layer_first_layer_thickness"),
             "type": "missing",
-            "ctx": {"relevant_for": "VolumeMesh"},
+            "ctx": {"relevant_for": ["VolumeMesh"]},
         },
         {
             "loc": ("meshing", "defaults", "surface_max_edge_length"),
             "type": "missing",
-            "ctx": {"relevant_for": "SurfaceMesh"},
+            "ctx": {"relevant_for": ["SurfaceMesh"]},
         },
         {
             "loc": ("operating_condition", "velocity_magnitude"),
             "type": "missing",
-            "ctx": {"relevant_for": "Case"},
+            "ctx": {"relevant_for": ["Case"]},
         },
     ]
 
@@ -351,12 +351,12 @@ def test_validate_init_data_for_sm_and_vm_errors():
         {
             "loc": ("meshing", "defaults", "boundary_layer_first_layer_thickness"),
             "type": "missing",
-            "ctx": {"relevant_for": "VolumeMesh"},
+            "ctx": {"relevant_for": ["VolumeMesh"]},
         },
         {
             "loc": ("meshing", "defaults", "surface_max_edge_length"),
             "type": "missing",
-            "ctx": {"relevant_for": "SurfaceMesh"},
+            "ctx": {"relevant_for": ["SurfaceMesh"]},
         },
     ]
 
@@ -378,7 +378,7 @@ def test_validate_init_data_vm_workflow_errors():
         {
             "loc": ("operating_condition", "velocity_magnitude"),
             "type": "missing",
-            "ctx": {"relevant_for": "Case"},
+            "ctx": {"relevant_for": ["Case"]},
         },
     ]
 
@@ -619,7 +619,7 @@ def test_generate_process_json():
     with pytest.raises(
         ValueError,
         match=re.escape(
-            "[Internal] Validation error occurred for supposedly validated param! Errors are: [{'type': 'missing', 'loc': ('meshing', 'surface_max_edge_length'), 'msg': 'Field required', 'input': None, 'ctx': {'relevant_for': 'SurfaceMesh'}, 'url': 'https://errors.pydantic.dev/2.7/v/missing'}]"
+            "[Internal] Validation error occurred for supposedly validated param! Errors are: [{'type': 'missing', 'loc': ('meshing', 'surface_max_edge_length'), 'msg': 'Field required', 'input': None, 'ctx': {'relevant_for': ['SurfaceMesh']}, 'url': 'https://errors.pydantic.dev/2.7/v/missing'}]"
         ),
     ):
         res1, res2, res3 = services.generate_process_json(
@@ -638,7 +638,7 @@ def test_generate_process_json():
     with pytest.raises(
         ValueError,
         match=re.escape(
-            "[Internal] Validation error occurred for supposedly validated param! Errors are: [{'type': 'missing', 'loc': ('meshing', 'defaults', 'boundary_layer_first_layer_thickness'), 'msg': 'Field required', 'input': None, 'ctx': {'relevant_for': 'VolumeMesh'}, 'url': 'https://errors.pydantic.dev/2.7/v/missing'}]"
+            "[Internal] Validation error occurred for supposedly validated param! Errors are: [{'type': 'missing', 'loc': ('meshing', 'defaults', 'boundary_layer_first_layer_thickness'), 'msg': 'Field required', 'input': None, 'ctx': {'relevant_for': ['VolumeMesh']}, 'url': 'https://errors.pydantic.dev/2.7/v/missing'}]"
         ),
     ):
         res1, res2, res3 = services.generate_process_json(
@@ -657,7 +657,7 @@ def test_generate_process_json():
     with pytest.raises(
         ValueError,
         match=re.escape(
-            "[Internal] Validation error occurred for supposedly validated param! Errors are: [{'type': 'missing', 'loc': ('operating_condition', 'velocity_magnitude'), 'msg': 'Field required', 'input': None, 'ctx': {'relevant_for': 'Case'}, 'url': 'https://errors.pydantic.dev/2.7/v/missing'}]"
+            "[Internal] Validation error occurred for supposedly validated param! Errors are: [{'type': 'missing', 'loc': ('operating_condition', 'velocity_magnitude'), 'msg': 'Field required', 'input': None, 'ctx': {'relevant_for': ['Case']}, 'url': 'https://errors.pydantic.dev/2.7/v/missing'}]"
         ),
     ):
         res1, res2, res3 = services.generate_process_json(

--- a/tests/simulation/service/test_services_v2.py
+++ b/tests/simulation/service/test_services_v2.py
@@ -4,13 +4,10 @@ import re
 import pytest
 
 from flow360.component.simulation import services
-from flow360.component.simulation.entity_info import VolumeMeshEntityInfo
-from flow360.component.simulation.framework.param_utils import AssetCache
-from flow360.component.simulation.primitives import Surface
 from flow360.component.simulation.validation.validation_context import (
+    CASE,
     SURFACE_MESH,
     VOLUME_MESH,
-    ValidationLevelContext,
 )
 from tests.utils import compare_dict_to_ref, compare_values
 
@@ -106,7 +103,7 @@ def test_validate_service():
     assert errors is None
 
     _, errors, _ = services.validate_model(
-        params_as_dict=params_data_from_vm, root_item_type="VolumeMesh"
+        params_as_dict=params_data_from_vm, root_item_type="VolumeMesh", validation_level=CASE
     )
 
     assert errors is None
@@ -164,7 +161,7 @@ def test_validate_error():
         {
             "loc": ("meshing", "farfield"),
             "type": "extra_forbidden",
-            "ctx": {"relevant_for": ["SurfaceMesh"]},
+            "ctx": {"relevant_for": ["SurfaceMesh", "VolumeMesh"]},
         },
     ]
     assert len(errors) == len(excpected_errors)
@@ -225,7 +222,7 @@ def test_validate_multiple_errors():
         {
             "loc": ("meshing", "farfield"),
             "type": "extra_forbidden",
-            "ctx": {"relevant_for": ["SurfaceMesh"]},
+            "ctx": {"relevant_for": ["SurfaceMesh", "VolumeMesh"]},
         },
         {
             "loc": ("reference_geometry", "area", "value"),
@@ -372,7 +369,9 @@ def test_validate_init_data_vm_workflow_errors():
     data = services.get_default_params(
         unit_system_name="SI", length_unit="m", root_item_type="VolumeMesh"
     )
-    _, errors, _ = services.validate_model(params_as_dict=data, root_item_type="VolumeMesh")
+    _, errors, _ = services.validate_model(
+        params_as_dict=data, root_item_type="VolumeMesh", validation_level=CASE
+    )
 
     excpected_errors = [
         {

--- a/tests/simulation/service/test_translator_service.py
+++ b/tests/simulation/service/test_translator_service.py
@@ -29,6 +29,7 @@ from flow360.component.simulation.services import (
 from flow360.component.simulation.simulation_params import SimulationParams
 from flow360.component.simulation.unit_system import SI_unit_system, u
 from flow360.component.simulation.validation.validation_context import (
+    CASE,
     SURFACE_MESH,
     VOLUME_MESH,
 )
@@ -479,6 +480,29 @@ def test_simulation_to_case_json():
         ],
         "unit_system": {"name": "SI"},
         "version": "24.2.0",
+        "meshing": {
+            "refinement_factor": 1,
+            "defaults": {
+                "surface_edge_growth_rate": 1.2,
+                "boundary_layer_first_layer_thickness": {"value": 0.001, "units": "m"},
+                "boundary_layer_growth_rate": 1.2,
+                "curvature_resolution_angle": {"value": 10, "units": "degree"},
+                "surface_max_edge_length": {"value": 0.15, "units": "m"},
+            },
+            "refinements": [],
+            "volume_zones": [
+                {
+                    "method": "auto",
+                    "type": "AutomatedFarfield",
+                    "private_attribute_entity": {
+                        "private_attribute_registry_bucket_name": "VolumetricEntityType",
+                        "private_attribute_entity_type_name": "GenericVolume",
+                        "name": "automated_farfied_entity",
+                        "private_attribute_zone_boundary_names": {"items": []},
+                    },
+                }
+            ],
+        },
         "private_attribute_asset_cache": {
             "project_length_unit": "m",
             "project_entity_info": {
@@ -521,8 +545,7 @@ def test_simulation_to_case_json():
         },
     }
 
-    params, err, _ = validate_model(params_as_dict=param_data, root_item_type="Geometry")
-    print("errors: ", err)
+    params, _, _ = validate_model(params_as_dict=param_data, root_item_type="Geometry")
     simulation_to_case_json(params, {"value": 100.0, "units": "cm"})
 
     with pytest.raises(ValueError, match="Mesh unit is required for translation."):
@@ -621,14 +644,18 @@ def test_simulation_to_case_vm_workflow():
         },
     }
 
-    params, _, _ = validate_model(params_as_dict=param_data, root_item_type="Geometry")
+    params, _, _ = validate_model(
+        params_as_dict=param_data, root_item_type="Geometry", validation_level=CASE
+    )
 
     with pytest.raises(ValueError):
-        case_json, hash = simulation_to_case_json(params, {"value": 100.0, "units": "cm"})
+        case_json, _ = simulation_to_case_json(params, {"value": 100.0, "units": "cm"})
         print(case_json)
 
-    params, errors, _ = validate_model(params_as_dict=param_data, root_item_type="VolumeMesh")
-    case_json, hash = simulation_to_case_json(params, {"value": 100.0, "units": "cm"})
+    params, _, _ = validate_model(
+        params_as_dict=param_data, root_item_type="VolumeMesh", validation_level=CASE
+    )
+    case_json, _ = simulation_to_case_json(params, {"value": 100.0, "units": "cm"})
     print(case_json)
 
 


### PR DESCRIPTION
- [x] fix(): SimulationParam->meshing no longer has default settings as it does not make sense and also the default value is incomplete anyway.
- [x] feat(): ConditionalFields now support having multiple context levels.
- [x] fix(): Validation context will always be list to make everyone's life easier.