### PR TITLE
Expression unit test fixes

### DIFF
--- a/flow360/component/simulation/translator/solver_translator.py
+++ b/flow360/component/simulation/translator/solver_translator.py
@@ -975,7 +975,12 @@ def get_solver_json(
         geometry = remove_units_in_dict(dump_dict(input_params.reference_geometry))
         translated["geometry"] = {}
         if input_params.reference_geometry.area is not None:
-            translated["geometry"]["refArea"] = geometry["area"]
+            if geometry["area"]["typeName"] == "number":
+                translated["geometry"]["refArea"] = geometry["area"]["value"]
+            elif geometry["area"]["typeName"] == "expression":
+                if not geometry["area"]["evaluatedValue"]:
+                    raise ValueError("Value of reference area cannot evaluate to a non-numeric value")
+                translated["geometry"]["refArea"] = geometry["area"]["evaluatedValue"]
         if input_params.reference_geometry.moment_center is not None:
             translated["geometry"]["momentCenter"] = list(geometry["momentCenter"])
         if input_params.reference_geometry.moment_length is not None:

--- a/flow360/component/simulation/user_code.py
+++ b/flow360/component/simulation/user_code.py
@@ -221,7 +221,7 @@ class Expression(Flow360BaseModel):
             expression = str(value)
         else:
             details = InitErrorDetails(
-                type="value_error", ctx={"error": f"Invalid type {type(value)}"}
+                type="value_error", ctx={"error": f"Invalid type {type(value)} for {value}"}
             )
             raise pd.ValidationError.from_exception_data("expression type error", [details])
 

--- a/tests/ref/simulation/service_init_geometry.json
+++ b/tests/ref/simulation/service_init_geometry.json
@@ -7,49 +7,90 @@
     "refinement_factor": 1.0,
     "gap_treatment_strength": 0.0,
     "defaults": {
-      "boundary_layer_growth_rate": 1.2,
-      "curvature_resolution_angle": {
-        "units": "degree",
-        "value": 12.0
-      },
       "surface_edge_growth_rate": 1.2,
-      "planar_face_tolerance": 1e-6
+      "boundary_layer_growth_rate": 1.2,
+      "planar_face_tolerance": 1e-06,
+      "curvature_resolution_angle": {
+        "value": 12.0,
+        "units": "degree"
+      }
     },
-  "refinements": [],
-  "volume_zones": [
-    {
-      "type": "AutomatedFarfield",
-      "name": "Farfield",
-      "method": "auto"
+    "refinements": [],
+    "volume_zones": [
+      {
+        "type": "AutomatedFarfield",
+        "name": "Farfield",
+        "method": "auto"
+      }
+    ]
+  },
+  "reference_geometry": {
+    "moment_center": {
+      "value": [
+        0.0,
+        0.0,
+        0.0
+      ],
+      "units": "m"
+    },
+    "moment_length": {
+      "value": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "units": "m"
+    },
+    "area": {
+      "type_name": "number",
+      "value": 1.0,
+      "units": "m**2"
     }
-  ]
-},
-"reference_geometry": {
-  "moment_center": {
-    "value": [
-      0.0,
-      0.0,
-      0.0
-    ],
-    "units": "m"
   },
-  "moment_length": {
-    "value": [
-      1.0,
-      1.0,
-      1.0
-    ],
-    "units": "m"
-  },
-  "area": {
-    "value": 1.0,
-    "units": "m**2"
-  }
-},
-"operating_condition": {
-  "type_name": "AerospaceCondition",
-  "private_attribute_constructor": "default",
-  "private_attribute_input_cache": {
+  "operating_condition": {
+    "type_name": "AerospaceCondition",
+    "private_attribute_constructor": "default",
+    "private_attribute_input_cache": {
+      "alpha": {
+        "value": 0.0,
+        "units": "degree"
+      },
+      "beta": {
+        "value": 0.0,
+        "units": "degree"
+      },
+      "thermal_state": {
+        "type_name": "ThermalState",
+        "private_attribute_constructor": "default",
+        "private_attribute_input_cache": {},
+        "temperature": {
+          "value": 288.15,
+          "units": "K"
+        },
+        "density": {
+          "value": 1.225,
+          "units": "kg/m**3"
+        },
+        "material": {
+          "type": "air",
+          "name": "air",
+          "dynamic_viscosity": {
+            "reference_viscosity": {
+              "value": 1.716e-05,
+              "units": "Pa*s"
+            },
+            "reference_temperature": {
+              "value": 273.15,
+              "units": "K"
+            },
+            "effective_temperature": {
+              "value": 110.4,
+              "units": "K"
+            }
+          }
+        }
+      }
+    },
     "alpha": {
       "value": 0.0,
       "units": "degree"
@@ -90,215 +131,176 @@
       }
     }
   },
-  "alpha": {
-    "value": 0.0,
-    "units": "degree"
-  },
-  "beta": {
-    "value": 0.0,
-    "units": "degree"
-  },
-  "thermal_state": {
-    "type_name": "ThermalState",
-    "private_attribute_constructor": "default",
-    "private_attribute_input_cache": {},
-    "temperature": {
-      "value": 288.15,
-      "units": "K"
-    },
-    "density": {
-      "value": 1.225,
-      "units": "kg/m**3"
-    },
-    "material": {
-      "type": "air",
-      "name": "air",
-      "dynamic_viscosity": {
-        "reference_viscosity": {
-          "value": 1.716e-05,
-          "units": "Pa*s"
-        },
-        "reference_temperature": {
-          "value": 273.15,
-          "units": "K"
-        },
-        "effective_temperature": {
-          "value": 110.4,
-          "units": "K"
-        }
-      }
-    }
-  }
-},
-"models": [
-  {
-    "type": "Wall",
-    "entities": {
-      "stored_entities": [
-        {
-          "private_attribute_registry_bucket_name": "SurfaceEntityType",
-          "private_attribute_entity_type_name": "Surface",
-          "name": "*",
-          "private_attribute_sub_components": [],
-          "private_attribute_potential_issues": []
-        }
-      ]
-    },
-    "name": "Wall",
-    "use_wall_function": false,
-    "heat_spec": {
-      "value":{
-        "value":0.0,
-        "units": "W/m**2"
-      },
-      "type_name": "HeatFlux"
-    },
-    "roughness_height": {
-      "value": 0.0,
-      "units": "m"
-    }
-  },
-  {
-    "type": "Freestream",
-    "entities": {
-      "stored_entities": [
-        {
-          "private_attribute_registry_bucket_name": "SurfaceEntityType",
-          "private_attribute_entity_type_name": "GhostSurface",
-          "name": "farfield"
-        }
-      ]
-    },
-    "name": "Freestream"
-  },
-  {
-    "material": {
-      "type": "air",
-      "name": "air",
-      "dynamic_viscosity": {
-        "reference_viscosity": {
-          "value": 1.716e-05,
-          "units": "Pa*s"
-        },
-        "reference_temperature": {
-          "value": 273.15,
-          "units": "K"
-        },
-        "effective_temperature": {
-          "value": 110.4,
-          "units": "K"
-        }
-      }
-    },
-    "type": "Fluid",
-    "initial_condition": {
-      "type_name": "NavierStokesInitialCondition",
-      "rho": "rho",
-      "u": "u",
-      "v": "v",
-      "w": "w",
-      "p": "p"
-    },
-    "navier_stokes_solver": {
-      "absolute_tolerance": 1e-10,
-      "relative_tolerance": 0.0,
-      "order_of_accuracy": 2,
-      "equation_evaluation_frequency": 1,
-      "linear_solver": {
-        "max_iterations": 30
-      },
-      "CFL_multiplier": 1.0,
-      "kappa_MUSCL": -1.0,
-      "numerical_dissipation_factor": 1.0,
-      "limit_velocity": false,
-      "limit_pressure_density": false,
-      "type_name": "Compressible",
-      "low_mach_preconditioner": false,
-      "update_jacobian_frequency": 4,
-      "max_force_jac_update_physical_steps": 0
-    },
-    "turbulence_model_solver": {
-      "absolute_tolerance": 1e-08,
-      "relative_tolerance": 0.0,
-      "order_of_accuracy": 2,
-      "equation_evaluation_frequency": 4,
-      "linear_solver": {
-        "max_iterations": 20
-      },
-      "CFL_multiplier": 2.0,
-      "type_name": "SpalartAllmaras",
-      "reconstruction_gradient_limiter": 0.5,
-      "quadratic_constitutive_relation": false,
-      "modeling_constants": {
-        "type_name": "SpalartAllmarasConsts",
-        "C_DES": 0.72,
-        "C_d": 8.0,
-        "C_cb1": 0.1355,
-        "C_cb2": 0.622,
-        "C_sigma": 0.6666666666666666,
-        "C_v1": 7.1,
-        "C_vonKarman": 0.41,
-        "C_w2": 0.3,
-        "C_t3": 1.2,
-        "C_t4": 0.5,
-        "C_min_rd": 10.0
-      },
-      "update_jacobian_frequency": 4,
-      "max_force_jac_update_physical_steps": 0,
-      "rotation_correction": false
-    },
-    "transition_model_solver": {
-      "type_name": "None"
-    }
-  }
-],
-"time_stepping": {
-  "type_name": "Steady",
-  "max_steps": 2000,
-  "CFL": {
-    "type": "adaptive",
-    "min": 0.1,
-    "max": 10000.0,
-    "max_relative_change": 1.0,
-    "convergence_limiting_factor": 0.25
-  }
-},
-"outputs": [
-  {
-    "frequency": -1,
-    "frequency_offset": 0,
-    "output_format": "paraview",
-    "name": "Surface output",
-    "write_single_file": false,
-    "output_fields": {
-      "items": [
-        "Cp",
-        "yPlus",
-        "Cf",
-        "CfVec"
-      ]
-    },
-    "entities": {
+  "models": [
+    {
+      "type": "Wall",
+      "entities": {
         "stored_entities": [
-            {
-                "private_attribute_registry_bucket_name": "SurfaceEntityType",
-                "private_attribute_entity_type_name": "Surface",
-                "name": "*",
-                "private_attribute_sub_components": [],
-                "private_attribute_potential_issues": []
-            }
+          {
+            "private_attribute_registry_bucket_name": "SurfaceEntityType",
+            "private_attribute_entity_type_name": "Surface",
+            "name": "*",
+            "private_attribute_sub_components": [],
+            "private_attribute_potential_issues": []
+          }
         ]
+      },
+      "name": "Wall",
+      "use_wall_function": false,
+      "heat_spec": {
+        "value": {
+          "value": 0.0,
+          "units": "W/m**2"
+        },
+        "type_name": "HeatFlux"
+      },
+      "roughness_height": {
+        "value": 0.0,
+        "units": "m"
+      }
     },
-    "output_type": "SurfaceOutput"
-  }
-],
-"user_defined_fields":[],
-"private_attribute_asset_cache": {
-  "project_length_unit": {
-    "value": 1.0,
-    "units": "m"
+    {
+      "type": "Freestream",
+      "entities": {
+        "stored_entities": [
+          {
+            "private_attribute_registry_bucket_name": "SurfaceEntityType",
+            "private_attribute_entity_type_name": "GhostSurface",
+            "name": "farfield"
+          }
+        ]
+      },
+      "name": "Freestream"
+    },
+    {
+      "material": {
+        "type": "air",
+        "name": "air",
+        "dynamic_viscosity": {
+          "reference_viscosity": {
+            "value": 1.716e-05,
+            "units": "Pa*s"
+          },
+          "reference_temperature": {
+            "value": 273.15,
+            "units": "K"
+          },
+          "effective_temperature": {
+            "value": 110.4,
+            "units": "K"
+          }
+        }
+      },
+      "initial_condition": {
+        "type_name": "NavierStokesInitialCondition",
+        "rho": "rho",
+        "u": "u",
+        "v": "v",
+        "w": "w",
+        "p": "p"
+      },
+      "type": "Fluid",
+      "navier_stokes_solver": {
+        "absolute_tolerance": 1e-10,
+        "relative_tolerance": 0.0,
+        "order_of_accuracy": 2,
+        "equation_evaluation_frequency": 1,
+        "linear_solver": {
+          "max_iterations": 30
+        },
+        "CFL_multiplier": 1.0,
+        "kappa_MUSCL": -1.0,
+        "numerical_dissipation_factor": 1.0,
+        "limit_velocity": false,
+        "limit_pressure_density": false,
+        "type_name": "Compressible",
+        "low_mach_preconditioner": false,
+        "update_jacobian_frequency": 4,
+        "max_force_jac_update_physical_steps": 0
+      },
+      "turbulence_model_solver": {
+        "absolute_tolerance": 1e-08,
+        "relative_tolerance": 0.0,
+        "order_of_accuracy": 2,
+        "equation_evaluation_frequency": 4,
+        "linear_solver": {
+          "max_iterations": 20
+        },
+        "CFL_multiplier": 2.0,
+        "type_name": "SpalartAllmaras",
+        "reconstruction_gradient_limiter": 0.5,
+        "quadratic_constitutive_relation": false,
+        "modeling_constants": {
+          "type_name": "SpalartAllmarasConsts",
+          "C_DES": 0.72,
+          "C_d": 8.0,
+          "C_cb1": 0.1355,
+          "C_cb2": 0.622,
+          "C_sigma": 0.6666666666666666,
+          "C_v1": 7.1,
+          "C_vonKarman": 0.41,
+          "C_w2": 0.3,
+          "C_t3": 1.2,
+          "C_t4": 0.5,
+          "C_min_rd": 10.0
+        },
+        "update_jacobian_frequency": 4,
+        "max_force_jac_update_physical_steps": 0,
+        "rotation_correction": false
+      },
+      "transition_model_solver": {
+        "type_name": "None"
+      }
+    }
+  ],
+  "time_stepping": {
+    "type_name": "Steady",
+    "max_steps": 2000,
+    "CFL": {
+      "type": "adaptive",
+      "min": 0.1,
+      "max": 10000.0,
+      "max_relative_change": 1.0,
+      "convergence_limiting_factor": 0.25
+    }
   },
-  "use_inhouse_mesher": false,
-  "use_geometry_AI": false
-}
+  "user_defined_fields": [],
+  "outputs": [
+    {
+      "output_fields": {
+        "items": [
+          "Cp",
+          "yPlus",
+          "Cf",
+          "CfVec"
+        ]
+      },
+      "frequency": -1,
+      "frequency_offset": 0,
+      "output_format": "paraview",
+      "name": "Surface output",
+      "entities": {
+        "stored_entities": [
+          {
+            "private_attribute_registry_bucket_name": "SurfaceEntityType",
+            "private_attribute_entity_type_name": "Surface",
+            "name": "*",
+            "private_attribute_sub_components": [],
+            "private_attribute_potential_issues": []
+          }
+        ]
+      },
+      "write_single_file": false,
+      "output_type": "SurfaceOutput"
+    }
+  ],
+  "private_attribute_asset_cache": {
+    "project_length_unit": {
+      "value": 1.0,
+      "units": "m"
+    },
+    "use_inhouse_mesher": false,
+    "use_geometry_AI": false,
+    "project_variables": []
+  }
 }

--- a/tests/ref/simulation/service_init_volume_mesh.json
+++ b/tests/ref/simulation/service_init_volume_mesh.json
@@ -1,269 +1,271 @@
 {
-    "version": "25.4.1b2",
-    "unit_system": {
-        "name": "SI"
+  "version": "25.4.1b2",
+  "unit_system": {
+    "name": "SI"
+  },
+  "reference_geometry": {
+    "moment_center": {
+      "value": [
+        0.0,
+        0.0,
+        0.0
+      ],
+      "units": "m"
     },
-    "reference_geometry": {
-        "moment_center": {
-            "value": [
-                0.0,
-                0.0,
-                0.0
-            ],
-            "units": "m"
-        },
-        "moment_length": {
-            "value": [
-                1.0,
-                1.0,
-                1.0
-            ],
-            "units": "m"
-        },
-        "area": {
-            "value": 1.0,
-            "units": "m**2"
-        }
+    "moment_length": {
+      "value": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "units": "m"
     },
-    "operating_condition": {
-        "type_name": "AerospaceCondition",
-        "private_attribute_constructor": "default",
-        "private_attribute_input_cache": {
-            "alpha": {
-                "value": 0.0,
-                "units": "degree"
-            },
-            "beta": {
-                "value": 0.0,
-                "units": "degree"
-            },
-            "thermal_state": {
-                "type_name": "ThermalState",
-                "private_attribute_constructor": "default",
-                "private_attribute_input_cache": {},
-                "temperature": {
-                    "value": 288.15,
-                    "units": "K"
-                },
-                "density": {
-                    "value": 1.225,
-                    "units": "kg/m**3"
-                },
-                "material": {
-                    "type": "air",
-                    "name": "air",
-                    "dynamic_viscosity": {
-                        "reference_viscosity": {
-                            "value": 1.716e-05,
-                            "units": "Pa*s"
-                        },
-                        "reference_temperature": {
-                            "value": 273.15,
-                            "units": "K"
-                        },
-                        "effective_temperature": {
-                            "value": 110.4,
-                            "units": "K"
-                        }
-                    }
-                }
-            }
-        },
-        "alpha": {
-            "value": 0.0,
-            "units": "degree"
-        },
-        "beta": {
-            "value": 0.0,
-            "units": "degree"
-        },
-        "thermal_state": {
-            "type_name": "ThermalState",
-            "private_attribute_constructor": "default",
-            "private_attribute_input_cache": {},
-            "temperature": {
-                "value": 288.15,
-                "units": "K"
-            },
-            "density": {
-                "value": 1.225,
-                "units": "kg/m**3"
-            },
-            "material": {
-                "type": "air",
-                "name": "air",
-                "dynamic_viscosity": {
-                    "reference_viscosity": {
-                        "value": 1.716e-05,
-                        "units": "Pa*s"
-                    },
-                    "reference_temperature": {
-                        "value": 273.15,
-                        "units": "K"
-                    },
-                    "effective_temperature": {
-                        "value": 110.4,
-                        "units": "K"
-                    }
-                }
-            }
-        }
-    },
-    "models": [
-        {
-            "type": "Wall",
-            "entities": {
-                "stored_entities": []
-            },
-            "name": "Wall",
-            "use_wall_function": false,
-            "heat_spec": {
-                "value": {
-                    "value": 0.0,
-                    "units": "W/m**2"
-                },
-                "type_name": "HeatFlux"
-            },
-            "roughness_height": {
-              "value": 0.0,
-              "units": "m"
-            }
-        },
-        {
-            "type": "Freestream",
-            "entities": {
-                "stored_entities": []
-            },
-            "name": "Freestream"
-        },
-        {
-            "material": {
-                "type": "air",
-                "name": "air",
-                "dynamic_viscosity": {
-                    "reference_viscosity": {
-                        "value": 1.716e-05,
-                        "units": "Pa*s"
-                    },
-                    "reference_temperature": {
-                        "value": 273.15,
-                        "units": "K"
-                    },
-                    "effective_temperature": {
-                        "value": 110.4,
-                        "units": "K"
-                    }
-                }
-            },
-            "initial_condition": {
-                "type_name": "NavierStokesInitialCondition",
-                "rho": "rho",
-                "u": "u",
-                "v": "v",
-                "w": "w",
-                "p": "p"
-            },
-            "type": "Fluid",
-            "navier_stokes_solver": {
-                "absolute_tolerance": 1e-10,
-                "relative_tolerance": 0.0,
-                "order_of_accuracy": 2,
-                "equation_evaluation_frequency": 1,
-                "linear_solver": {
-                    "max_iterations": 30
-                },
-                "CFL_multiplier": 1.0,
-                "kappa_MUSCL": -1.0,
-                "numerical_dissipation_factor": 1.0,
-                "limit_velocity": false,
-                "limit_pressure_density": false,
-                "type_name": "Compressible",
-                "low_mach_preconditioner": false,
-                "update_jacobian_frequency": 4,
-                "max_force_jac_update_physical_steps": 0
-            },
-            "turbulence_model_solver": {
-                "absolute_tolerance": 1e-08,
-                "relative_tolerance": 0.0,
-                "order_of_accuracy": 2,
-                "equation_evaluation_frequency": 4,
-                "linear_solver": {
-                    "max_iterations": 20
-                },
-                "CFL_multiplier": 2.0,
-                "type_name": "SpalartAllmaras",
-                "reconstruction_gradient_limiter": 0.5,
-                "quadratic_constitutive_relation": false,
-                "modeling_constants": {
-                    "type_name": "SpalartAllmarasConsts",
-                    "C_DES": 0.72,
-                    "C_d": 8.0,
-                    "C_cb1": 0.1355,
-                    "C_cb2": 0.622,
-                    "C_sigma": 0.6666666666666666,
-                    "C_v1": 7.1,
-                    "C_vonKarman": 0.41,
-                    "C_w2": 0.3,
-                    "C_t3": 1.2,
-                    "C_t4": 0.5,
-                    "C_min_rd": 10.0
-                },
-                "update_jacobian_frequency": 4,
-                "max_force_jac_update_physical_steps": 0,
-                "rotation_correction": false
-            },
-            "transition_model_solver": {
-                "type_name": "None"
-            }
-        }
-    ],
-    "time_stepping": {
-        "type_name": "Steady",
-        "max_steps": 2000,
-        "CFL": {
-            "type": "adaptive",
-            "min": 0.1,
-            "max": 10000.0,
-            "max_relative_change": 1.0,
-            "convergence_limiting_factor": 0.25
-        }
-    },
-    "outputs": [
-        {
-            "frequency": -1,
-            "frequency_offset": 0,
-            "output_format": "paraview",
-            "name": "Surface output",
-            "write_single_file": false,
-            "output_fields": {
-                "items": [
-                    "Cp",
-                    "yPlus",
-                    "Cf",
-                    "CfVec"
-                ]
-            },
-            "entities": {
-                "stored_entities": [
-                    {
-                        "private_attribute_registry_bucket_name": "SurfaceEntityType",
-                        "private_attribute_entity_type_name": "Surface",
-                        "name": "*",
-                        "private_attribute_sub_components": [],
-                        "private_attribute_potential_issues": []
-                    }
-                ]
-            },
-            "output_type": "SurfaceOutput"
-        }
-    ],
-    "user_defined_fields": [],
-    "private_attribute_asset_cache": {
-        "project_length_unit": {
-            "value": 1.0,
-            "units": "m"
-        },
-        "use_inhouse_mesher": false,
-        "use_geometry_AI": false
+    "area": {
+      "type_name": "number",
+      "value": 1.0,
+      "units": "m**2"
     }
+  },
+  "operating_condition": {
+    "type_name": "AerospaceCondition",
+    "private_attribute_constructor": "default",
+    "private_attribute_input_cache": {
+      "alpha": {
+        "value": 0.0,
+        "units": "degree"
+      },
+      "beta": {
+        "value": 0.0,
+        "units": "degree"
+      },
+      "thermal_state": {
+        "type_name": "ThermalState",
+        "private_attribute_constructor": "default",
+        "private_attribute_input_cache": {},
+        "temperature": {
+          "value": 288.15,
+          "units": "K"
+        },
+        "density": {
+          "value": 1.225,
+          "units": "kg/m**3"
+        },
+        "material": {
+          "type": "air",
+          "name": "air",
+          "dynamic_viscosity": {
+            "reference_viscosity": {
+              "value": 1.716e-05,
+              "units": "Pa*s"
+            },
+            "reference_temperature": {
+              "value": 273.15,
+              "units": "K"
+            },
+            "effective_temperature": {
+              "value": 110.4,
+              "units": "K"
+            }
+          }
+        }
+      }
+    },
+    "alpha": {
+      "value": 0.0,
+      "units": "degree"
+    },
+    "beta": {
+      "value": 0.0,
+      "units": "degree"
+    },
+    "thermal_state": {
+      "type_name": "ThermalState",
+      "private_attribute_constructor": "default",
+      "private_attribute_input_cache": {},
+      "temperature": {
+        "value": 288.15,
+        "units": "K"
+      },
+      "density": {
+        "value": 1.225,
+        "units": "kg/m**3"
+      },
+      "material": {
+        "type": "air",
+        "name": "air",
+        "dynamic_viscosity": {
+          "reference_viscosity": {
+            "value": 1.716e-05,
+            "units": "Pa*s"
+          },
+          "reference_temperature": {
+            "value": 273.15,
+            "units": "K"
+          },
+          "effective_temperature": {
+            "value": 110.4,
+            "units": "K"
+          }
+        }
+      }
+    }
+  },
+  "models": [
+    {
+      "type": "Wall",
+      "entities": {
+        "stored_entities": []
+      },
+      "name": "Wall",
+      "use_wall_function": false,
+      "heat_spec": {
+        "value": {
+          "value": 0.0,
+          "units": "W/m**2"
+        },
+        "type_name": "HeatFlux"
+      },
+      "roughness_height": {
+        "value": 0.0,
+        "units": "m"
+      }
+    },
+    {
+      "type": "Freestream",
+      "entities": {
+        "stored_entities": []
+      },
+      "name": "Freestream"
+    },
+    {
+      "material": {
+        "type": "air",
+        "name": "air",
+        "dynamic_viscosity": {
+          "reference_viscosity": {
+            "value": 1.716e-05,
+            "units": "Pa*s"
+          },
+          "reference_temperature": {
+            "value": 273.15,
+            "units": "K"
+          },
+          "effective_temperature": {
+            "value": 110.4,
+            "units": "K"
+          }
+        }
+      },
+      "initial_condition": {
+        "type_name": "NavierStokesInitialCondition",
+        "rho": "rho",
+        "u": "u",
+        "v": "v",
+        "w": "w",
+        "p": "p"
+      },
+      "type": "Fluid",
+      "navier_stokes_solver": {
+        "absolute_tolerance": 1e-10,
+        "relative_tolerance": 0.0,
+        "order_of_accuracy": 2,
+        "equation_evaluation_frequency": 1,
+        "linear_solver": {
+          "max_iterations": 30
+        },
+        "CFL_multiplier": 1.0,
+        "kappa_MUSCL": -1.0,
+        "numerical_dissipation_factor": 1.0,
+        "limit_velocity": false,
+        "limit_pressure_density": false,
+        "type_name": "Compressible",
+        "low_mach_preconditioner": false,
+        "update_jacobian_frequency": 4,
+        "max_force_jac_update_physical_steps": 0
+      },
+      "turbulence_model_solver": {
+        "absolute_tolerance": 1e-08,
+        "relative_tolerance": 0.0,
+        "order_of_accuracy": 2,
+        "equation_evaluation_frequency": 4,
+        "linear_solver": {
+          "max_iterations": 20
+        },
+        "CFL_multiplier": 2.0,
+        "type_name": "SpalartAllmaras",
+        "reconstruction_gradient_limiter": 0.5,
+        "quadratic_constitutive_relation": false,
+        "modeling_constants": {
+          "type_name": "SpalartAllmarasConsts",
+          "C_DES": 0.72,
+          "C_d": 8.0,
+          "C_cb1": 0.1355,
+          "C_cb2": 0.622,
+          "C_sigma": 0.6666666666666666,
+          "C_v1": 7.1,
+          "C_vonKarman": 0.41,
+          "C_w2": 0.3,
+          "C_t3": 1.2,
+          "C_t4": 0.5,
+          "C_min_rd": 10.0
+        },
+        "update_jacobian_frequency": 4,
+        "max_force_jac_update_physical_steps": 0,
+        "rotation_correction": false
+      },
+      "transition_model_solver": {
+        "type_name": "None"
+      }
+    }
+  ],
+  "time_stepping": {
+    "type_name": "Steady",
+    "max_steps": 2000,
+    "CFL": {
+      "type": "adaptive",
+      "min": 0.1,
+      "max": 10000.0,
+      "max_relative_change": 1.0,
+      "convergence_limiting_factor": 0.25
+    }
+  },
+  "user_defined_fields": [],
+  "outputs": [
+    {
+      "output_fields": {
+        "items": [
+          "Cp",
+          "yPlus",
+          "Cf",
+          "CfVec"
+        ]
+      },
+      "frequency": -1,
+      "frequency_offset": 0,
+      "output_format": "paraview",
+      "name": "Surface output",
+      "entities": {
+        "stored_entities": [
+          {
+            "private_attribute_registry_bucket_name": "SurfaceEntityType",
+            "private_attribute_entity_type_name": "Surface",
+            "name": "*",
+            "private_attribute_sub_components": [],
+            "private_attribute_potential_issues": []
+          }
+        ]
+      },
+      "write_single_file": false,
+      "output_type": "SurfaceOutput"
+    }
+  ],
+  "private_attribute_asset_cache": {
+    "project_length_unit": {
+      "value": 1.0,
+      "units": "m"
+    },
+    "use_inhouse_mesher": false,
+    "use_geometry_AI": false,
+    "project_variables": []
+  }
 }

--- a/tests/simulation/converter/ref/ref_monitor.json
+++ b/tests/simulation/converter/ref/ref_monitor.json
@@ -1,1 +1,204 @@
-{"version":"25.4.1b2","unit_system":{"name":"SI"},"meshing":null,"reference_geometry":null,"operating_condition":null,"models":[{"material":{"type":"air","name":"air","dynamic_viscosity":{"reference_viscosity":{"value":0.00001716,"units":"Pa*s"},"reference_temperature":{"value":273.15,"units":"K"},"effective_temperature":{"value":110.4,"units":"K"}}},"initial_condition":{"type_name":"NavierStokesInitialCondition","constants":null,"rho":"rho","u":"u","v":"v","w":"w","p":"p"},"type":"Fluid","navier_stokes_solver":{"absolute_tolerance":1e-10,"relative_tolerance":0.0,"order_of_accuracy":2,"equation_evaluation_frequency":1,"linear_solver":{"max_iterations":30,"absolute_tolerance":null,"relative_tolerance":null},"private_attribute_dict":null,"CFL_multiplier":1.0,"kappa_MUSCL":-1.0,"numerical_dissipation_factor":1.0,"limit_velocity":false,"limit_pressure_density":false,"type_name":"Compressible","low_mach_preconditioner":false,"low_mach_preconditioner_threshold":null,"update_jacobian_frequency":4,"max_force_jac_update_physical_steps":0},"turbulence_model_solver":{"absolute_tolerance":1e-8,"relative_tolerance":0.0,"order_of_accuracy":2,"equation_evaluation_frequency":4,"linear_solver":{"max_iterations":20,"absolute_tolerance":null,"relative_tolerance":null},"private_attribute_dict":null,"CFL_multiplier":2.0,"type_name":"SpalartAllmaras","reconstruction_gradient_limiter":0.5,"quadratic_constitutive_relation":false,"modeling_constants":{"type_name":"SpalartAllmarasConsts","C_DES":0.72,"C_d":8.0,"C_cb1":0.1355,"C_cb2":0.622,"C_sigma":0.6666666666666666,"C_v1":7.1,"C_vonKarman":0.41,"C_w2":0.3,"C_t3":1.2,"C_t4":0.5,"C_min_rd":10.0},"update_jacobian_frequency":4,"max_force_jac_update_physical_steps":0,"hybrid_model":null,"rotation_correction":false},"transition_model_solver":{"type_name":"None"}}],"time_stepping":{"type_name":"Steady","max_steps":2000,"CFL":{"type":"adaptive","min":0.1,"max":10000.0,"max_relative_change":1.0,"convergence_limiting_factor":0.25}},"user_defined_dynamics":null,"user_defined_fields":[],"outputs":[{"name":"R1","entities":{"stored_entities":[{"private_attribute_registry_bucket_name":"PointEntityType","private_attribute_entity_type_name":"Point","private_attribute_id":"b9de2bce-36c1-4bbf-af0a-2c6a2ab713a4","name":"Point-0","location":{"value":[2.694298,0.0,1.0195910000000001],"units":"m"}}]},"output_fields":{"items":["primitiveVars"]},"output_type":"ProbeOutput"},{"name":"V3","entities":{"stored_entities":[{"private_attribute_registry_bucket_name":"PointEntityType","private_attribute_entity_type_name":"Point","private_attribute_id":"a79cffc0-31d0-499d-906c-f271c2320166","name":"Point-1","location":{"value":[4.007,0.0,-0.31760000000000005],"units":"m"}},{"private_attribute_registry_bucket_name":"PointEntityType","private_attribute_entity_type_name":"Point","private_attribute_id":"8947eb10-fc59-4102-b9c7-168a91ca22b9","name":"Point-2","location":{"value":[4.007,0.0,-0.29760000000000003],"units":"m"}},{"private_attribute_registry_bucket_name":"PointEntityType","private_attribute_entity_type_name":"Point","private_attribute_id":"27ac4e03-592b-4dba-8fa1-8f6678087a96","name":"Point-3","location":{"value":[4.007,0.0,-0.2776],"units":"m"}}]},"output_fields":{"items":["mut"]},"output_type":"ProbeOutput"}],"private_attribute_asset_cache":{"project_length_unit":null,"project_entity_info":null, "use_inhouse_mesher": false, "use_geometry_AI": false}}
+{
+  "version": "25.4.1b2",
+  "unit_system": {
+    "name": "SI"
+  },
+  "meshing": null,
+  "reference_geometry": null,
+  "operating_condition": null,
+  "models": [
+    {
+      "material": {
+        "type": "air",
+        "name": "air",
+        "dynamic_viscosity": {
+          "reference_viscosity": {
+            "value": 0.00001716,
+            "units": "Pa*s"
+          },
+          "reference_temperature": {
+            "value": 273.15,
+            "units": "K"
+          },
+          "effective_temperature": {
+            "value": 110.4,
+            "units": "K"
+          }
+        }
+      },
+      "initial_condition": {
+        "type_name": "NavierStokesInitialCondition",
+        "constants": null,
+        "rho": "rho",
+        "u": "u",
+        "v": "v",
+        "w": "w",
+        "p": "p"
+      },
+      "type": "Fluid",
+      "navier_stokes_solver": {
+        "absolute_tolerance": 1e-10,
+        "relative_tolerance": 0.0,
+        "order_of_accuracy": 2,
+        "equation_evaluation_frequency": 1,
+        "linear_solver": {
+          "max_iterations": 30,
+          "absolute_tolerance": null,
+          "relative_tolerance": null
+        },
+        "private_attribute_dict": null,
+        "CFL_multiplier": 1.0,
+        "kappa_MUSCL": -1.0,
+        "numerical_dissipation_factor": 1.0,
+        "limit_velocity": false,
+        "limit_pressure_density": false,
+        "type_name": "Compressible",
+        "low_mach_preconditioner": false,
+        "low_mach_preconditioner_threshold": null,
+        "update_jacobian_frequency": 4,
+        "max_force_jac_update_physical_steps": 0
+      },
+      "turbulence_model_solver": {
+        "absolute_tolerance": 1e-8,
+        "relative_tolerance": 0.0,
+        "order_of_accuracy": 2,
+        "equation_evaluation_frequency": 4,
+        "linear_solver": {
+          "max_iterations": 20,
+          "absolute_tolerance": null,
+          "relative_tolerance": null
+        },
+        "private_attribute_dict": null,
+        "CFL_multiplier": 2.0,
+        "type_name": "SpalartAllmaras",
+        "reconstruction_gradient_limiter": 0.5,
+        "quadratic_constitutive_relation": false,
+        "modeling_constants": {
+          "type_name": "SpalartAllmarasConsts",
+          "C_DES": 0.72,
+          "C_d": 8.0,
+          "C_cb1": 0.1355,
+          "C_cb2": 0.622,
+          "C_sigma": 0.6666666666666666,
+          "C_v1": 7.1,
+          "C_vonKarman": 0.41,
+          "C_w2": 0.3,
+          "C_t3": 1.2,
+          "C_t4": 0.5,
+          "C_min_rd": 10.0
+        },
+        "update_jacobian_frequency": 4,
+        "max_force_jac_update_physical_steps": 0,
+        "hybrid_model": null,
+        "rotation_correction": false
+      },
+      "transition_model_solver": {
+        "type_name": "None"
+      }
+    }
+  ],
+  "time_stepping": {
+    "type_name": "Steady",
+    "max_steps": 2000,
+    "CFL": {
+      "type": "adaptive",
+      "min": 0.1,
+      "max": 10000.0,
+      "max_relative_change": 1.0,
+      "convergence_limiting_factor": 0.25
+    }
+  },
+  "user_defined_dynamics": null,
+  "user_defined_fields": [],
+  "outputs": [
+    {
+      "name": "R1",
+      "entities": {
+        "stored_entities": [
+          {
+            "private_attribute_registry_bucket_name": "PointEntityType",
+            "private_attribute_entity_type_name": "Point",
+            "private_attribute_id": "b9de2bce-36c1-4bbf-af0a-2c6a2ab713a4",
+            "name": "Point-0",
+            "location": {
+              "value": [
+                2.694298,
+                0.0,
+                1.0195910000000001
+              ],
+              "units": "m"
+            }
+          }
+        ]
+      },
+      "output_fields": {
+        "items": [
+          "primitiveVars"
+        ]
+      },
+      "output_type": "ProbeOutput"
+    },
+    {
+      "name": "V3",
+      "entities": {
+        "stored_entities": [
+          {
+            "private_attribute_registry_bucket_name": "PointEntityType",
+            "private_attribute_entity_type_name": "Point",
+            "private_attribute_id": "a79cffc0-31d0-499d-906c-f271c2320166",
+            "name": "Point-1",
+            "location": {
+              "value": [
+                4.007,
+                0.0,
+                -0.31760000000000005
+              ],
+              "units": "m"
+            }
+          },
+          {
+            "private_attribute_registry_bucket_name": "PointEntityType",
+            "private_attribute_entity_type_name": "Point",
+            "private_attribute_id": "8947eb10-fc59-4102-b9c7-168a91ca22b9",
+            "name": "Point-2",
+            "location": {
+              "value": [
+                4.007,
+                0.0,
+                -0.29760000000000003
+              ],
+              "units": "m"
+            }
+          },
+          {
+            "private_attribute_registry_bucket_name": "PointEntityType",
+            "private_attribute_entity_type_name": "Point",
+            "private_attribute_id": "27ac4e03-592b-4dba-8fa1-8f6678087a96",
+            "name": "Point-3",
+            "location": {
+              "value": [
+                4.007,
+                0.0,
+                -0.2776
+              ],
+              "units": "m"
+            }
+          }
+        ]
+      },
+      "output_fields": {
+        "items": [
+          "mut"
+        ]
+      },
+      "output_type": "ProbeOutput"
+    }
+  ],
+  "private_attribute_asset_cache": {
+    "project_length_unit": null,
+    "project_entity_info": null,
+    "project_variables": [],
+    "use_inhouse_mesher": false,
+    "use_geometry_AI": false
+  }
+}

--- a/tests/simulation/service/test_services_v2.py
+++ b/tests/simulation/service/test_services_v2.py
@@ -176,6 +176,7 @@ def test_validate_error():
         assert err["ctx"]["relevant_for"] == exp_err["ctx"]["relevant_for"]
 
 
+#TODO: Fix this by filtering errors based on the inferred input type
 def test_validate_multiple_errors():
     params_data = {
         "meshing": {
@@ -294,6 +295,7 @@ def test_init():
     assert "velocity_magnitude" not in data["operating_condition"].keys()
     # to convert tuples to lists:
     data = json.loads(json.dumps(data))
+
     compare_dict_to_ref(data, "../../ref/simulation/service_init_geometry.json")
 
     ##2: test default values for volume mesh starting point
@@ -303,6 +305,9 @@ def test_init():
     assert "meshing" not in data
     # to convert tuples to lists:
     data = json.loads(json.dumps(data))
+
+    print(data)
+
     compare_dict_to_ref(data, "../../ref/simulation/service_init_volume_mesh.json")
 
 


### PR DESCRIPTION
@maciej-flexcompute this fixes most of the unit tests (apart from one where I don't want to fix it as the failing unit test is related to error message filtering that we want to implement)

Not sure whether this should be merged - I suppose that depends on whether the `ReferenceGeometry.area` field will get migrated to use expressions in the initial version (which was my understanding - i.e. all scalar/vector fields will be moved to the value/expression union type) or are we only using this for user defined output for now. If it's the second case then I think this PR can be ignored as after frontend finishes integration the `ReferenceGeometry.area` will move back to the value type again...