### PR TITLE
[SCFD-4733] [SCFD-5021] [Hotfix-RC24.11] Get the default reference geometry settings with the provided length unit  (#892)

### DIFF
--- a/flow360/component/project_utils.py
+++ b/flow360/component/project_utils.py
@@ -137,6 +137,24 @@ def _set_up_params_non_persistent_entity_info(entity_info, params: SimulationPar
     return entity_info
 
 
+def _set_up_default_reference_geometry(params: SimulationParams, length_unit: LengthType):
+    """
+    Setting up the default reference geometry if not provided in params.
+    Ensure the simulation.json contains the default settings other than None.
+    """
+    # pylint: disable=protected-access
+    default_reference_geometry = services._get_default_reference_geometry(length_unit)
+    if params.reference_geometry is None:
+        params.reference_geometry = default_reference_geometry
+        return params
+
+    for field in params.reference_geometry.model_fields:
+        if getattr(params.reference_geometry, field) is None:
+            setattr(params.reference_geometry, field, getattr(default_reference_geometry, field))
+
+    return params
+
+
 def set_up_params_for_uploading(
     root_asset,
     length_unit: LengthType,
@@ -158,6 +176,8 @@ def set_up_params_for_uploading(
     # Replace the ghost surfaces in the SimulationParams by the real ghost ones from asset metadata.
     # This has to be done after `project_entity_info` is properly set.
     entity_info = _replace_ghost_surfaces(params)
+
+    params = _set_up_default_reference_geometry(params, length_unit)
 
     return params
 

--- a/flow360/component/simulation/services.py
+++ b/flow360/component/simulation/services.py
@@ -114,6 +114,14 @@ def _store_project_length_unit(length_unit, params: SimulationParams):
     return params
 
 
+def _get_default_reference_geometry(length_unit: LengthType):
+    return ReferenceGeometry(
+        area=1 * length_unit**2,
+        moment_center=(0, 0, 0) * length_unit,
+        moment_length=(1, 1, 1) * length_unit,
+    )
+
+
 def get_default_params(
     unit_system_name, length_unit, root_item_type: Literal["Geometry", "VolumeMesh"]
 ) -> SimulationParams:
@@ -130,17 +138,16 @@ def get_default_params(
 
     Returns
     -------
-    SimulationParams
-        Default parameters for Flow360 simulation.
+    dict
+        Default parameters for Flow360 simulation stored in a dictionary.
 
     """
 
     unit_system = init_unit_system(unit_system_name)
     dummy_value = 0.1
     with unit_system:
-        reference_geometry = ReferenceGeometry(
-            area=1, moment_center=(0, 0, 0), moment_length=(1, 1, 1)
-        )
+        # pylint: disable=no-member
+        reference_geometry = _get_default_reference_geometry(LengthType.validate(length_unit))
         operating_condition = AerospaceCondition(velocity_magnitude=dummy_value)
         surface_output = SurfaceOutput(
             name="Surface output",

--- a/tests/ref/simulation/service_init_volume_mesh_cm.json
+++ b/tests/ref/simulation/service_init_volume_mesh_cm.json
@@ -1,0 +1,267 @@
+{
+    "version": "24.11.12",
+    "unit_system": {
+        "name": "SI"
+    },
+    "reference_geometry": {
+        "moment_center": {
+            "value": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "units": "cm"
+        },
+        "moment_length": {
+            "value": [
+                1.0,
+                1.0,
+                1.0
+            ],
+            "units": "cm"
+        },
+        "area": {
+            "value": 1.0,
+            "units": "cm**2"
+        }
+    },
+    "operating_condition": {
+        "type_name": "AerospaceCondition",
+        "private_attribute_constructor": "default",
+        "private_attribute_input_cache": {
+            "alpha": {
+                "value": 0.0,
+                "units": "degree"
+            },
+            "beta": {
+                "value": 0.0,
+                "units": "degree"
+            },
+            "thermal_state": {
+                "type_name": "ThermalState",
+                "private_attribute_constructor": "default",
+                "private_attribute_input_cache": {},
+                "temperature": {
+                    "value": 288.15,
+                    "units": "K"
+                },
+                "density": {
+                    "value": 1.225,
+                    "units": "kg/m**3"
+                },
+                "material": {
+                    "type": "air",
+                    "name": "air",
+                    "dynamic_viscosity": {
+                        "reference_viscosity": {
+                            "value": 1.716e-05,
+                            "units": "Pa*s"
+                        },
+                        "reference_temperature": {
+                            "value": 273.15,
+                            "units": "K"
+                        },
+                        "effective_temperature": {
+                            "value": 110.4,
+                            "units": "K"
+                        }
+                    }
+                }
+            }
+        },
+        "alpha": {
+            "value": 0.0,
+            "units": "degree"
+        },
+        "beta": {
+            "value": 0.0,
+            "units": "degree"
+        },
+        "thermal_state": {
+            "type_name": "ThermalState",
+            "private_attribute_constructor": "default",
+            "private_attribute_input_cache": {},
+            "temperature": {
+                "value": 288.15,
+                "units": "K"
+            },
+            "density": {
+                "value": 1.225,
+                "units": "kg/m**3"
+            },
+            "material": {
+                "type": "air",
+                "name": "air",
+                "dynamic_viscosity": {
+                    "reference_viscosity": {
+                        "value": 1.716e-05,
+                        "units": "Pa*s"
+                    },
+                    "reference_temperature": {
+                        "value": 273.15,
+                        "units": "K"
+                    },
+                    "effective_temperature": {
+                        "value": 110.4,
+                        "units": "K"
+                    }
+                }
+            }
+        }
+    },
+    "models": [
+        {
+            "type": "Wall",
+            "entities": {
+                "stored_entities": []
+            },
+            "name": "Wall",
+            "use_wall_function": false,
+            "heat_spec": {
+                "value": {
+                    "value": 0.0,
+                    "units": "W/m**2"
+                },
+                "type_name": "HeatFlux"
+            }
+        },
+        {
+            "type": "Freestream",
+            "entities": {
+                "stored_entities": []
+            },
+            "name": "Freestream"
+        },
+        {
+            "material": {
+                "type": "air",
+                "name": "air",
+                "dynamic_viscosity": {
+                    "reference_viscosity": {
+                        "value": 1.716e-05,
+                        "units": "Pa*s"
+                    },
+                    "reference_temperature": {
+                        "value": 273.15,
+                        "units": "K"
+                    },
+                    "effective_temperature": {
+                        "value": 110.4,
+                        "units": "K"
+                    }
+                }
+            },
+            "initial_condition": {
+                "type_name": "NavierStokesInitialCondition",
+                "rho": "rho",
+                "u": "u",
+                "v": "v",
+                "w": "w",
+                "p": "p"
+            },
+            "type": "Fluid",
+            "navier_stokes_solver": {
+                "absolute_tolerance": 1e-10,
+                "relative_tolerance": 0.0,
+                "order_of_accuracy": 2,
+                "equation_evaluation_frequency": 1,
+                "linear_solver": {
+                    "max_iterations": 30
+                },
+                "CFL_multiplier": 1.0,
+                "kappa_MUSCL": -1.0,
+                "numerical_dissipation_factor": 1.0,
+                "limit_velocity": false,
+                "limit_pressure_density": false,
+                "type_name": "Compressible",
+                "low_mach_preconditioner": false,
+                "update_jacobian_frequency": 4,
+                "max_force_jac_update_physical_steps": 0
+            },
+            "turbulence_model_solver": {
+                "absolute_tolerance": 1e-08,
+                "relative_tolerance": 0.0,
+                "order_of_accuracy": 2,
+                "equation_evaluation_frequency": 4,
+                "linear_solver": {
+                    "max_iterations": 20
+                },
+                "CFL_multiplier": 2.0,
+                "type_name": "SpalartAllmaras",
+                "DDES": false,
+                "grid_size_for_LES": "maxEdgeLength",
+                "reconstruction_gradient_limiter": 0.5,
+                "quadratic_constitutive_relation": false,
+                "modeling_constants": {
+                    "type_name": "SpalartAllmarasConsts",
+                    "C_DES": 0.72,
+                    "C_d": 8.0,
+                    "C_cb1": 0.1355,
+                    "C_cb2": 0.622,
+                    "C_sigma": 0.6666666666666666,
+                    "C_v1": 7.1,
+                    "C_vonKarman": 0.41,
+                    "C_w2": 0.3,
+                    "C_t3": 1.2,
+                    "C_t4": 0.5,
+                    "C_min_rd": 10.0
+                },
+                "update_jacobian_frequency": 4,
+                "max_force_jac_update_physical_steps": 0,
+                "rotation_correction": false
+            },
+            "transition_model_solver": {
+                "type_name": "None"
+            }
+        }
+    ],
+    "time_stepping": {
+        "type_name": "Steady",
+        "max_steps": 2000,
+        "CFL": {
+            "type": "adaptive",
+            "min": 0.1,
+            "max": 10000.0,
+            "max_relative_change": 1.0,
+            "convergence_limiting_factor": 0.25
+        }
+    },
+    "user_defined_fields": [],
+    "outputs": [
+        {
+            "frequency": -1,
+            "frequency_offset": 0,
+            "output_format": "paraview",
+            "name": "Surface output",
+            "entities": {
+                "stored_entities": [
+                    {
+                        "private_attribute_registry_bucket_name": "SurfaceEntityType",
+                        "private_attribute_entity_type_name": "Surface",
+                        "name": "*",
+                        "private_attribute_sub_components": [],
+                        "private_attribute_potential_issues": []
+                    }
+                ]
+            },
+            "write_single_file": false,
+            "output_fields": {
+                "items": [
+                    "Cp",
+                    "yPlus",
+                    "Cf",
+                    "CfVec"
+                ]
+            },
+            "output_type": "SurfaceOutput"
+        }
+    ],
+    "private_attribute_asset_cache": {
+        "project_length_unit": {
+            "value": 1.0,
+            "units": "cm"
+        },
+        "use_inhouse_mesher": false,
+        "use_geometry_AI": false
+    }
+}

--- a/tests/simulation/service/test_project_util.py
+++ b/tests/simulation/service/test_project_util.py
@@ -1,8 +1,13 @@
+import numpy as np
 import pytest
 
-from flow360.component.project_utils import _replace_ghost_surfaces
+from flow360.component.project_utils import (
+    _replace_ghost_surfaces,
+    _set_up_default_reference_geometry,
+)
 from flow360.component.simulation.primitives import GhostSphere
 from flow360.component.simulation.simulation_params import SimulationParams
+from flow360.component.simulation.unit_system import LengthType
 
 
 @pytest.fixture(autouse=True)
@@ -17,3 +22,12 @@ def test_replace_ghost_surfaces():
     assert isinstance(entity, GhostSphere)  # This used to be GhostSurface by python
     assert entity.center == [5.0007498695, 0.0, 0.0]
     assert entity.max_radius == 504.16453591327473
+
+
+def test_set_up_default_reference_geometry():
+    params = SimulationParams.from_file("./data/simulation_with_old_ghost_surface.json")
+    length_unit = LengthType.validate("cm")
+    new_params = _set_up_default_reference_geometry(params, length_unit=length_unit)
+
+    assert np.all(new_params.reference_geometry.area == 1.0 * length_unit**2)
+    assert np.all(new_params.reference_geometry.moment_center == (0.0, 0.0, 0.0) * length_unit)

--- a/tests/simulation/service/test_services_v2.py
+++ b/tests/simulation/service/test_services_v2.py
@@ -305,6 +305,18 @@ def test_init():
     data = json.loads(json.dumps(data))
     compare_dict_to_ref(data, "../../ref/simulation/service_init_volume_mesh.json")
 
+    ##3: test default values for surface mesh starting point
+    data = services.get_default_params(
+        unit_system_name="SI", length_unit="cm", root_item_type="VolumeMesh"
+    )
+    assert data["reference_geometry"]["area"]["units"] == "cm**2"
+    assert data["reference_geometry"]["moment_center"]["units"] == "cm"
+    assert data["reference_geometry"]["moment_length"]["units"] == "cm"
+    assert data["private_attribute_asset_cache"]["project_length_unit"]["units"] == "cm"
+    # to convert tuples to lists:
+    data = json.loads(json.dumps(data))
+    compare_dict_to_ref(data, "../../ref/simulation/service_init_volume_mesh_cm.json")
+
 
 def test_validate_init_data_errors():
 


### PR DESCRIPTION
* Change the unit of reference geometry in the default params

* Encapsule the function to get default reference geometry

* Set up default reference geometry's value if None

* Update type hint for the get_default_params function

* address comment