### PR TITLE
Extend report generation feature for service tests

### DIFF
--- a/flow360/component/results/case_results.py
+++ b/flow360/component/results/case_results.py
@@ -695,7 +695,7 @@ class PerEntityResultCSVModel(ResultCSVModel):
         exclude : list or single item, optional
             List of patterns or single pattern to exclude.
         """
-        self._preprocess()
+        self.reload_data()
         include = (
             [include] if include is not None and not isinstance(include, list) else include or []
         )
@@ -780,6 +780,9 @@ class SurfaceForcesResultCSVModel(PerEntityResultCSVModel):
         super()._preprocess(
             filter_physical_steps_only=filter_physical_steps_only, include_time=include_time
         )
+
+    def reload_data(self, filter_physical_steps_only: bool = True, include_time: bool = True):
+        return super().reload_data(filter_physical_steps_only, include_time)
 
 
 class LegacyForceDistributionResultCSVModel(ResultCSVModel):

--- a/flow360/plugins/report/report_items.py
+++ b/flow360/plugins/report/report_items.py
@@ -307,6 +307,8 @@ class Table(ReportItem):
         def make_callable(fmt):
             if callable(fmt):
                 return fmt
+            if fmt == "bool":
+                return lambda x: f"{bool(x)}"
             return lambda x, ff=fmt: f"{x:{ff}}"
 
         formatters = [make_callable(f) for f in formatters]  # pylint: disable=not-an-iterable

--- a/flow360/plugins/report/report_items.py
+++ b/flow360/plugins/report/report_items.py
@@ -771,7 +771,7 @@ class Chart2D(Chart):
     type_name : Literal["Chart2D"], default="Chart2D"
         Specifies the type of report item as "Chart2D"; this field is immutable.
     include : Optional[List[str]]
-        List of boundaries to include from data. Applicable to:
+        List of boundaries to include in data. Applicable to:
         x_slicing_force_distribution, y_slicing_force_distribution, surface_forces
     exclude : Optional[List[str]]
         List of boundaries to exclude from data. Applicable to:

--- a/flow360/plugins/report/report_items.py
+++ b/flow360/plugins/report/report_items.py
@@ -747,6 +747,9 @@ class Chart2D(Chart):
         Internal list of requirements associated with the chart.
     type_name : Literal["Chart2D"], default="Chart2D"
         Specifies the type of report item as "Chart2D"; this field is immutable.
+    include : Optional[List[str]]
+        List of boundaries to include from data. Applicable to:
+        x_slicing_force_distribution, y_slicing_force_distribution, surface_forces
     exclude : Optional[List[str]]
         List of boundaries to exclude from data. Applicable to:
         x_slicing_force_distribution, y_slicing_force_distribution, surface_forces
@@ -766,6 +769,7 @@ class Chart2D(Chart):
     _requirements: List[str] = [_requirements_mapping["total_forces"]]
     type_name: Literal["Chart2D"] = Field("Chart2D", frozen=True)
     operations: Optional[Union[List[OperationTypes], OperationTypes]] = None
+    include: Optional[List[str]] = None
     exclude: Optional[List[str]] = None
     focus_x: Optional[Tuple[float, float]] = None
 
@@ -782,11 +786,13 @@ class Chart2D(Chart):
         Returns
         -------
         bool
-            True if the root path of `self.y` corresponds to "nonlinear_residuals",
-            indicating a logarithmic plot; False otherwise.
+            True if the root path of `self.y` corresponds to "nonlinear_residuals"
+            and "linear_residuals", indicating a logarithmic plot; False otherwise.
         """
         root_path = get_root_path(self.y)
-        return root_path.startswith("nonlinear_residuals")
+        return root_path.startswith("nonlinear_residuals") or root_path.startswith(
+            "linear_residuals"
+        )
 
     def _check_dimensions_consistency(self, data):
         if any(isinstance(d, unyt.unyt_array) for d in data):
@@ -841,13 +847,13 @@ class Chart2D(Chart):
         component = x_label
         for i, data in enumerate(x_data):
             if isinstance(data, case_results.PerEntityResultCSVModel):
-                data.filter(exclude=self.exclude)
+                data.filter(include=self.include, exclude=self.exclude)
                 x_data[i] = data.values[component]
 
         component = y_label
         for i, data in enumerate(y_data):
             if isinstance(data, case_results.PerEntityResultCSVModel):
-                data.filter(exclude=self.exclude)
+                data.filter(include=self.include, exclude=self.exclude)
                 y_data[i] = data.values[component]
 
         return x_data, y_data, x_label, y_label
@@ -984,6 +990,7 @@ class Chart2D(Chart):
                 show="boundaries",
                 camera=camera,
                 fig_name="background_" + self.fig_name,
+                include=self.include,
                 exclude=self.exclude,
             )
             return background

--- a/flow360/plugins/report/report_items.py
+++ b/flow360/plugins/report/report_items.py
@@ -106,23 +106,6 @@ class Settings(Flow360BaseModel):
     dpi: Optional[pd.PositiveInt] = 300
 
 
-class TableSettings(Settings):
-    """
-    Settings for controlling output tables.
-
-    Attributes
-    ----------
-    case_include : List[pd.NonNegativeInt], optional
-        The indices of cases to be included in the table
-
-    case_excluded : List[pd.NonNegativeInt], optional
-        The indices of cases to be excluded from the table
-    """
-
-    case_include: Optional[List[pd.NonNegativeInt]] = None
-    case_exclude: Optional[List[pd.NonNegativeInt]] = None
-
-
 class ReportItem(Flow360BaseModel):
     """
     Base class for for all report items
@@ -266,6 +249,8 @@ class Table(ReportItem):
         List of column headers for the table, default is None.
     type_name : Literal["Table"], default="Table"
         Specifies the type of report item as "Table"; this field is immutable.
+    select_indices : Optional[List[NonNegativeInt]], optional
+        Specific indices to select for the chart.
     formatter : Optional
         formatter can be:
         single str (e.g. ".4g")
@@ -276,8 +261,8 @@ class Table(ReportItem):
     section_title: Union[str, None]
     headers: Union[list[str], None] = None
     type_name: Literal["Table"] = Field("Table", frozen=True)
+    select_indices: Optional[List[NonNegativeInt]] = None
     formatter: Optional[Union[str, List[Union[str, None]]]] = None
-    settings: Optional[TableSettings] = TableSettings()
 
     @model_validator(mode="before")
     @classmethod
@@ -357,9 +342,7 @@ class Table(ReportItem):
         rows = []
         for idx, case in enumerate(context.cases):
             # pylint: disable=unsupported-membership-test
-            if self.settings.case_include and idx not in self.settings.case_include:
-                continue
-            if self.settings.case_exclude and idx in self.settings.case_exclude:
+            if self.select_indices and idx not in self.select_indices:
                 continue
             raw_values = []
             for path in self.data:

--- a/flow360/plugins/report/utils.py
+++ b/flow360/plugins/report/utils.py
@@ -580,6 +580,9 @@ class DataItem(Flow360BaseModel):
     title : str, optional
         A human-readable title for this data item. If omitted, the title defaults to the
         last component of the `data` path.
+    include : list[str], optional
+        A list of boundaries to include in the retrieved data (e.g., certain surfaces). Only
+        applicable to some data types, such as surface forces or slicing force distributions.
     exclude : list[str], optional
         A list of boundaries to exclude from the retrieved data (e.g., certain surfaces). Only
         applicable to some data types, such as surface forces or slicing force distributions.

--- a/flow360/plugins/report/utils.py
+++ b/flow360/plugins/report/utils.py
@@ -383,7 +383,6 @@ class Average(GenericOperation):
     start_time: Optional[pd.NonNegativeFloat] = None
     end_time: Optional[pd.NonNegativeFloat] = None
     fraction: Optional[pd.PositiveFloat] = pd.Field(None, le=1)
-    output_bool: pd.StrictBool = pd.Field(False)
     type_name: Literal["Average"] = pd.Field("Average", frozen=True)
 
     model_config = pd.ConfigDict(
@@ -408,8 +407,6 @@ class Average(GenericOperation):
             if self.fraction is None:
                 raise NotImplementedError('Only "fraction" average method implemented.')
             averages = data.get_averages(average_fraction=self.fraction)
-            if self.output_bool:
-                averages = averages.astype(bool)
             return data, cases, averages
 
         raise NotImplementedError(

--- a/flow360/plugins/report/utils.py
+++ b/flow360/plugins/report/utils.py
@@ -52,6 +52,7 @@ class RequirementItem(pd.BaseModel):
 # pylint: disable=protected-access
 _requirements_mapping = {
     "params": RequirementItem(filename="simulation.json"),
+    "cfl": RequirementItem(filename=case_results.CFLResultCSVModel()._remote_path()),
     "total_forces": RequirementItem(
         filename=case_results.TotalForcesResultCSVModel()._remote_path()
     ),

--- a/flow360/plugins/report/utils.py
+++ b/flow360/plugins/report/utils.py
@@ -57,6 +57,9 @@ _requirements_mapping = {
     "surface_forces": RequirementItem(
         filename=case_results.SurfaceForcesResultCSVModel()._remote_path()
     ),
+    "linear_residuals": RequirementItem(
+        filename=case_results.LinearResidualsResultCSVModel()._remote_path()
+    ),
     "nonlinear_residuals": RequirementItem(
         filename=case_results.NonlinearResidualsResultCSVModel()._remote_path()
     ),

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -228,19 +228,16 @@ def test_x_sectional_results(mock_id, mock_response):
     assert set(cd_curve.values.keys()) == set(all_headers_both_wings)
     assert cd_curve.as_dataframe().shape[0] == 168
 
-    cd_curve.reload_data()
     cd_curve.filter(exclude="*fuselage*")
     assert cd_curve.as_dataframe().iloc[-1]["totalCumulative_CD_Curve"] == cd_on_both_wings
     assert set(cd_curve.values.keys()) == set(all_headers_both_wings)
     assert cd_curve.as_dataframe().shape[0] == 168
 
     cd_on_fuselage = 0.0043524438673826
-    cd_curve.reload_data()
     cd_curve.filter(include="*fuselage*")
     assert cd_curve.as_dataframe().iloc[-1]["totalCumulative_CD_Curve"] == cd_on_fuselage
     assert cd_curve.as_dataframe().shape[0] == 300
 
-    cd_curve.reload_data()
     cd_curve.filter(include=["blk-1/leftWing", "blk-1/rightWing"])
     assert cd_curve.as_dataframe().iloc[-1]["totalCumulative_CD_Curve"] == cd_on_both_wings
 
@@ -253,7 +250,6 @@ def test_x_sectional_results(mock_id, mock_response):
     assert set(cd_curve.values.keys()) == set(all_headers_both_wings)
     assert cd_curve.as_dataframe().shape[0] == 168
 
-    cd_curve.reload_data()
     cd_curve.filter(exclude=["blk-1/leftWing", "blk-1/rightWing"])
     assert cd_curve.as_dataframe().iloc[-1]["totalCumulative_CD_Curve"] == cd_on_fuselage
     assert cd_curve.as_dataframe().shape[0] == 300
@@ -292,7 +288,18 @@ def test_y_sectional_results(mock_id, mock_response):
     assert set(y_slicing.values.keys()) == set(all_headers)
     assert y_slicing.as_dataframe().shape[0] == 280
 
-    y_slicing.reload_data()
+    # make sure the data excluded in the previous filter operation can still be retrieved
+    y_slicing.filter(include="*fuselage*")
+    assert y_slicing.as_dataframe().iloc[-1]["totalCFz_per_span"] == 1.436235385808551646e-01
+
+    boundaries = ["fluid/fuselage"]
+    all_headers = (
+        [f"{prefix}_{postfix}" for prefix, postfix in product(boundaries, variables)]
+        + x_columns
+        + total
+    )
+    assert set(y_slicing.values.keys()) == set(all_headers)
+
     y_slicing.filter(exclude="*fuselage*")
     assert y_slicing.as_dataframe().iloc[-1]["totalCFx_per_span"] == 0.0004722955787145
 
@@ -305,7 +312,6 @@ def test_y_sectional_results(mock_id, mock_response):
     assert set(y_slicing.values.keys()) == set(all_headers)
     assert y_slicing.as_dataframe().shape[0] == 280
 
-    y_slicing.reload_data()
     y_slicing.filter(include="*fuselage*")
     assert y_slicing.as_dataframe().iloc[-1]["totalCFx_per_span"] == 0.0010109367119019
 
@@ -318,7 +324,6 @@ def test_y_sectional_results(mock_id, mock_response):
     assert set(y_slicing.values.keys()) == set(all_headers)
     assert y_slicing.as_dataframe().shape[0] == 28
 
-    y_slicing.reload_data()
     y_slicing.filter(include=["blk-1/leftWing", "blk-1/rightWing"])
     assert y_slicing.as_dataframe().iloc[-1]["totalCFx_per_span"] == 0.0004722955787145
 
@@ -331,7 +336,6 @@ def test_y_sectional_results(mock_id, mock_response):
     assert set(y_slicing.values.keys()) == set(all_headers)
     assert y_slicing.as_dataframe().shape[0] == 280
 
-    y_slicing.reload_data()
     y_slicing.filter(include=["blk-1/leftWing"])
     assert y_slicing.as_dataframe().iloc[-1]["totalCFx_per_span"] == 0.000145645121735
 

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -290,9 +290,9 @@ def test_y_sectional_results(mock_id, mock_response):
 
     # make sure the data excluded in the previous filter operation can still be retrieved
     y_slicing.filter(include="*fuselage*")
-    assert y_slicing.as_dataframe().iloc[-1]["totalCFz_per_span"] == 1.436235385808551646e-01
+    assert y_slicing.as_dataframe().iloc[-1]["totalCFz_per_span"] == -0.0015624292568078
 
-    boundaries = ["fluid/fuselage"]
+    boundaries = ["blk-1/fuselage"]
     all_headers = (
         [f"{prefix}_{postfix}" for prefix, postfix in product(boundaries, variables)]
         + x_columns


### PR DESCRIPTION
- [x] Add linear residual result
- [x] Add `include` option to the `Chart2D` and `DataItem` class
- [x] Improve get_variables function in the `Expression` class to also filter math functions (such as `abs`, `where`) in the expression.
- [x] Fix the data filter in the PerEntityResultsCSVModel
- [x] Add TableSettings Class for selecting certain cases to show in the table.
- [x] ~Add `output_bool` option in the Average operation to output the boolean result after averaging.~ Add "bool" formatter to convert the output integer to boolean type result