### PR TITLE
Fix local report generation on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Environment ``FLOW360_APIKEY`` variable takes precedence before Flow360 configur
 ## setup
 0. clone repo
 1. Install poetry ``pip install poetry``
-2. Activate poetry shell ``poetry shell``
+2. Activate poetry shell ``poetry env activate``
 3. Install dependencies: ``poetry install``
 
 ## run examples

--- a/flow360/plugins/report/report_doc.py
+++ b/flow360/plugins/report/report_doc.py
@@ -192,7 +192,7 @@ class ReportDoc:
                         image_options="height=25pt",
                         filename=posixpath.join(
                             os.path.dirname(__file__), "img", "cover_logo.pdf"
-                            ).replace("\\", "/"),
+                        ).replace("\\", "/"),
                     )
                 )
         doc.preamble.append(page_style)

--- a/flow360/plugins/report/report_doc.py
+++ b/flow360/plugins/report/report_doc.py
@@ -168,9 +168,9 @@ class ReportDoc:
                     logo1.append(
                         StandAloneGraphic(
                             image_options="height=18pt",
-                            filename=os.path.join(
+                            filename=posixpath.join(
                                 os.path.dirname(__file__), "img", "flow360_logo_grey.pdf"
-                            ),
+                            ).replace("\\", "/"),
                         )
                     )
 
@@ -190,7 +190,9 @@ class ReportDoc:
                 footer_content.append(
                     StandAloneGraphic(
                         image_options="height=25pt",
-                        filename=os.path.join(os.path.dirname(__file__), "img", "cover_logo.pdf"),
+                        filename=posixpath.join(
+                            os.path.dirname(__file__), "img", "cover_logo.pdf"
+                            ).replace("\\", "/"),
                     )
                 )
         doc.preamble.append(page_style)

--- a/flow360/plugins/report/utils.py
+++ b/flow360/plugins/report/utils.py
@@ -893,7 +893,7 @@ def generate_colorbar_from_image(
     plt.close(fig)
 
 
-font_path = posixpath.join(here, "fonts/")
+font_path = posixpath.join(here, "fonts/").replace("\\", "/")
 font_definition = (
     r"""
 \setmainfont{TWKEverett}[

--- a/tests/report/test_report.py
+++ b/tests/report/test_report.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 import pytest
 
@@ -6,6 +7,7 @@ from flow360 import Case
 from flow360.component.case import CaseMeta
 from flow360.plugins.report.report import Report, ReportDraft, ReportTemplate
 from flow360.plugins.report.report_items import Chart2D, Inputs, Summary, Table
+from flow360.plugins.report.report_doc import ReportDoc
 from flow360.plugins.report.utils import _requirements_mapping
 
 
@@ -133,3 +135,16 @@ def test_reporttemplate_no_items():
     expected_keys = ["volume_mesh", "surface_mesh", "geometry"]
     expected_reqs = {_requirements_mapping[k] for k in expected_keys}
     assert set(reqs) == expected_reqs
+
+@pytest.mark.usefixtures("mock_detect_latex_compiler")
+def test_filepaths_format():
+    report_doc = ReportDoc(title="test_doc")
+    tex = report_doc.doc.dumps()
+    lines = tex.split("\n")
+    for line in lines:
+        line = line.lstrip()
+        if line.startswith(r"\includegraphics"):
+            path_match = re.search(r"\{(.*?)\}", line)
+            if path_match:
+                path: str = path_match.group(1)
+                assert "\\" not in path

--- a/tests/report/test_report.py
+++ b/tests/report/test_report.py
@@ -1,4 +1,3 @@
-import ntpath
 import os
 import re
 
@@ -140,7 +139,6 @@ def test_reporttemplate_no_items():
 
 @pytest.mark.usefixtures("mock_detect_latex_compiler")
 def test_filepaths_format():
-    os.path = ntpath
     report_doc = ReportDoc(title="test_doc")
     tex = report_doc.doc.dumps()
     lines = tex.split("\n")

--- a/tests/report/test_report.py
+++ b/tests/report/test_report.py
@@ -1,5 +1,6 @@
 import os
 import re
+import ntpath
 
 import pytest
 
@@ -138,6 +139,7 @@ def test_reporttemplate_no_items():
 
 @pytest.mark.usefixtures("mock_detect_latex_compiler")
 def test_filepaths_format():
+    os.path = ntpath
     report_doc = ReportDoc(title="test_doc")
     tex = report_doc.doc.dumps()
     lines = tex.split("\n")

--- a/tests/report/test_report.py
+++ b/tests/report/test_report.py
@@ -147,7 +147,7 @@ def test_filepaths_format():
         if line.startswith(r"\includegraphics"):
             path_match = re.search(r"\{(.*?)\}", line)
             if path_match:
-                path: str = path_match.group(1)
+                path = path_match.group(1)
                 assert "\\" not in path
         if line.startswith("Path"):
             assert "\\" not in line

--- a/tests/report/test_report.py
+++ b/tests/report/test_report.py
@@ -150,3 +150,5 @@ def test_filepaths_format():
             if path_match:
                 path: str = path_match.group(1)
                 assert "\\" not in path
+        if line.startswith("Path"):
+            assert "\\" not in line

--- a/tests/report/test_report.py
+++ b/tests/report/test_report.py
@@ -1,14 +1,14 @@
+import ntpath
 import os
 import re
-import ntpath
 
 import pytest
 
 from flow360 import Case
 from flow360.component.case import CaseMeta
 from flow360.plugins.report.report import Report, ReportDraft, ReportTemplate
-from flow360.plugins.report.report_items import Chart2D, Inputs, Summary, Table
 from flow360.plugins.report.report_doc import ReportDoc
+from flow360.plugins.report.report_items import Chart2D, Inputs, Summary, Table
 from flow360.plugins.report.utils import _requirements_mapping
 
 
@@ -136,6 +136,7 @@ def test_reporttemplate_no_items():
     expected_keys = ["volume_mesh", "surface_mesh", "geometry"]
     expected_reqs = {_requirements_mapping[k] for k in expected_keys}
     assert set(reqs) == expected_reqs
+
 
 @pytest.mark.usefixtures("mock_detect_latex_compiler")
 def test_filepaths_format():


### PR DESCRIPTION
Fixed the local report generation error on Windows due to the Windows style paths from os.path interfering with latex syntax.