### PR TITLE
[Hotfix RC-24.11][SCFD-4271] Cleanup redundant keys in the json file in the constructor of SimulationParams

### DIFF
--- a/flow360/component/simulation/framework/base_model.py
+++ b/flow360/component/simulation/framework/base_model.py
@@ -404,29 +404,6 @@ class Flow360BaseModel(pd.BaseModel):
         raise Flow360FileError(f"File must be .json, or .yaml, type, given {filename}")
 
     @classmethod
-    def _from_json(cls, filename: str, **parse_obj_kwargs) -> Flow360BaseModel:
-        """Load a :class:`Flow360BaseModel` from .json file.
-
-        Parameters
-        ----------
-        filename : str
-            Full path to the .json file to load the :class:`Flow360BaseModel` from.
-
-        Returns
-        -------
-        :class:`Flow360BaseModel`
-            An instance of the component class calling `load`.
-        **parse_obj_kwargs
-            Keyword arguments passed to pydantic's ``parse_obj`` method.
-
-        Example
-        -------
-        >>> params = Flow360BaseModel._from_json(filename='folder/flow360.json') # doctest: +SKIP
-        """
-        model_dict = cls._dict_from_file(filename=filename)
-        return cls.model_validate(model_dict, **parse_obj_kwargs)
-
-    @classmethod
     def _dict_from_json(cls, filename: str) -> dict:
         """Load dictionary of the model from a .json file.
 
@@ -466,29 +443,6 @@ class Flow360BaseModel(pd.BaseModel):
             model_dict["hash"] = self._calculate_hash(model_dict)
         with open(filename, "w+", encoding="utf-8") as file_handle:
             json.dump(model_dict, file_handle, indent=4, sort_keys=True)
-
-    @classmethod
-    def _from_yaml(cls, filename: str, **parse_obj_kwargs) -> Flow360BaseModel:
-        """Loads :class:`Flow360BaseModel` from .yaml file.
-
-        Parameters
-        ----------
-        filename : str
-            Full path to the .yaml file to load the :class:`Flow360BaseModel` from.
-        **parse_obj_kwargs
-            Keyword arguments passed to pydantic's ``parse_obj`` method.
-
-        Returns
-        -------
-        :class:`Flow360BaseModel`
-            An instance of the component class calling `from_yaml`.
-
-        Example
-        -------
-        >>> params = Flow360BaseModel._from_yaml(filename='folder/flow360.yaml') # doctest: +SKIP
-        """
-        model_dict = cls._dict_from_file(filename=filename)
-        return cls.model_validate(model_dict, **parse_obj_kwargs)
 
     @classmethod
     def _dict_from_yaml(cls, filename: str) -> dict:

--- a/flow360/component/simulation/services.py
+++ b/flow360/component/simulation/services.py
@@ -56,7 +56,6 @@ from flow360.component.simulation.validation.validation_context import (
     ParamsValidationInfo,
     ValidationContext,
 )
-from flow360.component.utils import remove_properties_by_name
 from flow360.exceptions import Flow360TranslationError
 
 unit_system_map = {
@@ -266,7 +265,8 @@ def validate_model(
     validation_warnings = None
     validated_param = None
 
-    params_as_dict = clean_params_dict(params_as_dict, root_item_type)
+    params_as_dict = clean_unrelated_setting_from_params_dict(params_as_dict, root_item_type)
+
     # The final validation levels will be the intersection of the requested levels and the levels available
     # We always assume we want to run case so that we can expose as many errors as possible
     available_levels = _determine_validation_level(up_to="Case", root_item_type=root_item_type)
@@ -290,9 +290,10 @@ def validate_model(
     return validated_param, validation_errors, validation_warnings
 
 
-def clean_params_dict(params: dict, root_item_type: str) -> dict:
+def clean_unrelated_setting_from_params_dict(params: dict, root_item_type: str) -> dict:
     """
-    Cleans the parameters dictionary by removing unwanted properties.
+    Cleans the parameters dictionary by removing properties if they do not affect the remaining workflow.
+
 
     Parameters
     ----------
@@ -306,8 +307,6 @@ def clean_params_dict(params: dict, root_item_type: str) -> dict:
     dict
         The cleaned parameters dictionary.
     """
-    params = remove_properties_by_name(params, "_id")
-    params = remove_properties_by_name(params, "hash")  # From client
 
     if root_item_type == "VolumeMesh":
         params.pop("meshing", None)

--- a/flow360/component/simulation/simulation_params.py
+++ b/flow360/component/simulation/simulation_params.py
@@ -139,7 +139,6 @@ class _ParamModelBase(Flow360BaseModel):
             )
         return model_dict
 
-
     @classmethod
     def _sanitize_params_dict(cls, model_dict):
         """

--- a/flow360/component/simulation/simulation_params.py
+++ b/flow360/component/simulation/simulation_params.py
@@ -172,6 +172,7 @@ class _ParamModelBase(Flow360BaseModel):
         """
         Initializes the simulation parameters with the given unit context.
         """
+        kwargs = self._handle_dict(**kwargs)
         kwargs = self._init_check_unit_system(**kwargs)
         super().__init__(unit_system=unit_system_manager.current, **kwargs)
 

--- a/flow360/component/simulation/simulation_params.py
+++ b/flow360/component/simulation/simulation_params.py
@@ -73,6 +73,7 @@ from flow360.component.simulation.validation.validation_simulation_params import
     _check_parent_volume_is_rotating,
     _check_time_average_output,
 )
+from flow360.component.utils import remove_properties_by_name
 from flow360.error_messages import (
     unit_system_inconsistent_msg,
     use_unit_system_for_simulation_msg,
@@ -138,6 +139,15 @@ class _ParamModelBase(Flow360BaseModel):
             )
         return model_dict
 
+
+    @classmethod
+    def _sanitize_params_dict(cls, model_dict):
+        """
+        Clean the redundant content in the params dict from WebUI
+        """
+        model_dict = remove_properties_by_name(model_dict, "_id")
+        return model_dict
+
     def _init_no_context(self, filename, **kwargs):
         """
         Initialize the simulation parameters without a unit context.
@@ -149,6 +159,8 @@ class _ParamModelBase(Flow360BaseModel):
             )
 
         model_dict = self._handle_file(filename=filename, **kwargs)
+
+        model_dict = _ParamModelBase._sanitize_params_dict(model_dict)
         # When treating files/file like contents the updater will always be run.
         model_dict = _ParamModelBase._update_param_dict(model_dict)
 

--- a/tests/data/case-f7480884-4493-4453-9a27-dd5f8498c608/simulation.json
+++ b/tests/data/case-f7480884-4493-4453-9a27-dd5f8498c608/simulation.json
@@ -1,4 +1,5 @@
 {
+    "hash": "59cebdad13daabd9f3fbfec61683efc899754eba5522638012943f6b7f283e13",
     "meshing": null,
     "models": [
         {

--- a/tests/data/case-f7480884-4493-4453-9a27-dd5f8498c608/simulation.json
+++ b/tests/data/case-f7480884-4493-4453-9a27-dd5f8498c608/simulation.json
@@ -1,5 +1,4 @@
 {
-    "hash": "59cebdad13daabd9f3fbfec61683efc899754eba5522638012943f6b7f283e13",
     "meshing": null,
     "models": [
         {

--- a/tests/simulation/framework/test_base_model_v2.py
+++ b/tests/simulation/framework/test_base_model_v2.py
@@ -156,49 +156,6 @@ def test_to_file():
         os.remove(temp_file_name)
 
 
-def test_from_json_yaml():
-    file_content = {
-        "some_value": 3210,
-        "hash": "e6d346f112fc2ba998a286f9736ce389abb79f154dc84a104d3b4eb8ba4d4529",
-    }
-
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as temp_file:
-        json.dump(file_content, temp_file)
-        temp_file.flush()
-        temp_file_name = temp_file.name
-
-    try:
-        base_model = BaseModelTestModel._from_json(temp_file_name)
-        assert base_model.some_value == 3210
-    finally:
-        os.remove(temp_file_name)
-
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as temp_file:
-        yaml.dump(file_content, temp_file)
-        temp_file.flush()
-        temp_file_name = temp_file.name
-
-    try:
-        base_model = BaseModelTestModel._from_yaml(temp_file_name)
-        assert base_model.some_value == 3210
-    finally:
-        os.remove(temp_file_name)
-
-    file_content = {"some_value": "43210", "hash": "aasdasd"}
-
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as temp_file:
-        json.dump(file_content, temp_file)
-        temp_file.flush()
-        temp_file_name = temp_file.name
-
-    print(json.dumps(file_content, indent=4))
-    try:
-        with pytest.raises(pd.ValidationError, match=r" Input should be a valid number"):
-            base_model = BaseModelTestModel._from_json(temp_file_name)
-    finally:
-        os.remove(temp_file_name)
-
-
 def test_preprocess():
     value = 123
     test_params = TempParams(pseudo_field=BaseModelTestModel(some_value=value), some_value=value)


### PR DESCRIPTION
Remove _from_json and _from_yaml in the base_model

Divide clean_params_dict into two parts:

clean redundant keys from webUI json
clean unnecessary keys based on the validation level
Address comments

Address comments