### PR TITLE
Add validation for setting velocity direction for subsonicinflow

### DIFF
--- a/flow360/component/simulation/models/surface_models.py
+++ b/flow360/component/simulation/models/surface_models.py
@@ -386,6 +386,15 @@ class Inflow(BoundaryBaseWithTurbulenceQuantities):
         description="Specify the total pressure or the mass flow rate at the `Inflow` boundary.",
     )
 
+    @pd.model_validator(mode="after")
+    def _check_velocity_direction_in_subsonic_inflow(self):
+        """
+        Check to ensure velocity_direction can only be specified for Subsonic Inflow Boundary.
+        """
+        if self.velocity_direction and not isinstance(self.spec, TotalPressure):
+            raise ValueError("The velocity_direction can only be specified for Subsonic Inflow.")
+        return self
+
 
 class SlipWall(BoundaryBase):
     """:class:`SlipWall` class defines the :code:`SlipWall` boundary condition.

--- a/tests/simulation/params/test_validators_params.py
+++ b/tests/simulation/params/test_validators_params.py
@@ -18,6 +18,8 @@ from flow360.component.simulation.models.material import SolidMaterial, aluminum
 from flow360.component.simulation.models.solver_numerics import TransitionModelSolver
 from flow360.component.simulation.models.surface_models import (
     Freestream,
+    Inflow,
+    MassFlowRate,
     Periodic,
     SlipWall,
     Translational,
@@ -760,3 +762,19 @@ def test_rotating_reference_frame_model_flag():
             )
 
     assert test_param.models[3].rotating_reference_frame_model == False
+
+
+def test_velocity_direction_in_subsonic_inflow():
+    msg = "The velocity_direction can only be specified for Subsonic Inflow."
+    with SI_unit_system, pytest.raises(ValueError, match=re.escape(msg)):
+        entity_surface = Surface(name="Inflow Surface")
+        SimulationParams(
+            models=[
+                Inflow(
+                    velocity_direction=(0, 0, 1),
+                    total_temperature=300 * u.K,
+                    spec=MassFlowRate(value=123 * u.lb / u.s),
+                    surfaces=entity_surface,
+                )
+            ],
+        )


### PR DESCRIPTION
The validation is to ensure velocity_direction can only be specified for Subsonic Inflow Boundary.