### PR TITLE
[HotFix] Add Updater to 24.11.7 (#660)

### DIFF
--- a/flow360/component/simulation/framework/updater.py
+++ b/flow360/component/simulation/framework/updater.py
@@ -9,14 +9,56 @@ TODO: remove duplication code with FLow360Params updater.
 import re
 
 from ....exceptions import Flow360NotImplementedError, Flow360RuntimeError
+from .entity_base import generate_uuid
+from .updater_utils import compare_dicts
 
 
 def _no_update(params_as_dict):
     return params_as_dict
 
 
+def _24_11_6_to_24_11_7_update(params_as_dict):
+    # Check if PointArray has private_attribute_id. If not, generate the uuid and assign the id
+    # to all occurance of the same PointArray
+    if params_as_dict.get("outputs") is None:
+        return params_as_dict
+
+    point_array_list = []
+    for output in params_as_dict["outputs"]:
+        if output.get("entities", None):
+            for entity in output["entities"]["stored_entities"]:
+                if (
+                    entity.get("private_attribute_entity_type_name") == "PointArray"
+                    and entity.get("private_attribute_id") is None
+                ):
+                    new_uuid = generate_uuid()
+                    entity["private_attribute_id"] = new_uuid
+                    point_array_list.append(entity)
+
+    if params_as_dict["private_attribute_asset_cache"].get("project_entity_info"):
+        for idx, draft_entity in enumerate(
+            params_as_dict["private_attribute_asset_cache"]["project_entity_info"]["draft_entities"]
+        ):
+            if draft_entity.get("private_attribute_entity_type_name") != "PointArray":
+                continue
+            for point_array in point_array_list:
+                if compare_dicts(
+                    dict1=draft_entity,
+                    dict2=point_array,
+                    ignore_keys=["private_attribute_id"],
+                ):
+                    params_as_dict["private_attribute_asset_cache"]["project_entity_info"][
+                        "draft_entities"
+                    ][idx] = point_array
+                    continue
+
+    return params_as_dict
+
+
 UPDATE_MAP = [
-    ("24.11.*", "24.11.*", _no_update),
+    ("24.11.^([0-5])$", "24.11.6", _no_update),
+    ("24.11.6", "24.11.7", _24_11_6_to_24_11_7_update),
+    ("24.11.7", "24.11.*", _no_update),
 ]
 
 

--- a/flow360/component/simulation/framework/updater_utils.py
+++ b/flow360/component/simulation/framework/updater_utils.py
@@ -1,0 +1,56 @@
+"""Utiliy functions for updater"""
+
+from numbers import Number
+
+import numpy as np
+
+
+def compare_dicts(dict1, dict2, atol=1e-15, rtol=1e-10, ignore_keys=None):
+    """Check two dictionaries are same or not"""
+    if ignore_keys is None:
+        ignore_keys = set()
+
+    # Filter out the keys to be ignored
+    dict1_filtered = {k: v for k, v in dict1.items() if k not in ignore_keys}
+    dict2_filtered = {k: v for k, v in dict2.items() if k not in ignore_keys}
+
+    if dict1_filtered.keys() != dict2_filtered.keys():
+        print(f"dict keys not equal, dict1 {dict1_filtered.keys()}, dict2 {dict2_filtered.keys()}")
+        return False
+
+    for key in dict1_filtered:
+        value1 = dict1_filtered[key]
+        value2 = dict2_filtered[key]
+
+        if not compare_values(value1, value2, atol, rtol, ignore_keys):
+            print(f"dict value of key {key} not equal dict1 {dict1[key]}, dict2 {dict2[key]}")
+            return False
+
+    return True
+
+
+def compare_values(value1, value2, atol=1e-15, rtol=1e-10, ignore_keys=None):
+    """Check two values are same or not"""
+    if isinstance(value1, Number) and isinstance(value2, Number):
+        return np.isclose(value1, value2, rtol, atol)
+    if isinstance(value1, dict) and isinstance(value2, dict):
+        return compare_dicts(value1, value2, atol, rtol, ignore_keys)
+    if isinstance(value1, list) and isinstance(value2, list):
+        return compare_lists(value1, value2, atol, rtol, ignore_keys)
+    return value1 == value2
+
+
+def compare_lists(list1, list2, atol=1e-15, rtol=1e-10, ignore_keys=None):
+    """Check two lists are same or not"""
+    if len(list1) != len(list2):
+        return False
+
+    if list1 and not isinstance(list1[0], dict):
+        list1, list2 = sorted(list1), sorted(list2)
+
+    for item1, item2 in zip(list1, list2):
+        if not compare_values(item1, item2, atol, rtol, ignore_keys):
+            print(f"list value not equal list1 {item1}, list2 {item2}")
+            return False
+
+    return True

--- a/tests/data/simulation/simulation_24_11_6.json
+++ b/tests/data/simulation/simulation_24_11_6.json
@@ -1,0 +1,561 @@
+{
+    "version": "24.11.6",
+    "unit_system": {
+        "name": "SI"
+    },
+    "meshing": null,
+    "reference_geometry": {
+        "moment_center": {
+            "value": [
+                0.25,
+                -0.5,
+                0
+            ],
+            "units": "m"
+        },
+        "moment_length": {
+            "value": [
+                1,
+                1,
+                1
+            ],
+            "units": "m"
+        },
+        "area": {
+            "value": 1,
+            "units": "m**2"
+        }
+    },
+    "operating_condition": {
+        "type_name": "AerospaceCondition",
+        "private_attribute_constructor": "from_mach",
+        "private_attribute_input_cache": {
+            "mach": 0.15,
+            "alpha": {
+                "value": 15,
+                "units": "degree"
+            },
+            "beta": {
+                "value": 0,
+                "units": "degree"
+            },
+            "thermal_state": {
+                "type_name": "ThermalState",
+                "private_attribute_constructor": "default",
+                "private_attribute_input_cache": {
+                    "altitude": null,
+                    "temperature_offset": null
+                },
+                "temperature": {
+                    "value": 300,
+                    "units": "K"
+                },
+                "density": {
+                    "value": 2.1265048131848094,
+                    "units": "Pa*s**2/m**2"
+                },
+                "material": {
+                    "type": "air",
+                    "name": "air",
+                    "dynamic_viscosity": {
+                        "reference_viscosity": {
+                            "value": 0.00001716,
+                            "units": "Pa*s"
+                        },
+                        "reference_temperature": {
+                            "value": 273.15,
+                            "units": "K"
+                        },
+                        "effective_temperature": {
+                            "value": 110.4,
+                            "units": "K"
+                        }
+                    }
+                }
+            },
+            "reference_mach": null
+        },
+        "alpha": {
+            "value": 15,
+            "units": "degree"
+        },
+        "beta": {
+            "value": 0,
+            "units": "degree"
+        },
+        "velocity_magnitude": {
+            "value": 52.08310575416946,
+            "units": "m/s"
+        },
+        "thermal_state": {
+            "type_name": "ThermalState",
+            "private_attribute_constructor": "default",
+            "private_attribute_input_cache": {
+                "altitude": null,
+                "temperature_offset": null
+            },
+            "temperature": {
+                "value": 300,
+                "units": "K"
+            },
+            "density": {
+                "value": 2.1265048131848094,
+                "units": "Pa*s**2/m**2"
+            },
+            "material": {
+                "type": "air",
+                "name": "air",
+                "dynamic_viscosity": {
+                    "reference_viscosity": {
+                        "value": 0.00001716,
+                        "units": "Pa*s"
+                    },
+                    "reference_temperature": {
+                        "value": 273.15,
+                        "units": "K"
+                    },
+                    "effective_temperature": {
+                        "value": 110.4,
+                        "units": "K"
+                    }
+                }
+            }
+        },
+        "reference_velocity_magnitude": null
+    },
+    "models": [
+        {
+            "material": {
+                "type": "air",
+                "name": "air",
+                "dynamic_viscosity": {
+                    "reference_viscosity": {
+                        "value": 0.00001716,
+                        "units": "Pa*s"
+                    },
+                    "reference_temperature": {
+                        "value": 273.15,
+                        "units": "K"
+                    },
+                    "effective_temperature": {
+                        "value": 110.4,
+                        "units": "K"
+                    }
+                }
+            },
+            "initial_condition": {
+                "type_name": "NavierStokesInitialCondition",
+                "constants": null,
+                "rho": "rho",
+                "u": "u",
+                "v": "v",
+                "w": "w",
+                "p": "p"
+            },
+            "type": "Fluid",
+            "navier_stokes_solver": {
+                "absolute_tolerance": 1e-10,
+                "relative_tolerance": 0,
+                "order_of_accuracy": 2,
+                "equation_evaluation_frequency": 1,
+                "linear_solver": {
+                    "max_iterations": 30,
+                    "absolute_tolerance": null,
+                    "relative_tolerance": null
+                },
+                "private_attribute_dict": null,
+                "CFL_multiplier": 1,
+                "kappa_MUSCL": -1,
+                "numerical_dissipation_factor": 1,
+                "limit_velocity": false,
+                "limit_pressure_density": false,
+                "type_name": "Compressible",
+                "low_mach_preconditioner": false,
+                "low_mach_preconditioner_threshold": null,
+                "update_jacobian_frequency": 4,
+                "max_force_jac_update_physical_steps": 1000000
+            },
+            "turbulence_model_solver": {
+                "absolute_tolerance": 1e-8,
+                "relative_tolerance": 0,
+                "order_of_accuracy": 2,
+                "equation_evaluation_frequency": 1,
+                "linear_solver": {
+                    "max_iterations": 20,
+                    "absolute_tolerance": null,
+                    "relative_tolerance": null
+                },
+                "private_attribute_dict": null,
+                "CFL_multiplier": 2,
+                "type_name": "SpalartAllmaras",
+                "DDES": false,
+                "grid_size_for_LES": "maxEdgeLength",
+                "reconstruction_gradient_limiter": 0.5,
+                "quadratic_constitutive_relation": false,
+                "modeling_constants": {
+                    "type_name": "SpalartAllmarasConsts",
+                    "C_DES": 0.72,
+                    "C_d": 8,
+                    "C_cb1": 0.1355,
+                    "C_cb2": 0.622,
+                    "C_sigma": 0.6666666666666666,
+                    "C_v1": 7.1,
+                    "C_vonKarman": 0.41,
+                    "C_w2": 0.3,
+                    "C_t3": 1.2,
+                    "C_t4": 0.5,
+                    "C_min_rd": 10
+                },
+                "update_jacobian_frequency": 4,
+                "max_force_jac_update_physical_steps": 1000000,
+                "rotation_correction": true
+            },
+            "transition_model_solver": {
+                "type_name": "None"
+            }
+        },
+        {
+            "type": "SlipWall",
+            "entities": {
+                "stored_entities": [
+                    {
+                        "private_attribute_registry_bucket_name": "SurfaceEntityType",
+                        "private_attribute_entity_type_name": "Surface",
+                        "private_attribute_id": null,
+                        "name": "Zone/QUAD_bdy    1",
+                        "private_attribute_full_name": "Zone/QUAD_bdy    1",
+                        "private_attribute_is_interface": false,
+                        "private_attribute_tag_key": null
+                    },
+                    {
+                        "private_attribute_registry_bucket_name": "SurfaceEntityType",
+                        "private_attribute_entity_type_name": "Surface",
+                        "private_attribute_id": null,
+                        "name": "Zone/QUAD_bdy    2",
+                        "private_attribute_full_name": "Zone/QUAD_bdy    2",
+                        "private_attribute_is_interface": false,
+                        "private_attribute_tag_key": null
+                    }
+                ]
+            },
+            "name": null
+        },
+        {
+            "type": "Wall",
+            "entities": {
+                "stored_entities": [
+                    {
+                        "private_attribute_registry_bucket_name": "SurfaceEntityType",
+                        "private_attribute_entity_type_name": "Surface",
+                        "private_attribute_id": null,
+                        "name": "Zone/QUAD_bdy    5",
+                        "private_attribute_full_name": "Zone/QUAD_bdy    5",
+                        "private_attribute_is_interface": false,
+                        "private_attribute_tag_key": null
+                    }
+                ]
+            },
+            "name": "Airfoil",
+            "use_wall_function": false,
+            "velocity": null,
+            "heat_spec": {
+                "value": {
+                    "value": 0,
+                    "units": "W/m**2"
+                },
+                "type_name": "HeatFlux"
+            }
+        },
+        {
+            "type": "Freestream",
+            "entities": {
+                "stored_entities": [
+                    {
+                        "private_attribute_registry_bucket_name": "SurfaceEntityType",
+                        "private_attribute_entity_type_name": "Surface",
+                        "private_attribute_id": null,
+                        "name": "Zone/QUAD_bdy    6",
+                        "private_attribute_full_name": "Zone/QUAD_bdy    6",
+                        "private_attribute_is_interface": false,
+                        "private_attribute_tag_key": null
+                    },
+                    {
+                        "private_attribute_registry_bucket_name": "SurfaceEntityType",
+                        "private_attribute_entity_type_name": "Surface",
+                        "private_attribute_id": null,
+                        "name": "Zone/QUAD_bdy    3",
+                        "private_attribute_full_name": "Zone/QUAD_bdy    3",
+                        "private_attribute_is_interface": false,
+                        "private_attribute_tag_key": null
+                    },
+                    {
+                        "private_attribute_registry_bucket_name": "SurfaceEntityType",
+                        "private_attribute_entity_type_name": "Surface",
+                        "private_attribute_id": null,
+                        "name": "Zone/QUAD_bdy    4",
+                        "private_attribute_full_name": "Zone/QUAD_bdy    4",
+                        "private_attribute_is_interface": false,
+                        "private_attribute_tag_key": null
+                    }
+                ]
+            },
+            "turbulence_quantities": {
+                "type_name": "TurbulentViscosityRatio",
+                "turbulent_viscosity_ratio": 0.210438
+            },
+            "name": null,
+            "velocity": null
+        }
+    ],
+    "time_stepping": {
+        "type_name": "Steady",
+        "max_steps": 100000,
+        "CFL": {
+            "type": "ramp",
+            "initial": 5,
+            "final": 100,
+            "ramp_steps": 10000
+        }
+    },
+    "user_defined_dynamics": null,
+    "outputs": [
+        {
+            "name": "Probe output",
+            "output_type": "ProbeOutput",
+            "output_fields": {
+                "items": [
+                    "T"
+                ]
+            },
+            "entities": {
+                "stored_entities": [
+                    {
+                        "private_attribute_id": null,
+                        "name": "Point array",
+                        "private_attribute_entity_type_name": "PointArray",
+                        "start": {
+                            "value": [
+                                0,
+                                0,
+                                0
+                            ],
+                            "units": "m"
+                        },
+                        "end": {
+                            "value": [
+                                1,
+                                0,
+                                0
+                            ],
+                            "units": "m"
+                        },
+                        "number_of_points": 10
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Probe output",
+            "output_type": "ProbeOutput",
+            "output_fields": {
+                "items": [
+                    "T"
+                ]
+            },
+            "entities": {
+                "stored_entities": [
+                    {
+                        "private_attribute_id": null,
+                        "name": "Point array",
+                        "private_attribute_entity_type_name": "PointArray",
+                        "start": {
+                            "value": [
+                                2,
+                                0,
+                                0
+                            ],
+                            "units": "m"
+                        },
+                        "end": {
+                            "value": [
+                                1,
+                                0,
+                                0
+                            ],
+                            "units": "m"
+                        },
+                        "number_of_points": 10
+                    }
+                ]
+            }
+        },
+        {
+            "frequency": -1,
+            "frequency_offset": 0,
+            "output_format": "tecplot",
+            "name": "Volume output",
+            "output_fields": {
+                "items": [
+                    "primitiveVars",
+                    "residualNavierStokes",
+                    "residualTurbulence",
+                    "solutionTurbulence",
+                    "T",
+                    "s",
+                    "Cp",
+                    "mut",
+                    "nuHat",
+                    "mutRatio",
+                    "Mach",
+                    "gradW",
+                    "wallDistance"
+                ]
+            },
+            "output_type": "VolumeOutput"
+        }
+    ],
+    "private_attribute_asset_cache": {
+        "project_length_unit": {
+            "value": 1,
+            "units": "m"
+        },
+        "project_entity_info": {
+            "zones": [
+                {
+                    "private_attribute_registry_bucket_name": "VolumetricEntityType",
+                    "private_attribute_entity_type_name": "GenericVolume",
+                    "private_attribute_id": null,
+                    "name": "Zone",
+                    "private_attribute_zone_boundary_names": {
+                        "items": [
+                            "Zone/QUAD_bdy    1",
+                            "Zone/QUAD_bdy    2",
+                            "Zone/QUAD_bdy    3",
+                            "Zone/QUAD_bdy    4",
+                            "Zone/QUAD_bdy    5",
+                            "Zone/QUAD_bdy    6"
+                        ]
+                    },
+                    "private_attribute_full_name": "Zone",
+                    "axes": null,
+                    "axis": [
+                        0,
+                        0,
+                        1
+                    ],
+                    "center": {
+                        "value": [
+                            0,
+                            0,
+                            0
+                        ],
+                        "units": "m"
+                    }
+                }
+            ],
+            "boundaries": [
+                {
+                    "private_attribute_registry_bucket_name": "SurfaceEntityType",
+                    "private_attribute_entity_type_name": "Surface",
+                    "private_attribute_id": null,
+                    "name": "Zone/QUAD_bdy    5",
+                    "private_attribute_full_name": "Zone/QUAD_bdy    5",
+                    "private_attribute_is_interface": false,
+                    "private_attribute_tag_key": null
+                },
+                {
+                    "private_attribute_registry_bucket_name": "SurfaceEntityType",
+                    "private_attribute_entity_type_name": "Surface",
+                    "private_attribute_id": null,
+                    "name": "Zone/QUAD_bdy    1",
+                    "private_attribute_full_name": "Zone/QUAD_bdy    1",
+                    "private_attribute_is_interface": false,
+                    "private_attribute_tag_key": null
+                },
+                {
+                    "private_attribute_registry_bucket_name": "SurfaceEntityType",
+                    "private_attribute_entity_type_name": "Surface",
+                    "private_attribute_id": null,
+                    "name": "Zone/QUAD_bdy    6",
+                    "private_attribute_full_name": "Zone/QUAD_bdy    6",
+                    "private_attribute_is_interface": false,
+                    "private_attribute_tag_key": null
+                },
+                {
+                    "private_attribute_registry_bucket_name": "SurfaceEntityType",
+                    "private_attribute_entity_type_name": "Surface",
+                    "private_attribute_id": null,
+                    "name": "Zone/QUAD_bdy    3",
+                    "private_attribute_full_name": "Zone/QUAD_bdy    3",
+                    "private_attribute_is_interface": false,
+                    "private_attribute_tag_key": null
+                },
+                {
+                    "private_attribute_registry_bucket_name": "SurfaceEntityType",
+                    "private_attribute_entity_type_name": "Surface",
+                    "private_attribute_id": null,
+                    "name": "Zone/QUAD_bdy    4",
+                    "private_attribute_full_name": "Zone/QUAD_bdy    4",
+                    "private_attribute_is_interface": false,
+                    "private_attribute_tag_key": null
+                },
+                {
+                    "private_attribute_registry_bucket_name": "SurfaceEntityType",
+                    "private_attribute_entity_type_name": "Surface",
+                    "private_attribute_id": null,
+                    "name": "Zone/QUAD_bdy    2",
+                    "private_attribute_full_name": "Zone/QUAD_bdy    2",
+                    "private_attribute_is_interface": false,
+                    "private_attribute_tag_key": null
+                }
+            ],
+            "draft_entities": [
+                {
+                    "private_attribute_id": null,
+                    "name": "Point array",
+                    "private_attribute_entity_type_name": "PointArray",
+                    "start": {
+                        "value": [
+                            2,
+                            0,
+                            0
+                        ],
+                        "units": "m"
+                    },
+                    "end": {
+                        "value": [
+                            1,
+                            0,
+                            0
+                        ],
+                        "units": "m"
+                    },
+                    "number_of_points": 10
+                },
+                {
+                    "private_attribute_id": null,
+                    "name": "Point array",
+                    "private_attribute_entity_type_name": "PointArray",
+                    "start": {
+                        "value": [
+                            0,
+                            0,
+                            0
+                        ],
+                        "units": "m"
+                    },
+                    "end": {
+                        "value": [
+                            1,
+                            0,
+                            0
+                        ],
+                        "units": "m"
+                    },
+                    "number_of_points": 10
+                }
+            ],
+            "type_name": "VolumeMeshEntityInfo"
+        }
+    }
+}

--- a/tests/simulation/framework/test_unit_system_v2.py
+++ b/tests/simulation/framework/test_unit_system_v2.py
@@ -8,6 +8,7 @@ from numpy import nan
 
 from flow360.component.simulation import units as u
 from flow360.component.simulation.framework.base_model import Flow360BaseModel
+from flow360.component.simulation.framework.updater_utils import compare_dicts
 from flow360.component.simulation.unit_system import (
     AngleType,
     AngularVelocityType,
@@ -25,7 +26,6 @@ from flow360.component.simulation.unit_system import (
     VelocityType,
     ViscosityType,
 )
-from tests.utils import compare_dicts
 
 
 class DataWithUnits(pd.BaseModel):

--- a/tests/simulation/service/test_services_v2.py
+++ b/tests/simulation/service/test_services_v2.py
@@ -4,12 +4,13 @@ import re
 import pytest
 
 from flow360.component.simulation import services
+from flow360.component.simulation.framework.updater_utils import compare_values
 from flow360.component.simulation.validation.validation_context import (
     CASE,
     SURFACE_MESH,
     VOLUME_MESH,
 )
-from tests.utils import compare_dict_to_ref, compare_values
+from tests.utils import compare_dict_to_ref
 
 
 @pytest.fixture(autouse=True)

--- a/tests/simulation/test_updater.py
+++ b/tests/simulation/test_updater.py
@@ -1,0 +1,43 @@
+import json
+
+import pytest
+
+import flow360 as fl
+from flow360.component.simulation.framework.updater import updater
+
+
+@pytest.fixture(autouse=True)
+def change_test_dir(request, monkeypatch):
+    monkeypatch.chdir(request.fspath.dirname)
+
+
+def test_updater_to_24_11_7():
+
+    with open("../data/simulation/simulation_24_11_6.json", "r") as fp:
+        params_24_11_6 = json.load(fp)
+
+    params_24_11_7 = updater(
+        version_from="24.11.6", version_to="24.11.7", params_as_dict=params_24_11_6
+    )
+
+    assert params_24_11_7["outputs"][0]["entities"]["stored_entities"][0]["private_attribute_id"]
+    assert params_24_11_7["outputs"][1]["entities"]["stored_entities"][0]["private_attribute_id"]
+    assert params_24_11_7["private_attribute_asset_cache"]["project_entity_info"]["draft_entities"][
+        0
+    ]["private_attribute_id"]
+    assert params_24_11_7["private_attribute_asset_cache"]["project_entity_info"]["draft_entities"][
+        1
+    ]["private_attribute_id"]
+
+    assert (
+        params_24_11_7["outputs"][1]["entities"]["stored_entities"][0]["private_attribute_id"]
+        == params_24_11_7["private_attribute_asset_cache"]["project_entity_info"]["draft_entities"][
+            0
+        ]["private_attribute_id"]
+    )
+    assert (
+        params_24_11_7["outputs"][0]["entities"]["stored_entities"][0]["private_attribute_id"]
+        == params_24_11_7["private_attribute_asset_cache"]["project_entity_info"]["draft_entities"][
+            1
+        ]["private_attribute_id"]
+    )

--- a/tests/simulation/translator/test_solver_translator.py
+++ b/tests/simulation/translator/test_solver_translator.py
@@ -99,7 +99,7 @@ from tests.simulation.translator.utils.XV15HoverMRF_param_generator import (
 
 assertions = unittest.TestCase("__init__")
 
-from tests.utils import compare_values
+from flow360.component.simulation.framework.updater_utils import compare_values
 
 
 @pytest.fixture()

--- a/tests/simulation/translator/test_surface_meshing_translator.py
+++ b/tests/simulation/translator/test_surface_meshing_translator.py
@@ -6,6 +6,7 @@ import pytest
 import flow360.component.simulation.units as u
 from flow360.component.simulation.entity_info import GeometryEntityInfo
 from flow360.component.simulation.framework.param_utils import AssetCache
+from flow360.component.simulation.framework.updater_utils import compare_values
 from flow360.component.simulation.meshing_param.edge_params import (
     AngleBasedRefinement,
     HeightBasedRefinement,
@@ -28,7 +29,6 @@ from flow360.component.simulation.unit_system import (
     imperial_unit_system,
 )
 from tests.simulation.conftest import AssetBase
-from tests.utils import compare_values
 
 
 class TempGeometry(AssetBase):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -60,55 +60,6 @@ def show_dict_diff(dict1, dict2):
     print("end of diff")
 
 
-def compare_dicts(dict1, dict2, atol=1e-15, rtol=1e-10, ignore_keys=None):
-    if ignore_keys is None:
-        ignore_keys = set()
-
-    # Filter out the keys to be ignored
-    dict1_filtered = {k: v for k, v in dict1.items() if k not in ignore_keys}
-    dict2_filtered = {k: v for k, v in dict2.items() if k not in ignore_keys}
-
-    if dict1_filtered.keys() != dict2_filtered.keys():
-        print(f"dict keys not equal, dict1 {dict1_filtered.keys()}, dict2 {dict2_filtered.keys()}")
-        return False
-
-    for key in dict1_filtered:
-        value1 = dict1_filtered[key]
-        value2 = dict2_filtered[key]
-
-        if not compare_values(value1, value2, atol, rtol, ignore_keys):
-            print(f"dict value of key {key} not equal dict1 {dict1[key]}, dict2 {dict2[key]}")
-            return False
-
-    return True
-
-
-def compare_values(value1, value2, atol=1e-15, rtol=1e-10, ignore_keys=None):
-    if isinstance(value1, Number) and isinstance(value2, Number):
-        return np.isclose(value1, value2, rtol, atol)
-    elif isinstance(value1, dict) and isinstance(value2, dict):
-        return compare_dicts(value1, value2, atol, rtol, ignore_keys)
-    elif isinstance(value1, list) and isinstance(value2, list):
-        return compare_lists(value1, value2, atol, rtol, ignore_keys)
-    else:
-        return value1 == value2
-
-
-def compare_lists(list1, list2, atol=1e-15, rtol=1e-10, ignore_keys=None):
-    if len(list1) != len(list2):
-        return False
-
-    if list1 and not isinstance(list1[0], dict):
-        list1, list2 = sorted(list1), sorted(list2)
-
-    for item1, item2 in zip(list1, list2):
-        if not compare_values(item1, item2, atol, rtol, ignore_keys):
-            print(f"list value not equal list1 {item1}, list2 {item2}")
-            return False
-
-    return True
-
-
 def to_file_from_file_test(obj):
     test_extentions = ["yaml", "json"]
     factory = obj.__class__


### PR DESCRIPTION
* Add updater from 24.11.6 to 24.11.7 to handle missing private_attribute_id of PointArray

* Move compare_dicts, _lists and _values to updater_utils

* Reduce the size of reference simulation json for unit test