### PR TITLE
Fixed vertical page overflow when using items_in_row

### DIFF
--- a/flow360/plugins/report/report_items.py
+++ b/flow360/plugins/report/report_items.py
@@ -603,9 +603,12 @@ class Chart(ReportItem):
         Using Doc manually here may be unnecessary - but it does allow for more control
         """
 
+
         # Smaller than 1 to avoid overflowing
         minipage_size = 0.86 / self.items_in_row if self.items_in_row != 1 else 0.8
-        doc.append(NoEscape(r"\begin{figure}[h!]"))
+
+
+        
 
         if sub_fig_captions is None:
             sub_fig_captions = range(1, len(img_list) + 1)
@@ -641,12 +644,14 @@ class Chart(ReportItem):
         ]
 
         for row_idx in idx_list:
+            doc.append(NoEscape(r"\begin{figure}[h!]"))
             for idx in row_idx:
                 doc.append(figures[idx])
                 doc.append(NoEscape(r"\hfill"))
             doc.append(NoEscape(r"\\"))
-        doc.append(NoEscape(r"\caption{" + escape_latex(fig_caption) + "}"))
-        doc.append(NoEscape(r"\end{figure}"))
+            if row_idx == idx_list[-1]:
+                doc.append(NoEscape(r"\caption{" + escape_latex(fig_caption) + "}"))
+            doc.append(NoEscape(r"\end{figure}"))
 
 
 class PlotModel(BaseModel):

--- a/flow360/plugins/report/report_items.py
+++ b/flow360/plugins/report/report_items.py
@@ -603,12 +603,8 @@ class Chart(ReportItem):
         Using Doc manually here may be unnecessary - but it does allow for more control
         """
 
-
         # Smaller than 1 to avoid overflowing
         minipage_size = 0.86 / self.items_in_row if self.items_in_row != 1 else 0.8
-
-
-        
 
         if sub_fig_captions is None:
             sub_fig_captions = range(1, len(img_list) + 1)

--- a/tests/report/test_report_items.py
+++ b/tests/report/test_report_items.py
@@ -836,7 +836,7 @@ def test_subfigure_row_splitting():
         line = line.lstrip()
         if line.startswith(r"\caption") and in_figure and (not in_subfigure):
             caption_in_figure = True
-        if line.startswith(r"\begin{subfigure}[t]"):
+        if line.startswith(r"\begin{subfigure}"):
             in_subfigure = True
             subplots_in_row += 1
         if line.startswith(r"\end{subfigure}"):

--- a/tests/report/test_report_items.py
+++ b/tests/report/test_report_items.py
@@ -11,8 +11,8 @@ from flow360.component.resource_base import local_metadata_builder
 from flow360.component.utils import LocalResourceCache
 from flow360.component.volume_mesh import VolumeMeshMetaV2, VolumeMeshV2
 from flow360.plugins.report.report import ReportTemplate
-from flow360.plugins.report.report_doc import ReportDoc
 from flow360.plugins.report.report_context import ReportContext
+from flow360.plugins.report.report_doc import ReportDoc
 from flow360.plugins.report.report_items import (
     Camera,
     Chart2D,
@@ -804,17 +804,18 @@ def test_3d_caption(cases):
         == "This is case: case-2222222222-2222-2222-2222-2222222222-name with ID: case-2222222222-2222-2222-2222-2222222222"
     )
 
+
 def test_subfigure_row_splitting():
     report_doc = ReportDoc("tester")
 
     chart = Chart2D(
-            x="nonlinear_residuals/pseudo_step",
-            y="nonlinear_residuals/0_cont",
-            section_title="Continuity convergence",
-            fig_name="convergence_cont",
-            items_in_row=2,
-        )
-    
+        x="nonlinear_residuals/pseudo_step",
+        y="nonlinear_residuals/0_cont",
+        section_title="Continuity convergence",
+        fig_name="convergence_cont",
+        items_in_row=2,
+    )
+
     chart._add_row_figure(doc=report_doc.doc, img_list=["." for _ in range(6)], fig_caption="test")
 
     tex = report_doc.doc.dumps()
@@ -832,7 +833,7 @@ def test_subfigure_row_splitting():
 
     for line in lines:
         line = line.lstrip()
-        if (line.startswith(r"\caption") and in_figure and (not in_subfigure)):
+        if line.startswith(r"\caption") and in_figure and (not in_subfigure):
             caption_in_figure = True
         if line.startswith(r"\begin{subfigure}[t]"):
             in_subfigure = True
@@ -851,4 +852,3 @@ def test_subfigure_row_splitting():
                 assert not caption_in_figure
             caption_in_figure = False
             in_figure = False
-            

--- a/tests/report/test_report_items.py
+++ b/tests/report/test_report_items.py
@@ -841,7 +841,7 @@ def test_subfigure_row_splitting():
             subplots_in_row += 1
         if line.startswith(r"\end{subfigure}"):
             in_subfigure = False
-        if line.startswith(r"\begin{figure}[h!]"):
+        if line.startswith(r"\begin{figure}"):
             in_figure = True
         if line.startswith(r"\end{figure}"):
             assert subplots_in_row == 2

--- a/tests/report/test_report_items.py
+++ b/tests/report/test_report_items.py
@@ -805,6 +805,7 @@ def test_3d_caption(cases):
     )
 
 
+@pytest.mark.usefixtures("mock_detect_latex_compiler")
 def test_subfigure_row_splitting():
     report_doc = ReportDoc("tester")
 

--- a/tests/report/test_report_items.py
+++ b/tests/report/test_report_items.py
@@ -11,6 +11,7 @@ from flow360.component.resource_base import local_metadata_builder
 from flow360.component.utils import LocalResourceCache
 from flow360.component.volume_mesh import VolumeMeshMetaV2, VolumeMeshV2
 from flow360.plugins.report.report import ReportTemplate
+from flow360.plugins.report.report_doc import ReportDoc
 from flow360.plugins.report.report_context import ReportContext
 from flow360.plugins.report.report_items import (
     Camera,
@@ -39,6 +40,7 @@ def here():
 
 @pytest.fixture
 def cases(here):
+
     case_ids = [
         "case-11111111-1111-1111-1111-111111111111",
         "case-2222222222-2222-2222-2222-2222222222",
@@ -801,3 +803,52 @@ def test_3d_caption(cases):
         chart._handle_3d_caption(case=cases[1])
         == "This is case: case-2222222222-2222-2222-2222-2222222222-name with ID: case-2222222222-2222-2222-2222-2222222222"
     )
+
+def test_subfigure_row_splitting():
+    report_doc = ReportDoc("tester")
+
+    chart = Chart2D(
+            x="nonlinear_residuals/pseudo_step",
+            y="nonlinear_residuals/0_cont",
+            section_title="Continuity convergence",
+            fig_name="convergence_cont",
+            items_in_row=2,
+        )
+    
+    chart._add_row_figure(doc=report_doc.doc, img_list=["." for _ in range(6)], fig_caption="test")
+
+    tex = report_doc.doc.dumps()
+
+    lines = tex.split("\n")
+
+    subplots_in_row = 0
+
+    rows = 0
+
+    in_subfigure = False
+    in_figure = False
+
+    caption_in_figure = False
+
+    for line in lines:
+        line = line.lstrip()
+        if (line.startswith(r"\caption") and in_figure and (not in_subfigure)):
+            caption_in_figure = True
+        if line.startswith(r"\begin{subfigure}[t]"):
+            in_subfigure = True
+            subplots_in_row += 1
+        if line.startswith(r"\end{subfigure}"):
+            in_subfigure = False
+        if line.startswith(r"\begin{figure}[h!]"):
+            in_figure = True
+        if line.startswith(r"\end{figure}"):
+            assert subplots_in_row == 2
+            subplots_in_row = 0
+            rows += 1
+            if rows == 3:
+                assert caption_in_figure
+            else:
+                assert not caption_in_figure
+            caption_in_figure = False
+            in_figure = False
+            


### PR DESCRIPTION
Figures with items_in_row get created as 1 row -> 1 figure which allows for splitting them between pages