### PR TITLE
[FL-71][Hotfix RC-25.2] Improve Validation Error For MultiConstructor Model

### DIFF
--- a/flow360/component/simulation/framework/multi_constructor_model_base.py
+++ b/flow360/component/simulation/framework/multi_constructor_model_base.py
@@ -8,7 +8,7 @@
 import abc
 import inspect
 from functools import wraps
-from typing import Any, Callable, Literal, Optional
+from typing import Any, Callable, Literal, Optional, Union
 
 import pydantic as pd
 
@@ -154,6 +154,22 @@ def get_class_by_name(class_name, global_vars):
     return cls
 
 
+def _add_parent_location_to_validation_error(
+    validation_error: pd.ValidationError, parent_loc=None
+) -> pd.ValidationError:
+    """Convert the validation error by appending the parent location"""
+    if parent_loc is None:
+        return validation_error
+    updated_errors = []
+    for error in validation_error.errors():
+        error["loc"] = (parent_loc,) + error["loc"]
+        updated_errors.append(error)
+    return pd.ValidationError.from_exception_data(
+        title=validation_error.title,
+        line_errors=updated_errors,
+    )
+
+
 def model_custom_constructor_parser(model_as_dict, global_vars):
     """Parse the dictionary, construct the object and return obj dict."""
     constructor_name = model_as_dict.get("private_attribute_constructor", None)
@@ -166,16 +182,31 @@ def model_custom_constructor_parser(model_as_dict, global_vars):
             id_kwarg["private_attribute_id"] = model_as_dict["private_attribute_id"]
         if constructor_name != "default":
             constructor = get_class_method(model_cls, constructor_name)
-            return constructor(**(input_kwargs | id_kwarg)).model_dump(exclude_none=True)
+            try:
+                return constructor(**(input_kwargs | id_kwarg)).model_dump(exclude_none=True)
+            except pd.ValidationError as err:
+                # pylint:disable = raise-missing-from
+                raise _add_parent_location_to_validation_error(
+                    validation_error=err, parent_loc="private_attribute_input_cache"
+                )
+
     return model_as_dict
 
 
-def parse_model_dict(model_as_dict, global_vars) -> dict:
+def parse_model_dict(model_as_dict, global_vars, parent_loc: Union[str, int] = None) -> dict:
     """Recursively parses the model dictionary and attempts to construct the multi-constructor object."""
-    if isinstance(model_as_dict, dict):
-        for key, value in model_as_dict.items():
-            model_as_dict[key] = parse_model_dict(value, global_vars)
-        model_as_dict = model_custom_constructor_parser(model_as_dict, global_vars)
-    elif isinstance(model_as_dict, list):
-        model_as_dict = [parse_model_dict(item, global_vars) for item in model_as_dict]
+    try:
+        if isinstance(model_as_dict, dict):
+            for key, value in model_as_dict.items():
+                model_as_dict[key] = parse_model_dict(value, global_vars, key)
+
+            model_as_dict = model_custom_constructor_parser(model_as_dict, global_vars)
+        elif isinstance(model_as_dict, list):
+            model_as_dict = [
+                parse_model_dict(item, global_vars, idx) for idx, item in enumerate(model_as_dict)
+            ]
+    except pd.ValidationError as err:
+        # pylint:disable = raise-missing-from
+        raise _add_parent_location_to_validation_error(validation_error=err, parent_loc=parent_loc)
+
     return model_as_dict

--- a/flow360/component/simulation/meshing_param/edge_params.py
+++ b/flow360/component/simulation/meshing_param/edge_params.py
@@ -43,7 +43,7 @@ class SurfaceEdgeRefinement(Flow360BaseModel):
     Setting for growing anisotropic layers orthogonal to the specified `Edge` (s).
     """
 
-    name: Optional[str] = pd.Field(None)
+    name: Optional[str] = pd.Field("Surface edge refinement")
     refinement_type: Literal["SurfaceEdgeRefinement"] = pd.Field(
         "SurfaceEdgeRefinement", frozen=True
     )

--- a/flow360/component/simulation/meshing_param/face_params.py
+++ b/flow360/component/simulation/meshing_param/face_params.py
@@ -21,7 +21,7 @@ class SurfaceRefinement(Flow360BaseModel):
     Setting for refining surface elements for given `Surface`.
     """
 
-    name: Optional[str] = pd.Field(None)
+    name: Optional[str] = pd.Field("Surface refinement")
     refinement_type: Literal["SurfaceRefinement"] = pd.Field("SurfaceRefinement", frozen=True)
     entities: EntityList[Surface] = pd.Field(alias="faces")
     # pylint: disable=no-member
@@ -42,7 +42,7 @@ class PassiveSpacing(Flow360BaseModel):
     setting or doing nothing to change existing surface mesh at all.
     """
 
-    name: Optional[str] = pd.Field(None)
+    name: Optional[str] = pd.Field("Passive spacing")
     type: Literal["projected", "unchanged"] = pd.Field(
         description="""
         1. When set to *projected*, turn off anisotropic layers growing for this `Surface`. 
@@ -67,7 +67,7 @@ class BoundaryLayer(Flow360BaseModel):
     Setting for growing anisotropic layers orthogonal to the specified `Surface` (s).
     """
 
-    name: Optional[str] = pd.Field(None)
+    name: Optional[str] = pd.Field("Boundary layer refinement")
     refinement_type: Literal["BoundaryLayer"] = pd.Field("BoundaryLayer", frozen=True)
     entities: EntityList[Surface] = pd.Field(alias="faces")
     # pylint: disable=no-member

--- a/flow360/component/simulation/meshing_param/volume_params.py
+++ b/flow360/component/simulation/meshing_param/volume_params.py
@@ -25,7 +25,7 @@ from flow360.component.simulation.validation_utils import (
 class UniformRefinement(Flow360BaseModel):
     """Uniform spacing refinement inside specified region of mesh."""
 
-    name: Optional[str] = pd.Field(None)
+    name: Optional[str] = pd.Field("Uniform refinement")
     refinement_type: Literal["UniformRefinement"] = pd.Field("UniformRefinement", frozen=True)
     entities: EntityList[Box, Cylinder] = pd.Field(
         description=":class:`UniformRefinement` can be applied to :class:`~flow360.Box` "
@@ -58,7 +58,7 @@ class AxisymmetricRefinement(CylindricalRefinementBase):
     - The spacings along the axial, radial and circumferential directions can be adjusted independently.
     """
 
-    name: Optional[str] = pd.Field(None)
+    name: Optional[str] = pd.Field("Axisymmetric refinement")
     refinement_type: Literal["AxisymmetricRefinement"] = pd.Field(
         "AxisymmetricRefinement", frozen=True
     )
@@ -78,7 +78,7 @@ class RotationCylinder(CylindricalRefinementBase):
     # Note: 78d442233fa944e6af8eed4de9541bb1?pvs=4#c2de0b822b844a12aa2c00349d1f68a3
 
     type: Literal["RotationCylinder"] = pd.Field("RotationCylinder", frozen=True)
-    name: Optional[str] = pd.Field(None, description="Name to display in the GUI.")
+    name: Optional[str] = pd.Field("Rotation cylinder", description="Name to display in the GUI.")
     entities: EntityList[Cylinder] = pd.Field()
     enclosed_entities: Optional[EntityList[Cylinder, Surface]] = pd.Field(
         None,

--- a/flow360/component/simulation/migration/BETDisk.py
+++ b/flow360/component/simulation/migration/BETDisk.py
@@ -174,7 +174,7 @@ def read_single_v1_BETDisk(
         return BETDisk(**bet_disk_dict, entities=Cylinder(**cylinder_dict))
     except KeyError as err:
         raise ValueError(
-            "The supplied Flow360 input for BETDisk hsa invalid format. Details: " + str(err) + "."
+            "The supplied Flow360 input for BETDisk has invalid format. Details: " + str(err) + "."
         ) from err
 
 

--- a/flow360/component/simulation/models/bet/bet_translator_interface.py
+++ b/flow360/component/simulation/models/bet/bet_translator_interface.py
@@ -433,6 +433,7 @@ def generate_xfoil_bet_json(
     number_of_blades,
     angle_unit,
     length_unit,
+    name,
 ):
     """
     Take in a geometry input file along with the remaining required
@@ -452,6 +453,7 @@ def generate_xfoil_bet_json(
     twist_vec, chord_vec, sectional_radiuses = parse_geometry_file(
         geometry_file_content, length_unit=length_unit, angle_unit=angle_unit
     )
+    bet_disk["name"] = name
     bet_disk["entities"] = entities.stored_entities
     bet_disk["omega"] = omega
     bet_disk["chord_ref"] = chord_ref
@@ -591,6 +593,7 @@ def generate_c81_bet_json(
     angle_unit,
     length_unit,
     number_of_blades,
+    name,
 ):
     """
     Take in a geometry input file along with the remaining required
@@ -610,6 +613,7 @@ def generate_c81_bet_json(
     )
 
     bet_disk = {}
+    bet_disk["name"] = name
     bet_disk["entities"] = entities.stored_entities
     bet_disk["omega"] = omega
     bet_disk["chord_ref"] = chord_ref
@@ -1417,6 +1421,7 @@ def generate_xrotor_bet_json(
     entities,
     angle_unit,
     length_unit,
+    name,
 ):
     """
     Takes in an XROTOR or DFDC input file and translates it into a flow360 BET input dictionary.
@@ -1435,6 +1440,7 @@ def generate_xrotor_bet_json(
 
     bet_disk = {}
 
+    bet_disk["name"] = name
     bet_disk["entities"] = entities.stored_entities
     bet_disk["omega"] = omega
     bet_disk["chord_ref"] = chord_ref
@@ -1478,6 +1484,7 @@ def generate_dfdc_bet_json(
     entities,
     angle_unit,
     length_unit,
+    name,
 ):
     """
     Takes in an XROTOR or DFDC input file and translates it into a flow360 BET input dictionary.
@@ -1502,4 +1509,5 @@ def generate_dfdc_bet_json(
         entities=entities,
         angle_unit=angle_unit,
         length_unit=length_unit,
+        name=name,
     )

--- a/flow360/component/simulation/models/surface_models.py
+++ b/flow360/component/simulation/models/surface_models.py
@@ -536,7 +536,7 @@ class SlipWall(BoundaryBase):
     """
 
     name: Optional[str] = pd.Field(
-        "SlipWall", description="Name of the `SlipWall` boundary condition."
+        "Slip wall", description="Name of the `SlipWall` boundary condition."
     )
     type: Literal["SlipWall"] = pd.Field("SlipWall", frozen=True)
     entities: EntityList[Surface, GhostSurface, GhostCircularPlane] = pd.Field(
@@ -567,7 +567,7 @@ class SymmetryPlane(BoundaryBase):
     """
 
     name: Optional[str] = pd.Field(
-        "SymmetryPlane", description="Name of the `SymmetryPlane` boundary condition."
+        "Symmetry", description="Name of the `SymmetryPlane` boundary condition."
     )
     type: Literal["SymmetryPlane"] = pd.Field("SymmetryPlane", frozen=True)
     entities: EntityList[Surface, GhostSurface, GhostCircularPlane] = pd.Field(

--- a/flow360/component/simulation/models/volume_models.py
+++ b/flow360/component/simulation/models/volume_models.py
@@ -414,7 +414,7 @@ class ActuatorDisk(Flow360BaseModel):
         description="The force per area input for the `ActuatorDisk` model. "
         + "See :class:`ForcePerArea` documentation."
     )
-    name: Optional[str] = pd.Field(None, description="Name of the `ActuatorDisk` model.")
+    name: Optional[str] = pd.Field("Actuator disk", description="Name of the `ActuatorDisk` model.")
     type: Literal["ActuatorDisk"] = pd.Field("ActuatorDisk", frozen=True)
 
 
@@ -636,7 +636,7 @@ class BETDisk(MultiConstructorBaseModel):
     ====
     """
 
-    name: Optional[str] = pd.Field(None, description="Name of the `BETDisk` model.")
+    name: Optional[str] = pd.Field("BET disk", description="Name of the `BETDisk` model.")
     type: Literal["BETDisk"] = pd.Field("BETDisk", frozen=True)
     type_name: Literal["BETDisk"] = pd.Field("BETDisk", frozen=True)
     entities: EntityList[Cylinder] = pd.Field(alias="volumes")
@@ -1109,7 +1109,7 @@ class Rotation(Flow360BaseModel):
     ====
     """
 
-    name: Optional[str] = pd.Field(None, description="Name of the `Rotation` model.")
+    name: Optional[str] = pd.Field("Rotation", description="Name of the `Rotation` model.")
     type: Literal["Rotation"] = pd.Field("Rotation", frozen=True)
     entities: EntityList[GenericVolume, Cylinder] = pd.Field(
         alias="volumes",
@@ -1193,7 +1193,7 @@ class PorousMedium(Flow360BaseModel):
     ====
     """
 
-    name: Optional[str] = pd.Field(None, description="Name of the `PorousMedium` model.")
+    name: Optional[str] = pd.Field("Porous medium", description="Name of the `PorousMedium` model.")
     type: Literal["PorousMedium"] = pd.Field("PorousMedium", frozen=True)
     entities: EntityList[GenericVolume, Box] = pd.Field(
         alias="volumes",

--- a/flow360/component/simulation/models/volume_models.py
+++ b/flow360/component/simulation/models/volume_models.py
@@ -584,6 +584,7 @@ BETFileTypes = Annotated[
 class BETDiskCache(Flow360BaseModel):
     """[INTERNAL] Cache for BETDisk inputs"""
 
+    name: Optional[str] = None
     file: Optional[BETFileTypes] = None
     rotation_direction_rule: Optional[Literal["leftHand", "rightHand"]] = None
     omega: Optional[AngularVelocityType.NonNegative] = None
@@ -592,7 +593,6 @@ class BETDiskCache(Flow360BaseModel):
     entities: Optional[EntityList[Cylinder]] = None
     angle_unit: Optional[AngleType] = None
     length_unit: Optional[LengthType.NonNegative] = None
-    mesh_unit: Optional[LengthType.NonNegative] = None
     number_of_blades: Optional[pd.StrictInt] = None
     initial_blade_direction: Optional[Axis] = None
     blade_line_chord: Optional[LengthType.NonNegative] = None
@@ -670,34 +670,42 @@ class BETDisk(MultiConstructorBaseModel):
         "inf",
         description="Dimensional distance between blade tip and solid bodies to "
         + "define a :ref:`tip loss factor <TipGap>`.",
+        frozen=True,
     )
     mach_numbers: List[pd.NonNegativeFloat] = pd.Field(
         description="Mach numbers associated with airfoil polars provided "
-        + "in :class:`BETDiskSectionalPolar`."
+        + "in :class:`BETDiskSectionalPolar`.",
+        frozen=True,
     )
     reynolds_numbers: List[pd.PositiveFloat] = pd.Field(
         description="Reynolds numbers associated with the airfoil polars "
-        + "provided in :class:`BETDiskSectionalPolar`."
+        + "provided in :class:`BETDiskSectionalPolar`.",
+        frozen=True,
     )
     alphas: AngleType.Array = pd.Field(
         description="Alphas associated with airfoil polars provided in "
-        + ":class:`BETDiskSectionalPolar`."
+        + ":class:`BETDiskSectionalPolar`.",
+        frozen=True,
     )
     twists: List[BETDiskTwist] = pd.Field(
         description="A list of :class:`BETDiskTwist` objects specifying the twist in degrees as a "
-        + "function of radial location."
+        + "function of radial location.",
+        frozen=True,
     )
     chords: List[BETDiskChord] = pd.Field(
         description="A list of :class:`BETDiskChord` objects specifying the blade chord as a function "
-        + "of the radial location. "
+        + "of the radial location. ",
+        frozen=True,
     )
     sectional_polars: List[BETDiskSectionalPolar] = pd.Field(
         description="A list of :class:`BETDiskSectionalPolar` objects for every radial location specified in "
-        + ":py:attr:`sectional_radiuses`."
+        + ":py:attr:`sectional_radiuses`.",
+        frozen=True,
     )
     sectional_radiuses: LengthType.NonNegativeArray = pd.Field(
         description="A list of the radial locations in grid units at which :math:`C_l` "
-        + "and :math:`C_d` are specified in :class:`BETDiskSectionalPolar`."
+        + "and :math:`C_d` are specified in :class:`BETDiskSectionalPolar`.",
+        frozen=True,
     )
 
     private_attribute_input_cache: BETDiskCache = BETDiskCache()
@@ -741,6 +749,26 @@ class BETDisk(MultiConstructorBaseModel):
         """validate dimension of 3d coefficients in polars"""
         return _check_bet_disk_3d_coefficients_in_polars(self)
 
+    @pd.field_validator(
+        "name",
+        "rotation_direction_rule",
+        "omega",
+        "chord_ref",
+        "n_loading_nodes",
+        "number_of_blades",
+        "entities",
+        "initial_blade_direction",
+        mode="after",
+    )
+    @classmethod
+    def _update_input_cache(cls, value, info: pd.ValidationInfo):
+        setattr(
+            info.data["private_attribute_input_cache"],
+            info.field_name,
+            value if info.field_name != "entities" else value.stored_entities,
+        )
+        return value
+
     # pylint: disable=too-many-arguments, no-self-argument, not-callable
     @MultiConstructorBaseModel.model_constructor
     @pd.validate_call
@@ -757,6 +785,7 @@ class BETDisk(MultiConstructorBaseModel):
         angle_unit: AngleType,
         initial_blade_direction: Optional[Axis] = None,
         blade_line_chord: LengthType.NonNegative = 0 * u.m,
+        name: str = "BET disk",
     ):
         """Constructs a :class: `BETDisk` instance from a given C81 file and additional inputs.
 
@@ -822,6 +851,7 @@ class BETDisk(MultiConstructorBaseModel):
             angle_unit=angle_unit,
             length_unit=length_unit,
             number_of_blades=number_of_blades,
+            name=name,
         )
 
         return cls(**params)
@@ -841,6 +871,7 @@ class BETDisk(MultiConstructorBaseModel):
         angle_unit: AngleType,
         initial_blade_direction: Optional[Axis] = None,
         blade_line_chord: LengthType.NonNegative = 0 * u.m,
+        name: str = "BET disk",
     ):
         """Constructs a :class: `BETDisk` instance from a given DFDC file and additional inputs.
 
@@ -878,7 +909,7 @@ class BETDisk(MultiConstructorBaseModel):
         --------
         Create a BET disk with a DFDC file.
 
-        >>> param = fl.BETDisk.from_xrotor(
+        >>> param = fl.BETDisk.from_dfdc(
         ...     file=fl.DFDCFile(file_path="dfdc_xv15.case")),
         ...     rotation_direction_rule="leftHand",
         ...     omega=0.0046 * fl.u.deg / fl.u.s,
@@ -886,7 +917,6 @@ class BETDisk(MultiConstructorBaseModel):
         ...     n_loading_nodes=20,
         ...     entities=bet_cylinder,
         ...     length_unit=fl.u.m,
-        ...     mesh_unit=fl.u.m,
         ...     angle_unit=fl.u.deg,
         ... )
         """
@@ -902,6 +932,7 @@ class BETDisk(MultiConstructorBaseModel):
             entities=entities,
             angle_unit=angle_unit,
             length_unit=length_unit,
+            name=name,
         )
 
         return cls(**params)
@@ -922,6 +953,7 @@ class BETDisk(MultiConstructorBaseModel):
         number_of_blades: pd.StrictInt,
         initial_blade_direction: Optional[Axis],
         blade_line_chord: LengthType.NonNegative = 0 * u.m,
+        name: str = "BET disk",
     ):
         """Constructs a :class: `BETDisk` instance from a given XROTOR file and additional inputs.
 
@@ -989,6 +1021,7 @@ class BETDisk(MultiConstructorBaseModel):
             angle_unit=angle_unit,
             length_unit=length_unit,
             number_of_blades=number_of_blades,
+            name=name,
         )
 
         return cls(**params)
@@ -1008,6 +1041,7 @@ class BETDisk(MultiConstructorBaseModel):
         angle_unit: AngleType,
         initial_blade_direction: Optional[Axis] = None,
         blade_line_chord: LengthType.NonNegative = 0 * u.m,
+        name: str = "BET disk",
     ):
         """Constructs a :class: `BETDisk` instance from a given XROTOR file and additional inputs.
 
@@ -1068,6 +1102,7 @@ class BETDisk(MultiConstructorBaseModel):
             entities=entities,
             angle_unit=angle_unit,
             length_unit=length_unit,
+            name=name,
         )
 
         return cls(**params)

--- a/flow360/component/simulation/outputs/outputs.py
+++ b/flow360/component/simulation/outputs/outputs.py
@@ -425,7 +425,7 @@ class SurfaceIntegralOutput(Flow360BaseModel):
     ====
     """
 
-    name: str = pd.Field(description="Name of integral.")
+    name: str = pd.Field("Surface integral output", description="Name of integral.")
     entities: EntityList[Surface, GhostSurface, GhostCircularPlane, GhostSphere] = pd.Field(
         alias="surfaces",
         description="List of boundaries where the surface integral will be calculated.",
@@ -486,7 +486,7 @@ class ProbeOutput(Flow360BaseModel):
     ====
     """
 
-    name: str = pd.Field(description="Name of the monitor group.")
+    name: str = pd.Field("Probe output", description="Name of the monitor group.")
     entities: EntityList[Point, PointArray] = pd.Field(
         alias="probe_points",
         description="List of monitored :class:`~flow360.Point`/"
@@ -544,7 +544,7 @@ class SurfaceProbeOutput(Flow360BaseModel):
     ====
     """
 
-    name: str = pd.Field(description="Name of the surface monitor group.")
+    name: str = pd.Field("Surface probe output", description="Name of the surface monitor group.")
     entities: EntityList[Point, PointArray] = pd.Field(
         alias="probe_points",
         description="List of monitored :class:`~flow360.Point`/"
@@ -576,7 +576,7 @@ class SurfaceSliceOutput(_AnimationAndFileFormatSettings):
     Surface slice settings.
     """
 
-    name: str = pd.Field(description="Name of the `SurfaceSliceOutput`.")
+    name: str = pd.Field("Surface slice output", description="Name of the `SurfaceSliceOutput`.")
     entities: EntityList[Slice] = pd.Field(
         alias="slices", description="List of :class:`Slice` entities."
     )
@@ -663,6 +663,9 @@ class TimeAverageProbeOutput(ProbeOutput):
 
     """
 
+    name: Optional[str] = pd.Field(
+        "Time average probe output", description="Name of the `TimeAverageProbeOutput`."
+    )
     # pylint: disable=abstract-method
     frequency: int = pd.Field(
         default=1,
@@ -751,6 +754,10 @@ class TimeAverageSurfaceProbeOutput(SurfaceProbeOutput):
     ====
     """
 
+    name: Optional[str] = pd.Field(
+        "Time average surface probe output",
+        description="Name of the `TimeAverageSurfaceProbeOutput`.",
+    )
     # pylint: disable=abstract-method
     frequency: int = pd.Field(
         default=1,

--- a/flow360/component/simulation/user_defined_dynamics/user_defined_dynamics.py
+++ b/flow360/component/simulation/user_defined_dynamics/user_defined_dynamics.py
@@ -55,7 +55,9 @@ class UserDefinedDynamic(Flow360BaseModel):
 
     """
 
-    name: str = pd.Field(description="Name of the dynamics defined by the user.")
+    name: str = pd.Field(
+        "User defined dynamics", description="Name of the dynamics defined by the user."
+    )
     input_vars: List[str] = pd.Field(
         description="List of the inputs to define the user defined dynamics. For example :code:`CL`, :code:`CD`, "
         + ":code:`bet_NUM_torque`,  :code:`bet_NUM_thrust`, (NUM is the index of the BET disk starting from 0), "

--- a/tests/simulation/converter/ref/ref_c81.json
+++ b/tests/simulation/converter/ref/ref_c81.json
@@ -1,5 +1,5 @@
 {
-    "name": null,
+    "name": "BET disk",
     "type": "BETDisk",
     "entities": {
         "stored_entities": [

--- a/tests/simulation/converter/ref/ref_dfdc.json
+++ b/tests/simulation/converter/ref/ref_dfdc.json
@@ -1,5 +1,5 @@
 {
-    "name": null,
+    "name": "BET disk",
     "type": "BETDisk",
     "entities": {
         "stored_entities": [

--- a/tests/simulation/converter/ref/ref_single_bet_disk.json
+++ b/tests/simulation/converter/ref/ref_single_bet_disk.json
@@ -468,16 +468,59 @@
     "private_attribute_input_cache": {
         "angle_unit": null,
         "blade_line_chord": null,
-        "chord_ref": null,
-        "entities": null,
+        "chord_ref": {
+            "value": 14.0,
+            "units": "cm"
+        },
+        "entities": {
+            "stored_entities": [
+                {
+                    "axis": [
+                        0.0,
+                        0.0,
+                        1.0
+                    ],
+                    "center": {
+                        "units": "cm",
+                        "value": [
+                            0.0,
+                            0.0,
+                            0.0
+                        ]
+                    },
+                    "height": {
+                        "units": "cm",
+                        "value": 15.0
+                    },
+                    "inner_radius": {
+                        "units": "cm",
+                        "value": 0.0
+                    },
+                    "name": "bet_cylinder1",
+                    "outer_radius": {
+                        "units": "cm",
+                        "value": 150.0
+                    },
+                    "private_attribute_entity_type_name": "Cylinder",
+                    "private_attribute_full_name": null,
+                    "private_attribute_registry_bucket_name": "VolumetricEntityType",
+                    "private_attribute_zone_boundary_names": {
+                        "items": []
+                    }
+                }
+            ]
+        },
         "file": null,
         "initial_blade_direction": null,
         "length_unit": null,
-        "mesh_unit": null,
-        "n_loading_nodes": null,
-        "number_of_blades": null,
-        "omega": null,
-        "rotation_direction_rule": null
+        "n_loading_nodes": 20,
+        "name": "BET disk",
+        "number_of_blades": 3,
+        "omega": {
+            "value": 156.5352426717779,
+            "units": "rad/s"
+        },
+        "rotation_direction_rule": "leftHand"
     },
     "reynolds_numbers": [
         1000000.0

--- a/tests/simulation/converter/ref/ref_single_bet_disk.json
+++ b/tests/simulation/converter/ref/ref_single_bet_disk.json
@@ -458,7 +458,7 @@
         0.0
     ],
     "n_loading_nodes": 20,
-    "name": null,
+    "name": "BET disk",
     "number_of_blades": 3,
     "omega": {
         "units": "rad/s",

--- a/tests/simulation/converter/ref/ref_xfoil.json
+++ b/tests/simulation/converter/ref/ref_xfoil.json
@@ -1,5 +1,5 @@
 {
-    "name": null,
+    "name": "BET disk",
     "type": "BETDisk",
     "entities": {
         "stored_entities": [

--- a/tests/simulation/converter/ref/ref_xrotor.json
+++ b/tests/simulation/converter/ref/ref_xrotor.json
@@ -1,5 +1,5 @@
 {
-    "name": null,
+    "name": "BET disk",
     "type": "BETDisk",
     "entities": {
         "stored_entities": [

--- a/tests/simulation/converter/test_bet_disk_flow360_converter.py
+++ b/tests/simulation/converter/test_bet_disk_flow360_converter.py
@@ -29,6 +29,9 @@ def test_single_flow360_bet_convert(atol=1e-15, rtol=1e-10, debug=False):
     disk = disk.model_dump_json()
     disk = json.loads(disk)
     del disk["entities"]["stored_entities"][0]["private_attribute_id"]
+    del disk["private_attribute_input_cache"]["entities"]["stored_entities"][0][
+        "private_attribute_id"
+    ]
     with open("./ref/ref_single_bet_disk.json", mode="r") as fp:
         ref_dict = json.load(fp=fp)
     if debug:
@@ -50,7 +53,7 @@ def test_single_flow360_bet_convert(atol=1e-15, rtol=1e-10, debug=False):
     with pytest.raises(
         ValueError,
         match=re.escape(
-            "The supplied Flow360 input for BETDisk hsa invalid format. Details: 'axisOfRotation'."
+            "The supplied Flow360 input for BETDisk has invalid format. Details: 'axisOfRotation'."
         ),
     ):
         # Wrong usage by supplying incorrect schema json

--- a/tests/simulation/params/test_validators_bet_disk.py
+++ b/tests/simulation/params/test_validators_bet_disk.py
@@ -29,7 +29,7 @@ def test_bet_disk_blade_line_chord(create_steady_bet_disk):
     bet_disk = create_steady_bet_disk
     with pytest.raises(
         ValueError,
-        match="In one of the BETDisk: the blade_line_chord has to be positive since its initial_blade_direction is specified.",
+        match="BETDisk with name 'BET disk': the blade_line_chord has to be positive since its initial_blade_direction is specified.",
     ):
         bet_disk.initial_blade_direction = (1, 0, 0)
 
@@ -40,7 +40,7 @@ def test_bet_disk_initial_blade_direction(create_steady_bet_disk):
 
     with pytest.raises(
         ValueError,
-        match="In one of the BETDisk: the initial_blade_direction is required to specify since its blade_line_chord is non-zero",
+        match="BETDisk with name 'BET disk': the initial_blade_direction is required to specify since its blade_line_chord is non-zero",
     ):
         bet_disk_2 = bet_disk.model_copy(deep=True)
         bet_disk_2.blade_line_chord = 0.1 * u.inch
@@ -60,7 +60,7 @@ def test_bet_disk_disorder_alphas(create_steady_bet_disk):
     bet_disk = create_steady_bet_disk
     with pytest.raises(
         ValueError,
-        match="In one of the BETDisk: the alphas are not in increasing order.",
+        match="BETDisk with name 'BET disk': the alphas are not in increasing order.",
     ):
         tmp = bet_disk.alphas[0]
         bet_disk.alphas[0] = bet_disk.alphas[1]

--- a/tests/simulation/params/test_validators_bet_disk.py
+++ b/tests/simulation/params/test_validators_bet_disk.py
@@ -97,10 +97,12 @@ def test_bet_disk_nonequal_sectional_radiuses_and_polars(create_steady_bet_disk)
         match=r"BETDisk with name 'diskABC': the length of sectional_radiuses \(7\) is not the same as that of sectional_polars \(6\).",
     ):
         bet_disk.name = "diskABC"
-        sectional_radiuses_value = bet_disk.sectional_radiuses.value.tolist()
-        sectional_radiuses_value.append(bet_disk.sectional_radiuses[-1])
-        bet_disk.sectional_radiuses = sectional_radiuses_value * bet_disk.sectional_radiuses.units
-        BETDisk.model_validate(bet_disk)
+        bet_disk_dict = bet_disk.model_dump()
+        bet_disk_dict["sectional_radiuses"]["value"] = bet_disk_dict["sectional_radiuses"][
+            "value"
+        ] + (bet_disk.sectional_radiuses[-1],)
+        bet_disk_error = BETDisk(**bet_disk_dict)
+        BETDisk.model_validate(bet_disk_error)
 
 
 def test_bet_disk_3d_coefficients_dimension_wrong_mach_numbers(create_steady_bet_disk):
@@ -132,8 +134,7 @@ def test_bet_disk_3d_coefficients_dimension_wrong_alpha_numbers(create_steady_be
         match=r"BETDisk with name 'diskABC': \(cross section: 0\) \(Mach index \(0-based\) 0, Reynolds index \(0-based\) 0\): number of Alphas = 18, but the third dimension of lift_coeffs is 17.",
     ):
         bet_disk.name = "diskABC"
-
-        alphas_value = bet_disk.alphas.value.tolist()
-        alphas_value.append(bet_disk.alphas[-1])
-        bet_disk.alphas = alphas_value * bet_disk.alphas.units
-        BETDisk.model_validate(bet_disk)
+        bet_disk_dict = bet_disk.model_dump()
+        bet_disk_dict["alphas"]["value"] = bet_disk_dict["alphas"]["value"] + (bet_disk.alphas[-1],)
+        bet_disk_error = BETDisk(**bet_disk_dict)
+        BETDisk.model_validate(bet_disk_error)

--- a/tests/simulation/service/test_services_v2.py
+++ b/tests/simulation/service/test_services_v2.py
@@ -305,6 +305,317 @@ def test_validate_errors():
     json.dumps(errors)
 
 
+def test_validate_error_from_multi_constructor():
+
+    def _compare_validation_errors(err, exp_err):
+        assert len(errors) == len(expected_errors)
+        for err, exp_err in zip(errors, expected_errors):
+            assert err["loc"] == exp_err["loc"]
+            assert err["type"] == exp_err["type"]
+            assert err["msg"] == exp_err["msg"]
+            assert err["input"] == exp_err["input"]
+            assert err["ctx"] == exp_err["ctx"]
+
+    # test from_mach() with two validation errors within private_attribute_input_cache
+    params_data = {
+        "operating_condition": {
+            "private_attribute_constructor": "from_mach",
+            "type_name": "AerospaceCondition",
+            "private_attribute_input_cache": {
+                "mach": -1,
+                "alpha": {"value": 0, "units": "degree"},
+                "beta": {"value": 0, "units": "degree"},
+                "thermal_state": {
+                    "type_name": "ThermalState",
+                    "private_attribute_constructor": "default",
+                    "density": {"value": -2, "units": "kg/m**3"},
+                    "temperature": {"value": 288.15, "units": "K"},
+                },
+            },
+        },
+        "unit_system": {"name": "SI"},
+        "version": "24.11.5",
+    }
+
+    _, errors, _ = services.validate_model(
+        params_as_dict=params_data,
+        validated_by=services.ValidationCalledBy.LOCAL,
+        root_item_type="VolumeMesh",
+    )
+
+    expected_errors = [
+        {
+            "loc": ("operating_condition", "private_attribute_input_cache", "mach"),
+            "type": "greater_than_equal",
+            "msg": "Input should be greater than or equal to 0",
+            "input": -1,
+            "ctx": {"ge": "0.0"},
+        },
+        {
+            "loc": (
+                "operating_condition",
+                "private_attribute_input_cache",
+                "thermal_state",
+                "density",
+                "value",
+            ),
+            "type": "greater_than",
+            "msg": "Input should be greater than 0",
+            "input": -2,
+            "ctx": {"gt": "0.0"},
+        },
+    ]
+    _compare_validation_errors(errors, expected_errors)
+
+    # test BETDisk.from_dfdc() with:
+    #   1. one validation error within private_attribute_input_cache
+    #   2. an extra BETDiskCache argument for the dfdc constructor
+    #   3. one validation error outside the input_cache
+    params_data = {
+        "models": [
+            {
+                "name": "BET disk",
+                "private_attribute_constructor": "from_dfdc",
+                "private_attribute_input_cache": {
+                    "angle_unit": {"units": "degree", "value": 1.0},
+                    "blade_line_chord": {"units": "m", "value": 5.0},
+                    "chord_ref": {"units": "m", "value": -14.0},
+                    "entities": {
+                        "stored_entities": [
+                            {
+                                "axis": [0.0, 0.0, 1.0],
+                                "center": {"units": "m", "value": [0.0, 0.0, 0.0]},
+                                "height": {"units": "m", "value": -15.0},
+                                "inner_radius": {"units": "m", "value": 0.0},
+                                "name": "BET_cylinder",
+                                "outer_radius": {"units": "m", "value": 3.81},
+                                "private_attribute_entity_type_name": "Cylinder",
+                                "private_attribute_full_name": None,
+                                "private_attribute_id": "ca0d3a3f-49cb-4637-a789-744c643ce955",
+                                "private_attribute_registry_bucket_name": "VolumetricEntityType",
+                                "private_attribute_zone_boundary_names": {"items": []},
+                            }
+                        ]
+                    },
+                    "file": {
+                        "content": "DFDC Version 0.70E+03\nvb block 1 c 25 HP SLS\n\nOPER\n!   Vinf         Vref         RPM1\n   0.000       10.000         15.0\n!   Rho          Vso          Rmu          Alt\n   1.0          342.0      0.17791E-04  0.30000E-01\n!  XDwake             Nwake\n   1.0000               20\n!        Lwkrlx\n            F\nENDOPER\n\nAERO\n!  #sections\n     5\n!  Xisection\n  0.09\n  !       A0deg        dCLdA        CLmax         CLmin\n    -6.5           4.000       1.2500     -0.0000\n  !  dCLdAstall     dCLstall      Cmconst         Mcrit\n    0.10000      0.10000     -0.10000      0.75000\n  !       CDmin      CLCDmin     dCDdCL^2\n    0.075000E-01  0.00000      0.40000E-02\n  !       REref        REexp\n    0.30000E+06 -0.70000\n    0.17\n  !       A0deg        dCLdA        CLmax         CLmin\n          -6.0         6.0       1.300     -0.55000\n  !  dCLdAstall     dCLstall      Cmconst         Mcrit\n      0.10000      0.10000     -0.10000      0.75000\n  !       CDmin      CLCDmin     dCDdCL^2\n      0.075000E-01  0.10000      0.40000E-02\n  !       REref        REexp\n      0.30000E+06 -0.70000\n     0.51\n  !       A0deg        dCLdA        CLmax         CLmin\n     -1.0       6.00                1.400     -1.4000\n  !  dCLdAstall     dCLstall      Cmconst         Mcrit\n       0.10000      0.10000     -0.10000      0.75000\n  !       CDmin      CLCDmin     dCDdCL^2\n       0.05000E-01  0.10000      0.40000E-02\n  !       REref        REexp\n       0.30000E+06 -0.70000\n    0.8\n  !       A0deg        dCLdA        CLmax         CLmin\n         -1.0      6.0       1.600     -1.500\n  !  dCLdAstall     dCLstall      Cmconst         Mcrit\n           0.10000      0.10000     -0.10000      0.75000\n  !       CDmin      CLCDmin     dCDdCL^2\n           0.03000E-01  0.10000      0.40000E-02\n  !       REref        REexp\n           0.30000E+06 -0.70000\n    1.0\n  !       A0deg        dCLdA        CLmax         CLmin\n            -1          6.0           1.0     -1.8000\n  !  dCLdAstall     dCLstall      Cmconst         Mcrit\n        0.10000      0.10000     -0.10000      0.75000\n  !       CDmin      CLCDmin     dCDdCL^2\n          0.04000E-01  0.10000      0.40000E-02\n  !       REref        REexp\n        0.30000E+06 -0.70000\nENDAERO\n\nROTOR\n!  Xdisk               Nblds       NRsta\n  150                   3           63\n!  #stations\n    63\n!      r        C       Beta0deg\n0.087645023\t0.432162215\t33.27048712\n0.149032825\t0.432162215\t32.37853609\n0.230063394\t0.432162215\t31.42712165\n0.31845882\t0.432162215\t30.65409742\n0.354421836\t0.432162215\t30.13214089\n0.412445831\t0.432162215\t29.41523066\n0.465733177\t0.425230275\t28.75567325\n0.535598785\t0.418298338\t27.89538097\n0.607834576\t0.411366397\t26.69097178\n0.657570537\t0.404434457\t25.88803232\n0.695464717\t0.39750252\t25.25715132\n0.733359236\t0.390570579\t24.5689175\n0.773621567\t0.383638638\t23.93803649\n0.818620882\t0.376706702\t23.19244985\n0.86598886\t0.369774761\t22.36083398\n0.912171916\t0.36284282\t21.67260016\n0.958355818\t0.355910895\t20.84098429\n1.008092457\t0.355906578\t19.92333919\n1.051908539\t0.355902261\t19.03437051\n1.090987133\t0.355897941\t18.34613668\n1.134803219\t0.355893624\t17.457168\n1.17980135\t0.355889307\t16.91231622\n1.229536976\t0.355884987\t16.16672958\n1.275719693\t0.35588067\t15.53584858\n1.314797781\t0.355876353\t14.93364398\n1.358613021\t0.355872033\t14.18805734\n1.398875352\t0.355867716\t13.55717634\n1.42966541\t0.355863399\t12.86894251\n1.468744004\t0.355859079\t12.18070869\n1.51019075\t0.355854762\t11.49247487\n1.549268331\t0.355850445\t10.9762995\n1.596633604\t0.355846125\t10.60350618\n1.6629458\t0.355841808\t9.94394877\n1.717417226\t0.355837491\t9.28439136\n1.773072894\t0.355833171\t8.59615753\n1.81688746\t0.355828854\t7.96527653\n1.866622407\t0.355824537\t7.33439553\n1.893858878\t0.355820217\t6.87557298\n1.949512352\t0.3558159\t6.56013248\n2.015823535\t0.355811583\t6.07263352\n2.07503076\t0.355807263\t5.49910533\n2.124764355\t0.355802946\t5.0976356\n2.169761643\t0.355798629\t4.69616587\n2.231337023\t0.355794309\t4.12263769\n2.273965822\t0.355789992\t3.77852078\n2.321330759\t0.355785675\t3.46308028\n2.395930475\t0.355781355\t2.97558132\n2.533289143\t0.355777038\t2.0005834\n2.61499265\t0.355772721\t1.62779008\n2.664726078\t0.355768401\t1.25499676\n2.709722688\t0.355764084\t0.96823267\n2.768929239\t0.355759767\t0.50941012\n2.839977235\t0.355755447\t-0.064118065\n2.906288246\t0.35575113\t-0.522940614\n3.03772619\t0.355746813\t-1.44058571\n3.208240195\t0.355742493\t-2.61631849\n3.342045113\t0.355738176\t-3.333228722\n3.481771091\t0.355733859\t-4.164844591\n3.56702767\t0.355729539\t-4.681019957\n3.647547098\t0.355725222\t-5.053813278\n3.725699048\t0.355720905\t-5.541312235\n3.770695491\t0.355716585\t-5.799399919\n3.81\t0.355714554\t-6.1\nENDROTOR\n\nGEOM\n    /IGNORED BELOW THIS POINT\n",
+                        "file_path": "aba",
+                        "type_name": "DFDCFile",
+                    },
+                    "initial_blade_direction": [1.0, 0.0, 0.0],
+                    "length_unit": {"units": "m", "value": 1.0},
+                    "n_loading_nodes": 20,
+                    "omega": {"units": "degree/s", "value": 0.0046},
+                    "rotation_direction_rule": "leftHand",
+                    "number_of_blades": 2,
+                },
+                "type": "BETDisk",
+                "type_name": "BETDisk",
+            },
+            {
+                "entities": {"stored_entities": []},
+                "heat_spec": {"type_name": "HeatFlux", "value": {"units": "W/m**2", "value": 0.0}},
+                "name": "Wall",
+                "roughness_height": {"units": "m", "value": -10.0},
+                "type": "Wall",
+                "use_wall_function": False,
+                "velocity": None,
+            },
+        ],
+        "unit_system": {"name": "SI"},
+        "version": "24.11.5",
+    }
+
+    _, errors, _ = services.validate_model(
+        params_as_dict=params_data,
+        validated_by=services.ValidationCalledBy.LOCAL,
+        root_item_type="VolumeMesh",
+    )
+
+    expected_errors = [
+        {
+            "loc": ("models", 0, "private_attribute_input_cache", "chord_ref", "value"),
+            "type": "greater_than",
+            "msg": "Input should be greater than 0",
+            "input": -14,
+            "ctx": {"gt": "0.0"},
+        },
+        {
+            "loc": (
+                "models",
+                0,
+                "private_attribute_input_cache",
+                "entities",
+                "stored_entities",
+                0,
+                "height",
+                "value",
+            ),
+            "type": "greater_than",
+            "msg": "Input should be greater than 0",
+            "input": -15,
+            "ctx": {"gt": "0.0"},
+        },
+        {
+            "type": "unexpected_keyword_argument",
+            "loc": ("models", 0, "private_attribute_input_cache", "number_of_blades"),
+            "msg": "Unexpected keyword argument",
+            "input": 2,
+            "ctx": {},
+        },
+    ]
+    _compare_validation_errors(errors, expected_errors)
+
+    # test Box.from_principal_axes() with one validation error within private_attribute_input_cache
+    # the multiconstructor call is within a default constructor call
+    params_data = {
+        "models": [
+            {
+                "darcy_coefficient": {"units": "m**(-2)", "value": [1000000.0, 0.0, 0.0]},
+                "entities": {
+                    "stored_entities": [
+                        {
+                            "angle_of_rotation": {"units": "rad", "value": -2.0943951023931953},
+                            "axis_of_rotation": [
+                                -0.5773502691896257,
+                                -0.5773502691896257,
+                                -0.5773502691896261,
+                            ],
+                            "center": {"units": "m", "value": [0, 0, 0]},
+                            "name": "porous_zone",
+                            "private_attribute_constructor": "from_principal_axes",
+                            "private_attribute_entity_type_name": "Box",
+                            "private_attribute_full_name": None,
+                            "private_attribute_id": "69751367-210b-4df3-b4cd-1f2adbd866ed",
+                            "private_attribute_input_cache": {
+                                "axes": [[0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
+                                "center": {"units": "m", "value": [0, 0, 0]},
+                                "name": "porous_zone",
+                                "size": {"units": "m", "value": [0.2, 0.3, -2.0]},
+                            },
+                            "private_attribute_registry_bucket_name": "VolumetricEntityType",
+                            "private_attribute_zone_boundary_names": {"items": []},
+                            "size": {"units": "m", "value": [0.2, 0.3, 2.0]},
+                            "type_name": "Box",
+                        }
+                    ]
+                },
+                "forchheimer_coefficient": {"units": "1/m", "value": [1, 0, 0]},
+                "name": "Porous medium",
+                "type": "PorousMedium",
+                "volumetric_heat_source": {"units": "W/m**3", "value": 1.0},
+            }
+        ],
+        "unit_system": {"name": "SI"},
+        "version": "24.11.5",
+    }
+
+    _, errors, _ = services.validate_model(
+        params_as_dict=params_data,
+        validated_by=services.ValidationCalledBy.LOCAL,
+        root_item_type="VolumeMesh",
+    )
+    expected_errors = [
+        {
+            "type": "value_error",
+            "loc": (
+                "models",
+                0,
+                "entities",
+                "stored_entities",
+                0,
+                "private_attribute_input_cache",
+                "size",
+            ),
+            "msg": "Value error, arg '[ 0.2  0.3 -2. ] m' cannot have negative value",
+            "input": {"units": "m", "value": [0.2, 0.3, -2.0]},
+            "ctx": {"error": "arg '[ 0.2  0.3 -2. ] m' cannot have negative value"},
+        }
+    ]
+    _compare_validation_errors(errors, expected_errors)
+
+    # test ThermalState.from_standard_atmosphere() with one validation error within private_attribute_input_cache
+    # the multiconstructor call is nested in another multiconstructor call
+    params_data = {
+        "operating_condition": {
+            "alpha": {"units": "degree", "value": 0.0},
+            "beta": {"units": "degree", "value": 0.0},
+            "private_attribute_constructor": "from_mach",
+            "private_attribute_input_cache": {
+                "alpha": {"units": "degree", "value": 0.0},
+                "beta": {"units": "degree", "value": 0.0},
+                "mach": -1,
+                "reference_mach": None,
+                "thermal_state": {
+                    "density": {"units": "kg/m**3", "value": 1.1724995324950298},
+                    "material": {
+                        "dynamic_viscosity": {
+                            "effective_temperature": {"units": "K", "value": 110.4},
+                            "reference_temperature": {"units": "K", "value": 273.15},
+                            "reference_viscosity": {"units": "Pa*s", "value": 1.716e-05},
+                        },
+                        "name": "air",
+                        "type": "air",
+                    },
+                    "private_attribute_constructor": "from_standard_atmosphere",
+                    "private_attribute_input_cache": {
+                        "altitude": {"units": "m", "value": 100.0},
+                        "temperature_offset": {"units": "K", "value": 10.0},
+                    },
+                    "temperature": {"units": "K", "value": 297.5000102251644},
+                    "type_name": "ThermalState",
+                },
+            },
+            "reference_velocity_magnitude": None,
+            "thermal_state": {
+                "density": {"units": "kg/m**3", "value": 1.1724995324950298},
+                "material": {
+                    "dynamic_viscosity": {
+                        "effective_temperature": {"units": "K", "value": 110.4},
+                        "reference_temperature": {"units": "K", "value": 273.15},
+                        "reference_viscosity": {"units": "Pa*s", "value": 1.716e-05},
+                    },
+                    "name": "air",
+                    "type": "air",
+                },
+                "private_attribute_constructor": "from_standard_atmosphere",
+                "private_attribute_input_cache": {
+                    "altitude": {"units": "K", "value": 100.0},
+                    "temperature_offset": {"units": "K", "value": 10.0},
+                },
+                "temperature": {"units": "K", "value": 297.5000102251644},
+                "type_name": "ThermalState",
+            },
+            "type_name": "AerospaceCondition",
+            "velocity_magnitude": {"units": "m/s", "value": 34.57709313392731},
+        },
+        "unit_system": {"name": "SI"},
+        "version": "24.11.5",
+    }
+
+    _, errors, _ = services.validate_model(
+        params_as_dict=params_data,
+        validated_by=services.ValidationCalledBy.LOCAL,
+        root_item_type="VolumeMesh",
+    )
+
+    expected_errors = [
+        {
+            "type": "value_error",
+            "loc": (
+                "operating_condition",
+                "thermal_state",
+                "private_attribute_input_cache",
+                "altitude",
+            ),
+            "msg": "Value error, arg '100.0 K' does not match (length) dimension.",
+            "input": None,
+            "ctx": {"error": "arg '100.0 K' does not match (length) dimension."},
+        }
+    ]
+    _compare_validation_errors(errors, expected_errors)
+
+
 def test_init():
     ##1: test default values for geometry starting point
     data = services.get_default_params(


### PR DESCRIPTION
* Remove typo and unused parameter in BETDiskCache

* Add function to convert multiconstructor validation error

* Add unit test

* Add function to update input cache

* Address comments

* fix unit test

* formatting

* fix unit test

* Add name to the BETDiskCache

* Add an unit test to test the extra input_cache key for the used constructor

Also includes the hotfix of #901