### PR TITLE
changed omega dimensionalization for bet converter

### DIFF
--- a/examples/migration_guide/example_bet_conversion.py
+++ b/examples/migration_guide/example_bet_conversion.py
@@ -1,5 +1,7 @@
 import os
 
+import flow360 as fl
+
 from flow360.component.simulation.migration import BETDisk
 from flow360.component.simulation.unit_system import u
 
@@ -8,14 +10,22 @@ script_dir = os.path.dirname(os.path.abspath(__file__))
 # Change the current working directory to the script directory
 os.chdir(script_dir)
 
+with fl.SI_unit_system:
+    params = fl.SimulationParams(
+        operating_condition=fl.AerospaceCondition(
+            velocity_magnitude=10
+        )
+    )
+
 my_BETDisk = BETDisk.read_single_v1_BETDisk(
     file_path="./BET_tutorial_Flow360.json",
     mesh_unit=u.m,
-    time_unit=u.s,
+    freestream_temperature=params.operating_condition.thermal_state.temperature
 )
 
-print(my_BETDisk)
+print(my_BETDisk.omega)
 
+# Converted BETDisk can be used in a simulation
 """
 with SI_unit_system:
     params = fl.SimulationParams(
@@ -27,4 +37,11 @@ with SI_unit_system:
         ]
         ...
     )
+"""
+
+# After creating params, changing the value of omega can be done by doing the following
+"""
+params.models[X].omega = 500 * fl.u.rpm
+
+where X is an int specifying chosen BETDisk's position in the list of models
 """

--- a/examples/migration_guide/example_bet_conversion.py
+++ b/examples/migration_guide/example_bet_conversion.py
@@ -1,7 +1,6 @@
 import os
 
 import flow360 as fl
-
 from flow360.component.simulation.migration import BETDisk
 from flow360.component.simulation.unit_system import u
 
@@ -11,19 +10,15 @@ script_dir = os.path.dirname(os.path.abspath(__file__))
 os.chdir(script_dir)
 
 with fl.SI_unit_system:
-    params = fl.SimulationParams(
-        operating_condition=fl.AerospaceCondition(
-            velocity_magnitude=10
-        )
-    )
+    params = fl.SimulationParams(operating_condition=fl.AerospaceCondition(velocity_magnitude=10))
 
 my_BETDisk = BETDisk.read_single_v1_BETDisk(
     file_path="./BET_tutorial_Flow360.json",
     mesh_unit=u.m,
-    freestream_temperature=params.operating_condition.thermal_state.temperature
+    freestream_temperature=params.operating_condition.thermal_state.temperature,
 )
 
-print(my_BETDisk.omega)
+print(my_BETDisk)
 
 # Converted BETDisk can be used in a simulation
 """
@@ -42,6 +37,5 @@ with SI_unit_system:
 # After creating params, changing the value of omega can be done by doing the following
 """
 params.models[X].omega = 500 * fl.u.rpm
-
-where X is an int specifying chosen BETDisk's position in the list of models
 """
+# where X is an int specifying chosen BETDisk's position in the list of models

--- a/flow360/component/simulation/migration/BETDisk.py
+++ b/flow360/component/simulation/migration/BETDisk.py
@@ -113,7 +113,7 @@ def _parse_flow360_bet_disk_dict(
     )
 
     log.info("Provided temperature was used to calculate the value of omega in rad/s.")
-    log.info("Omega can be manually changed to a desired value and unit.")
+    log.info("You can print and correct the value and unit of `Omega` afterwards if needed.")
 
     updated_bet_dict["chord_ref"] = updated_bet_dict["chord_ref"] * mesh_unit
     updated_bet_dict["sectional_radiuses"] = updated_bet_dict["sectional_radiuses"] * mesh_unit

--- a/flow360/component/simulation/migration/BETDisk.py
+++ b/flow360/component/simulation/migration/BETDisk.py
@@ -11,7 +11,7 @@ from pydantic import validate_call
 import flow360.component.simulation.units as u
 from flow360.component.simulation.models.volume_models import BETDisk
 from flow360.component.simulation.primitives import Cylinder
-from flow360.component.simulation.unit_system import LengthType, AbsoluteTemperatureType
+from flow360.component.simulation.unit_system import AbsoluteTemperatureType, LengthType
 from flow360.log import log
 
 
@@ -134,7 +134,7 @@ def _load_flow360_json(*, file_path: str) -> dict:
 def read_single_v1_BETDisk(
     file_path: str,
     mesh_unit: LengthType.NonNegative,  # pylint: disable = no-member
-    freestream_temperature: AbsoluteTemperatureType
+    freestream_temperature: AbsoluteTemperatureType,
 ) -> BETDisk:
     """
     Constructs a single :class: `BETDisk` instance from a given V1 (legacy) Flow360 input.

--- a/flow360/component/simulation/migration/BETDisk.py
+++ b/flow360/component/simulation/migration/BETDisk.py
@@ -37,7 +37,7 @@ def _parse_flow360_bet_disk_dict(
         flow360_bet_disk_dict = flow360_bet_disk_dict["BETDisks"][0]
 
     specific_heat_ratio = 1.4
-    gas_constant = 287.0529 * u.m**2 / u.s**2 / u.K
+    gas_constant = 287.0529 * u.m**2 / u.s**2 / u.K # pylint: disable=no-member
     speed_of_sound = sqrt(specific_heat_ratio * gas_constant * freestream_temperature.to("K"))
     time_unit = mesh_unit / speed_of_sound
 

--- a/flow360/component/simulation/migration/BETDisk.py
+++ b/flow360/component/simulation/migration/BETDisk.py
@@ -37,7 +37,7 @@ def _parse_flow360_bet_disk_dict(
         flow360_bet_disk_dict = flow360_bet_disk_dict["BETDisks"][0]
 
     specific_heat_ratio = 1.4
-    gas_constant = 287.0529 * u.m**2 / u.s**2 / u.K # pylint: disable=no-member
+    gas_constant = 287.0529 * u.m**2 / u.s**2 / u.K  # pylint: disable=no-member
     speed_of_sound = sqrt(specific_heat_ratio * gas_constant * freestream_temperature.to("K"))
     time_unit = mesh_unit / speed_of_sound
 

--- a/tests/simulation/converter/ref/ref_single_bet_disk.json
+++ b/tests/simulation/converter/ref/ref_single_bet_disk.json
@@ -446,7 +446,6 @@
                 },
                 "private_attribute_entity_type_name": "Cylinder",
                 "private_attribute_full_name": null,
-                "private_attribute_id": "ace1caa3-4117-4f21-82bf-2aa8e1200b48",
                 "private_attribute_registry_bucket_name": "VolumetricEntityType",
                 "private_attribute_zone_boundary_names": {
                     "items": []
@@ -463,7 +462,7 @@
     "number_of_blades": 3,
     "omega": {
         "units": "rad/s",
-        "value": 0.0023
+        "value": 156.5352426717779
     },
     "private_attribute_constructor": "default",
     "private_attribute_input_cache": {
@@ -4980,5 +4979,5 @@
         }
     ],
     "type": "BETDisk",
-    "type_name": "MultiConstructorBaseModel"
+    "type_name": "BETDisk"
 }

--- a/tests/simulation/converter/test_bet_disk_flow360_converter.py
+++ b/tests/simulation/converter/test_bet_disk_flow360_converter.py
@@ -19,16 +19,23 @@ def change_test_dir(request, monkeypatch):
     monkeypatch.chdir(request.fspath.dirname)
 
 
-def test_single_flow360_bet_convert():
+def test_single_flow360_bet_convert(atol=1e-15, rtol=1e-10, debug=False):
     disk = read_single_v1_BETDisk(
         file_path="./data/single_flow360_bet_disk.json",
         mesh_unit=1 * u.cm,
-        time_unit=2 * u.s,
+        freestream_temperature=288.15 * u.K,
     )
     assert isinstance(disk, BETDisk)
+    disk = disk.model_dump_json()
+    disk = json.loads(disk)
+    del disk["entities"]["stored_entities"][0]["private_attribute_id"]
     with open("./ref/ref_single_bet_disk.json", mode="r") as fp:
         ref_dict = json.load(fp=fp)
-    compare_values(disk.model_dump(), ref_dict)
+    if debug:
+        print(">>> disk = ", disk)
+        print("=== disk ===\n", json.dumps(disk, indent=4, sort_keys=True))
+        print("=== ref_dict ===\n", json.dumps(ref_dict, indent=4, sort_keys=True))
+    assert compare_values(ref_dict, disk, atol=atol, rtol=rtol)
 
     with pytest.raises(
         ValueError,
@@ -38,7 +45,7 @@ def test_single_flow360_bet_convert():
         disk = read_single_v1_BETDisk(
             file_path="./data/full_flow360.json",
             mesh_unit=1 * u.cm,
-            time_unit=2 * u.s,
+            freestream_temperature=288.15 * u.K,
         )
     with pytest.raises(
         ValueError,
@@ -54,9 +61,7 @@ def test_single_flow360_bet_convert():
 
         try:
             read_single_v1_BETDisk(
-                file_path=temp_file_name,
-                mesh_unit=1 * u.cm,
-                time_unit=2 * u.s,
+                file_path=temp_file_name, mesh_unit=1 * u.cm, freestream_temperature=288.15 * u.K
             )
         finally:
             os.remove(temp_file_name)
@@ -67,7 +72,7 @@ def test_full_flow360_bet_convert():
     list_of_disks = read_all_v1_BETDisks(
         file_path="./data/full_flow360.json",
         mesh_unit=1 * u.cm,
-        time_unit=2 * u.s,
+        freestream_temperature=288.15 * u.K,
     )
 
     assert isinstance(list_of_disks, list)
@@ -82,5 +87,5 @@ def test_full_flow360_bet_convert():
         read_all_v1_BETDisks(
             file_path="./data/single_flow360_bet_disk.json",
             mesh_unit=1 * u.cm,
-            time_unit=2 * u.s,
+            freestream_temperature=288.15 * u.K,
         )


### PR DESCRIPTION
instead of time_unit as an input, now freestream_temperature is needed

fixed the unittest for bet converter as it was not working properly

for the example conversion the calculated value of omega is now very close to reference value from the tutorial
Tutorial states 460 RPM, calculated = 460.5687478679744 RPM but it most likely comes from simplifications made in the calculation of non-dimensional omega in the documentation