### PR TITLE
Fix unit conversion performance issues in model preprocessing for solver

### DIFF
--- a/flow360/component/simulation/framework/entity_base.py
+++ b/flow360/component/simulation/framework/entity_base.py
@@ -12,7 +12,6 @@ import numpy as np
 import pydantic as pd
 import unyt
 
-from flow360.component.simulation.conversion import need_conversion, unit_converter
 from flow360.component.simulation.framework.base_model import Flow360BaseModel
 from flow360.component.simulation.utils import is_exact_instance
 
@@ -481,70 +480,6 @@ class EntityList(Flow360BaseModel, metaclass=_EntityListMeta):
             return copy.deepcopy(expanded_entities)
         return expanded_entities
 
-    # pylint: disable=too-many-locals
-    def _batch_preprocess(self, **kwargs):
-        """
-        Batch preprocesses properties for all child entities that need processing.
-
-        Inspects each attribute of every stored entity. For attributes that need conversion
-        (as determined by conversion.need_conversion), it groups values by attribute name.
-
-        - If the value's underlying array is not already 2D (i.e. not a true batched array),
-        the value is grouped for batch processing.
-        - If the value is already a 2D array, it is marked for direct (traditional) conversion.
-
-        For batch groups, the underlying data of each unyt_array is converted to a common unit,
-        stacked into a single unyt_array, and then processed in one vectorized call.
-
-        For directly converted values, the conversion is applied individually.
-        """
-        stored_entities = self.stored_entities
-        groups = {}
-        direct = {}
-
-        for idx, entity in enumerate(stored_entities):
-            for attr, value in entity.__dict__.items():
-                if need_conversion(value):
-                    if getattr(value, "ndim", 1) == 2:
-                        direct.setdefault(attr, []).append(idx)
-                    else:
-                        groups.setdefault(attr, {"indices": [], "values": []})
-                        groups[attr]["indices"].append(idx)
-                        groups[attr]["values"].append(value)
-
-        for attr, data in groups.items():
-            group_values = data["values"]
-            ref_unit = group_values[0].units
-            converted = np.empty((len(group_values), group_values[0].size))
-            for i, val in enumerate(group_values):
-                converted[i] = val.to(ref_unit).v
-            data["values"] = unyt.unyt_array(converted, ref_unit)
-
-        params = kwargs.get("params")
-        required_by = kwargs.get("required_by", [])
-
-        new_entities = [entity.__dict__.copy() for entity in stored_entities]
-
-        for attr, data in groups.items():
-            flow360_conv_system = unit_converter(
-                data["values"].units.dimensions,
-                params=params,
-                required_by=[*required_by, attr],
-            )
-            # pylint: disable=no-member
-            data["values"].units.registry = flow360_conv_system.registry
-            processed_array = data["values"].in_base(unit_system="flow360_v2")
-
-            for idx, processed_val in zip(data["indices"], processed_array):
-                new_entities[idx][attr] = processed_val
-
-        for attr, indices in direct.items():
-            for idx in indices:
-                new_entities[idx] = stored_entities[idx].preprocess(**kwargs)
-
-        solver_values = {"stored_entities": new_entities}
-        return solver_values
-
     # pylint: disable=arguments-differ
     def preprocess(self, **kwargs):
         """
@@ -553,4 +488,4 @@ class EntityList(Flow360BaseModel, metaclass=_EntityListMeta):
         """
         # WARNING: this is very expensive all for long lists as it is quadratic
         self.stored_entities = self._get_expanded_entities(create_hard_copy=False)
-        return self._batch_preprocess(**kwargs)
+        return super().preprocess(**kwargs)


### PR DESCRIPTION
We were getting high runtimes for relatively small point group sizes so I investigated and narrowed most of the performance hit down to the getter for the unit converter. For every base model with dimensioned values we'd be calling the conversion system getter even if a certain dimension has already been registered for the current params. By caching the already processed dimensions and the registry itself I was able to bring down the runtime to for 1000 elements from approximately 8 seconds to approximately 0.2 seconds.

There is still room for improvement I think - we could swap recursive calls to preprocess for a stack + for loop and optimize the unit conversion logic, but for most use cases it seems acceptable. It seemed to display pretty consistent linear scaling during testing:

1000 points = ~ 0.2s
10000 points = ~ 2.0s
100000 points = ~ 16.0s