### PR TITLE
Fix reference computation in op_from_mach_reynolds function

### DIFF
--- a/flow360/component/simulation/operating_condition/operating_condition.py
+++ b/flow360/component/simulation/operating_condition/operating_condition.py
@@ -545,7 +545,9 @@ def operating_condition_from_mach_reynolds(
 
     material = Air()
 
-    velocity = mach * material.get_speed_of_sound(temperature)
+    velocity = (mach if reference_mach is None else reference_mach) * material.get_speed_of_sound(
+        temperature
+    )
 
     density = (
         reynolds * material.get_dynamic_viscosity(temperature) / (velocity * project_length_unit)

--- a/tests/simulation/params/test_simulation_params.py
+++ b/tests/simulation/params/test_simulation_params.py
@@ -355,6 +355,17 @@ def test_mach_reynolds_op_cond():
     assertions.assertAlmostEqual(condition.thermal_state.dynamic_viscosity.value, 1.78929763e-5)
     assertions.assertAlmostEqual(condition.thermal_state.density.value, 1.31452332)
 
+    condition = operating_condition_from_mach_reynolds(
+        mach=0.2,
+        reynolds=5e6,
+        temperature=288.15 * u.K,
+        alpha=2.0 * u.deg,
+        beta=0.0 * u.deg,
+        project_length_unit=u.m,
+        reference_mach=0.4,
+    )
+    assertions.assertAlmostEqual(condition.thermal_state.density.value, 0.6572616596801923)
+
     with pytest.raises(ValueError, match="Input should be greater than 0"):
         condition = operating_condition_from_mach_reynolds(
             mach=0.2,


### PR DESCRIPTION
Fix the bug that the reynolds number is computed based on speed of sound other than reference velocity.

https://docs.flexcompute.com/projects/flow360/en/release-24.2/solverConfiguration/solverConfiguration.html#slidinginterfaces-list:~:text=Description-,Reynolds,-Either%20Reynolds%20or