### PR TITLE
added support for UAT env when setting API key

### DIFF
--- a/flow360/cli/app.py
+++ b/flow360/cli/app.py
@@ -36,7 +36,10 @@ def flow360():
 )
 @click.option("--profile", prompt=False, default="default", help="Profile, e.g., default, dev.")
 @click.option(
-    "--dev", prompt=False, type=bool, is_flag=True, help="Only use this apikey in dev environment."
+    "--dev", prompt=False, type=bool, is_flag=True, help="Only use this apikey in DEV environment."
+)
+@click.option(
+    "--uat", prompt=False, type=bool, is_flag=True, help="Only use this apikey in UAT environment."
 )
 @click.option(
     "--suppress-submit-warning",
@@ -48,7 +51,7 @@ def flow360():
     type=bool,
     help="Toggle beta features support",
 )
-def configure(apikey, profile, dev, suppress_submit_warning, beta_features):
+def configure(apikey, profile, dev, uat, suppress_submit_warning, beta_features):
     """
     Configure flow360.
     """
@@ -62,7 +65,12 @@ def configure(apikey, profile, dev, suppress_submit_warning, beta_features):
             config = toml.loads(file_handler.read())
 
     if apikey is not None:
-        entry = {profile: {"apikey": apikey}} if not dev else {profile: {"dev": {"apikey": apikey}}}
+        if dev is True:
+            entry = {profile: {"dev": {"apikey": apikey}}}
+        elif uat is True:
+            entry = {profile: {"uat": {"apikey": apikey}}}
+        else:
+            entry = {profile: {"apikey": apikey}}
         dict_utils.merge_overwrite(config, entry)
         changed = True
 

--- a/flow360/cli/app.py
+++ b/flow360/cli/app.py
@@ -51,7 +51,8 @@ def flow360():
     type=bool,
     help="Toggle beta features support",
 )
-def configure(apikey, profile, dev, uat, suppress_submit_warning, beta_features): #pylint: disable=too-many-arguments
+# pylint: disable=too-many-arguments
+def configure(apikey, profile, dev, uat, suppress_submit_warning, beta_features):
     """
     Configure flow360.
     """
@@ -73,7 +74,6 @@ def configure(apikey, profile, dev, uat, suppress_submit_warning, beta_features)
             entry = {profile: {"apikey": apikey}}
         dict_utils.merge_overwrite(config, entry)
         changed = True
-
 
     if suppress_submit_warning is not None:
         dict_utils.merge_overwrite(

--- a/flow360/cli/app.py
+++ b/flow360/cli/app.py
@@ -51,7 +51,7 @@ def flow360():
     type=bool,
     help="Toggle beta features support",
 )
-def configure(apikey, profile, dev, uat, suppress_submit_warning, beta_features):
+def configure(apikey, profile, dev, uat, suppress_submit_warning, beta_features): #pylint: disable=too-many-arguments
     """
     Configure flow360.
     """
@@ -73,6 +73,7 @@ def configure(apikey, profile, dev, uat, suppress_submit_warning, beta_features)
             entry = {profile: {"apikey": apikey}}
         dict_utils.merge_overwrite(config, entry)
         changed = True
+
 
     if suppress_submit_warning is not None:
         dict_utils.merge_overwrite(

--- a/flow360/cloud/http_util.py
+++ b/flow360/cloud/http_util.py
@@ -31,6 +31,10 @@ def api_key_auth(request):
             raise Flow360AuthorisationError(
                 "API key not found for env=dev, please set it by commandline: flow360 configure --dev."
             )
+        if Env.current.name == "uat":
+            raise Flow360AuthorisationError(
+                "API key not found for env=uat, please set it by commandline: flow360 configure --uat."
+            )
         raise Flow360AuthorisationError(
             f"API key not found for profile={UserConfig.profile}, please set it by commandline: flow360 configure."
         )

--- a/flow360/environment.py
+++ b/flow360/environment.py
@@ -87,7 +87,7 @@ dev = EnvironmentConfig.from_domain(
     name="dev", domain="dev-simulation.cloud", aws_region="us-east-1", apikey_profile="dev"
 )
 uat = EnvironmentConfig.from_domain(
-    name="uat", domain="uat-simulation.cloud", aws_region="us-west-2"
+    name="uat", domain="uat-simulation.cloud", aws_region="us-west-2", apikey_profile="uat"
 )
 prod = EnvironmentConfig.from_domain(
     name="prod", domain="simulation.cloud", aws_region="us-gov-west-1"

--- a/flow360/user_config.py
+++ b/flow360/user_config.py
@@ -79,6 +79,8 @@ class BasicUserConfig:
         key = self.config.get(self.profile, {})
         if key and env.name == "dev":
             key = key.get("dev")
+        elif key and env.name == "uat":
+            key = key.get("uat")
         return None if key is None else key.get("apikey", "")
 
     def suppress_submit_warning(self):


### PR DESCRIPTION
How to use:

```
flow360 configure --apikey=... --profile=auto_test_1 --uat
```
then, when using:
```python
import flow360 as fl
from flow360.user_config import UserConfig

UserConfig.set_profile("auto_test_1")
fl.Env.uat.active()
```
it will parse correct API key.
