### PR TITLE
[HOTFIX] fix(): SurfaceMeshEntityInfo had wrong boundaries implementation (#765)

### DIFF
--- a/flow360/component/simulation/entity_info.py
+++ b/flow360/component/simulation/entity_info.py
@@ -1,4 +1,4 @@
-"""Desearlizer for entity info retrieved from asset metadata pipeline."""
+"""Deserializer for entity info retrieved from asset metadata pipeline."""
 
 from abc import ABCMeta, abstractmethod
 from typing import Annotated, List, Literal, Optional, Union
@@ -49,10 +49,11 @@ class EntityInfoModel(pd.BaseModel, metaclass=ABCMeta):
     ghost_entities: List[GhostSurfaceTypes] = pd.Field([])
 
     @abstractmethod
-    def get_boundaries(self, attribute_name: str = None) -> list:
+    def get_boundaries(self, attribute_name: str = None) -> list[Surface]:
         """
         Helper function.
-        Get the full list of boundary names. If it is geometry then use supplied attribute name to get the list.
+        Get the full list of boundary.
+        If it is geometry then use supplied attribute name to get the list.
         """
 
 
@@ -148,7 +149,7 @@ class GeometryEntityInfo(EntityInfoModel):
             f" in geometry metadata. Available: {entity_attribute_names}"
         )
 
-    def get_boundaries(self, attribute_name: str = None) -> list:
+    def get_boundaries(self, attribute_name: str = None) -> list[Surface]:
         """
         Get the full list of boundaries.
         If attribute_name is supplied then ignore stored face_group_tag and use supplied one.
@@ -166,7 +167,7 @@ class VolumeMeshEntityInfo(EntityInfoModel):
     @pd.field_validator("boundaries", mode="after")
     @classmethod
     def check_all_surface_has_interface_indicator(cls, value):
-        """private_attribute_is_interface should have been set comming from volume mesh."""
+        """private_attribute_is_interface should have been set coming from volume mesh."""
         for item in value:
             if item.private_attribute_is_interface is None:
                 raise ValueError(
@@ -177,7 +178,7 @@ class VolumeMeshEntityInfo(EntityInfoModel):
     # pylint: disable=arguments-differ
     def get_boundaries(self) -> list:
         """
-        Get the full list of boundary names. If it is geometry then use supplied attribute name to get the list.
+        Get the full list of boundary.
         """
         # pylint: disable=not-an-iterable
         return [item for item in self.boundaries if item.private_attribute_is_interface is False]
@@ -193,10 +194,10 @@ class SurfaceMeshEntityInfo(EntityInfoModel):
     # pylint: disable=arguments-differ
     def get_boundaries(self) -> list:
         """
-        Get the full list of boundary names.
+        Get the full list of boundary.
         """
         # pylint: disable=not-an-iterable
-        return [item.name for item in self.boundaries]
+        return self.boundaries
 
 
 EntityInfoUnion = Annotated[

--- a/flow360/component/simulation/framework/param_utils.py
+++ b/flow360/component/simulation/framework/param_utils.py
@@ -35,7 +35,7 @@ class AssetCache(Flow360BaseModel):
     @property
     def boundaries(self):
         """
-        Get all boundaries from the cached entity info.
+        Get all boundaries (not just names) from the cached entity info.
         """
         if self.project_entity_info is None:
             return None


### PR DESCRIPTION
* fix(): SurfaceMeshEntityInfo had wrong boundaries implementation

* IMprove the error message

* Fix typo