### PR TITLE
Fix a bug in generating captions for 2D charts

### DIFF
--- a/flow360/plugins/report/report_doc.py
+++ b/flow360/plugins/report/report_doc.py
@@ -100,7 +100,9 @@ class ReportDoc:
                 r"labelsep=none, justification=raggedright, singlelinecheck=false}"
             )
         )
-        doc.preamble.append(NoEscape(r"\captionsetup[subfigure]{labelformat=empty}"))
+        doc.preamble.append(
+            NoEscape(r"\captionsetup[subfigure]{labelformat=empty, justification=centering}")
+        )
 
         if self.use_xelatex:
             doc.preamble.append(NoEscape(font_definition))

--- a/flow360/plugins/report/report_items.py
+++ b/flow360/plugins/report/report_items.py
@@ -1284,8 +1284,12 @@ class Chart2D(Chart):
         """Handle captions for Chart2D."""
 
         if self.caption == "":
-            if self.separate_plots is True:
+            if (self.items_in_row is not None):
+                return f"{bold(y_lab)} against {bold(x_lab)}."
+            elif self.separate_plots is True:
                 return f"{bold(y_lab)} against {bold(x_lab)} for {bold(case.name)}."
+            elif self.select_indices is not None:
+                return f"{bold(y_lab)} against {bold(x_lab)} for {bold('selected cases')}." 
             return f"{bold(y_lab)} against {bold(x_lab)} for {bold('all cases')}."
         if self.separate_plots is True:
             if isinstance(self.caption, List):
@@ -1309,7 +1313,10 @@ class Chart2D(Chart):
 
         if self.items_in_row is not None:
             caption = NoEscape(self._handle_2d_caption(x_lab=x_lab, y_lab=y_lab))
-            self._add_row_figure(context.doc, file_names, caption)
+            self._add_row_figure(context.doc, 
+                                 file_names, 
+                                 caption,
+                                 [case.name for case in cases])
         else:
             if self.separate_plots is True:
                 for case_number, (case, file_name) in enumerate(zip(cases, file_names)):

--- a/flow360/plugins/report/report_items.py
+++ b/flow360/plugins/report/report_items.py
@@ -1284,12 +1284,12 @@ class Chart2D(Chart):
         """Handle captions for Chart2D."""
 
         if self.caption == "":
-            if (self.items_in_row is not None):
+            if self.items_in_row is not None:
                 return f"{bold(y_lab)} against {bold(x_lab)}."
             elif self.separate_plots is True:
                 return f"{bold(y_lab)} against {bold(x_lab)} for {bold(case.name)}."
             elif self.select_indices is not None:
-                return f"{bold(y_lab)} against {bold(x_lab)} for {bold('selected cases')}." 
+                return f"{bold(y_lab)} against {bold(x_lab)} for {bold('selected cases')}."
             return f"{bold(y_lab)} against {bold(x_lab)} for {bold('all cases')}."
         if self.separate_plots is True:
             if isinstance(self.caption, List):
@@ -1313,10 +1313,7 @@ class Chart2D(Chart):
 
         if self.items_in_row is not None:
             caption = NoEscape(self._handle_2d_caption(x_lab=x_lab, y_lab=y_lab))
-            self._add_row_figure(context.doc, 
-                                 file_names, 
-                                 caption,
-                                 [case.name for case in cases])
+            self._add_row_figure(context.doc, file_names, caption, [case.name for case in cases])
         else:
             if self.separate_plots is True:
                 for case_number, (case, file_name) in enumerate(zip(cases, file_names)):

--- a/flow360/plugins/report/report_items.py
+++ b/flow360/plugins/report/report_items.py
@@ -835,7 +835,9 @@ class SubsetLimit(Flow360BaseModel):
 
     @pd.model_validator(mode="after")
     def check_subset_values(self):
-        """Ensure that correct subset values are provided."""
+        """
+        Ensure that correct subset values are provided.
+        """
         lower, upper = self.subset
         if not lower < 1 or not upper <= 1:
             raise ValueError("Subset values need to be between 0 and 1 (inclusive).")
@@ -929,7 +931,7 @@ class Chart2D(Chart):
 
     def get_requirements(self):
         """
-        Returns requirements for this item
+        Returns requirements for this item.
         """
         return get_requirements_from_data_path([self.x, self.y])
 
@@ -951,7 +953,9 @@ class Chart2D(Chart):
     # pylint: disable=unpacking-non-sequence
     @pd.model_validator(mode="after")
     def _handle_deprecated_focus_x(self):
-        """Ensures that scripts containing deprecated focus_x will still work."""
+        """
+        Ensures that scripts containing deprecated focus_x will still work.
+        """
         if self.focus_x is not None:
             if self.ylim is not None:
                 raise ValueError("Fields ylim and focus_x cannot be used together.")
@@ -1249,7 +1253,7 @@ class Chart2D(Chart):
 
     def get_background_chart3d(self, cases) -> Tuple[Chart3D, Case]:
         """
-        returns Chart3D for background
+        Returns Chart3D for background.
         """
         x_data, _, _, _ = self._load_data(cases)
         reference_case = cases[0]
@@ -1278,17 +1282,20 @@ class Chart2D(Chart):
 
         return file_names, data.x_label, data.y_label
 
+    # pylint: disable=too-many-return-statements
     def _handle_2d_caption(
         self, case: Case = None, x_lab: str = None, y_lab: str = None, case_number: int = None
     ):
-        """Handle captions for Chart2D."""
+        """
+        Handle captions for Chart2D.
+        """
 
         if self.caption == "":
             if self.items_in_row is not None:
                 return f"{bold(y_lab)} against {bold(x_lab)}."
-            elif self.separate_plots is True:
+            if self.separate_plots is True:
                 return f"{bold(y_lab)} against {bold(x_lab)} for {bold(case.name)}."
-            elif self.select_indices is not None:
+            if self.select_indices is not None:
                 return f"{bold(y_lab)} against {bold(x_lab)} for {bold('selected cases')}."
             return f"{bold(y_lab)} against {bold(x_lab)} for {bold('all cases')}."
         if self.separate_plots is True:
@@ -1301,7 +1308,7 @@ class Chart2D(Chart):
     # pylint: disable=too-many-arguments,too-many-locals
     def get_doc_item(self, context: ReportContext, settings: Settings = None) -> None:
         """
-        returns doc item for chart
+        Returns doc item for chart.
         """
         self._handle_new_page(context.doc)
         self._handle_grid_input(context.cases)

--- a/tests/report/test_report_items.py
+++ b/tests/report/test_report_items.py
@@ -700,25 +700,20 @@ def test_2d_caption(cases):
     )
 
     chart_selected_cases = Chart2D(
-        x="total_forces/pseudo_step",
-        y="total_forces/CD",
-        select_indices=[1]
+        x="total_forces/pseudo_step", y="total_forces/CD", select_indices=[1]
     )
 
-    assert (chart_selected_cases._handle_2d_caption(x_lab='pseudo_step', y_lab='CD')
+    assert (
+        chart_selected_cases._handle_2d_caption(x_lab="pseudo_step", y_lab="CD")
         == f"{bold('CD')} against {bold('pseudo_step')} for {bold('selected cases')}."
     )
 
-    chart_items_in_row = Chart2D(
-        x="total_forces/pseudo_step",
-        y="total_forces/CD",
-        items_in_row=2
-    )
+    chart_items_in_row = Chart2D(x="total_forces/pseudo_step", y="total_forces/CD", items_in_row=2)
 
-    assert (chart_items_in_row._handle_2d_caption(x_lab='pseudo_step', y_lab='CD')
+    assert (
+        chart_items_in_row._handle_2d_caption(x_lab="pseudo_step", y_lab="CD")
         == f"{bold('CD')} against {bold('pseudo_step')}."
     )
-
 
 
 def test_3d_caption_validity(cases):

--- a/tests/report/test_report_items.py
+++ b/tests/report/test_report_items.py
@@ -3,6 +3,7 @@ import os
 import pandas
 import pytest
 from pylatex import Document
+from pylatex.utils import bold
 
 from flow360 import Case, u
 from flow360.component.case import CaseMeta
@@ -697,6 +698,27 @@ def test_2d_caption(cases):
         chart._handle_2d_caption(case=cases[1])
         == "This is case: case-2222222222-2222-2222-2222-2222222222-name with ID: case-2222222222-2222-2222-2222-2222222222"
     )
+
+    chart_selected_cases = Chart2D(
+        x="total_forces/pseudo_step",
+        y="total_forces/CD",
+        select_indices=[1]
+    )
+
+    assert (chart_selected_cases._handle_2d_caption(x_lab='pseudo_step', y_lab='CD')
+        == f"{bold('CD')} against {bold('pseudo_step')} for {bold('selected cases')}."
+    )
+
+    chart_items_in_row = Chart2D(
+        x="total_forces/pseudo_step",
+        y="total_forces/CD",
+        items_in_row=2
+    )
+
+    assert (chart_items_in_row._handle_2d_caption(x_lab='pseudo_step', y_lab='CD')
+        == f"{bold('CD')} against {bold('pseudo_step')}."
+    )
+
 
 
 def test_3d_caption_validity(cases):


### PR DESCRIPTION
Fixed a bug where report generation crashed when adding a 2D chart with items_in_row parameter, corrected the main caption when specifying selected_indices to be ".... for selected cases" rather than "... for all cases"