### PR TITLE
Added ability to convert expressions to C++ syntax

### DIFF
--- a/flow360/component/simulation/blueprint/__init__.py
+++ b/flow360/component/simulation/blueprint/__init__.py
@@ -1,7 +1,7 @@
 """Blueprint: Safe function serialization and visual programming integration."""
 
 from .codegen.generator import model_to_function
-from .codegen.parser import expression_to_model, function_to_model
+from .codegen.parser import expr_to_model, function_to_model
 from .core.function import Function
 
-__all__ = ["Function", "function_to_model", "model_to_function", "expression_to_model"]
+__all__ = ["Function", "function_to_model", "model_to_function", "expr_to_model"]

--- a/flow360/component/simulation/blueprint/codegen/generator.py
+++ b/flow360/component/simulation/blueprint/codegen/generator.py
@@ -1,3 +1,4 @@
+import functools
 from typing import Any
 
 from ..core.expressions import (
@@ -9,10 +10,12 @@ from ..core.expressions import (
     Name,
     RangeCall,
     Tuple,
+    UnaryOp,
 )
 from ..core.function import Function
 from ..core.statements import Assign, AugAssign, ForLoop, IfElse, Return, TupleUnpack
-from ..utils.operators import BINARY_OPERATORS
+from ..utils.operators import BINARY_OPERATORS, UNARY_OPERATORS
+from ..utils.types import TargetSyntax
 
 
 def _indent(code: str, level: int = 1) -> str:
@@ -21,33 +24,77 @@ def _indent(code: str, level: int = 1) -> str:
     return "\n".join(spaces + line if line else line for line in code.split("\n"))
 
 
-def expr_to_code(expr: Any) -> str:
-    """Convert an expression model back to Python code."""
-    if expr is None:
+def check_syntax_type(func):
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        result = func(*args, **kwargs)
+        if result is None:
+            raise ValueError(
+                f"Unsupported syntax type, available {[syntax.name for syntax in TargetSyntax]}"
+            )
+        return result
+
+    return wrapper
+
+
+@check_syntax_type
+def _empty(syntax):
+    if syntax == TargetSyntax.PYTHON:
         return "None"
+    elif syntax == TargetSyntax.CPP:
+        return "nullptr"
 
-    if isinstance(expr, Name):
-        return expr.id
 
-    elif isinstance(expr, Constant):
-        if isinstance(expr.value, str):
-            return f"'{expr.value}'"
-        return str(expr.value)
+@check_syntax_type
+def _name(expr, remap):
+    return expr.id if expr.id not in remap else remap[expr.id]
 
-    elif isinstance(expr, BinOp):
-        op_info = BINARY_OPERATORS[expr.op]
-        return f"({expr_to_code(expr.left)} {op_info.symbol} {expr_to_code(expr.right)})"
 
-    elif isinstance(expr, RangeCall):
-        return f"range({expr_to_code(expr.arg)})"
+@check_syntax_type
+def _constant(expr):
+    if isinstance(expr.value, str):
+        return f"'{expr.value}'"
+    return str(expr.value)
 
-    elif isinstance(expr, CallModel):
-        args_str = ", ".join(expr_to_code(arg) for arg in expr.args)
+
+@check_syntax_type
+def _unary_op(expr, syntax, remap):
+    op_info = UNARY_OPERATORS[expr.op]
+    return f"{op_info.symbol}{expr_to_code(expr.operand, syntax, remap)}"
+
+
+@check_syntax_type
+def _binary_op(expr, syntax, remap):
+    if syntax == TargetSyntax.CPP:
+        # Special case handling for operators not directly supported in CPP syntax, requires #include <cmath>
+        if expr.op == "FloorDiv":
+            return f"floor({expr_to_code(expr.left, syntax, remap)} / {expr_to_code(expr.right, syntax, remap)})"
+        if expr.op == "Pow":
+            return f"pow({expr_to_code(expr.left, syntax, remap)}, {expr_to_code(expr.right, syntax, remap)})"
+        if expr.op == "Is":
+            return f"&{expr_to_code(expr.left, syntax, remap)} == &{expr_to_code(expr.right, syntax, remap)}"
+
+    op_info = BINARY_OPERATORS[expr.op]
+    return f"({expr_to_code(expr.left, syntax, remap)} {op_info.symbol} {expr_to_code(expr.right, syntax, remap)})"
+
+
+@check_syntax_type
+def _range_call(expr, syntax, remap):
+    if syntax == TargetSyntax.PYTHON:
+        return f"range({expr_to_code(expr.arg, syntax, remap)})"
+
+    raise ValueError("Range calls are only supported for Python target syntax")
+
+
+@check_syntax_type
+def _call_model(expr, syntax, remap):
+    if syntax == TargetSyntax.PYTHON:
+        args_str = ", ".join(expr_to_code(arg, syntax, remap) for arg in expr.args)
         kwargs_parts = []
         for k, v in expr.kwargs.items():
             if v is None:
                 continue
-            val_str = expr_to_code(v)
+            val_str = expr_to_code(v, syntax, remap)
             if not val_str or val_str.isspace():
                 continue
             kwargs_parts.append(f"{k}={val_str}")
@@ -55,96 +102,166 @@ def expr_to_code(expr: Any) -> str:
         kwargs_str = ", ".join(kwargs_parts)
         all_args = ", ".join(x for x in [args_str, kwargs_str] if x)
         return f"{expr.func_qualname}({all_args})"
+    elif syntax == TargetSyntax.CPP:
+        args_str = ", ".join(expr_to_code(arg, syntax, remap) for arg in expr.args)
+        if expr.kwargs:
+            raise ValueError("Named arguments are not supported in C++ syntax")
+        return f"{expr.func_qualname}({args_str})"
 
-    elif isinstance(expr, Tuple):
+
+@check_syntax_type
+def _tuple(expr, syntax, remap):
+    if syntax == TargetSyntax.PYTHON:
         if len(expr.elements) == 0:
             return "()"
         elif len(expr.elements) == 1:
-            return f"({expr_to_code(expr.elements[0])},)"
-        return f"({', '.join(expr_to_code(e) for e in expr.elements)})"
+            return f"({expr_to_code(expr.elements[0], syntax, remap)},)"
+        return f"({', '.join(expr_to_code(e, syntax, remap) for e in expr.elements)})"
+    elif syntax == TargetSyntax.CPP:
+        if len(expr.elements) == 0:
+            return "{}"
+        elif len(expr.elements) == 1:
+            return f"{{{expr_to_code(expr.elements[0], syntax, remap)}}}"
+        return f"{{{', '.join(expr_to_code(e, syntax, remap) for e in expr.elements)}}}"
 
-    elif isinstance(expr, List):
+
+@check_syntax_type
+def _list(expr, syntax, remap):
+    if syntax == TargetSyntax.PYTHON:
         if not expr.elements:
             return "[]"
-        elements = [expr_to_code(e) for e in expr.elements]
+        elements = [expr_to_code(e, syntax, remap) for e in expr.elements]
         elements_str = ", ".join(elements)
         return f"[{elements_str}]"
+    elif syntax == TargetSyntax.CPP:
+        if len(expr.elements) == 0:
+            return "{}"
+        return f"{{{', '.join(expr_to_code(e, syntax, remap) for e in expr.elements)}}}"
+
+
+def _list_comp(expr, syntax, remap):
+    if syntax == TargetSyntax.PYTHON:
+        return f"[{expr_to_code(expr.element, syntax, remap)} for {expr.target, syntax, remap} in {expr_to_code(expr.iter, syntax, remap)}]"
+
+    raise ValueError("List comprehensions are only supported for Python target syntax")
+
+
+def expr_to_code(
+    expr: Any, syntax: TargetSyntax = TargetSyntax.PYTHON, remap: dict[str, str] = None
+) -> str:
+    """Convert an expression model back to source code."""
+    if expr is None:
+        return _empty(syntax)
+
+    # Names and constants are language-agnostic (apart from symbol remaps)
+    if isinstance(expr, Name):
+        return _name(expr, remap)
+
+    elif isinstance(expr, Constant):
+        return _constant(expr)
+
+    elif isinstance(expr, UnaryOp):
+        return _unary_op(expr, syntax, remap)
+
+    elif isinstance(expr, BinOp):
+        return _binary_op(expr, syntax, remap)
+
+    elif isinstance(expr, RangeCall):
+        return _range_call(expr, syntax, remap)
+
+    elif isinstance(expr, CallModel):
+        return _call_model(expr, syntax, remap)
+
+    elif isinstance(expr, Tuple):
+        return _tuple(expr, syntax, remap)
+
+    elif isinstance(expr, List):
+        return _list(expr, syntax, remap)
 
     elif isinstance(expr, ListComp):
-        return f"[{expr_to_code(expr.element)} for {expr.target} in {expr_to_code(expr.iter)}]"
+        return _list_comp(expr, syntax, remap)
 
     else:
         raise ValueError(f"Unsupported expression type: {type(expr)}")
 
 
-def stmt_to_code(stmt: Any) -> str:
-    """Convert a statement model back to Python code."""
-    if isinstance(stmt, Assign):
-        if stmt.target == "_":  # Expression statement
-            return expr_to_code(stmt.value)
-        return f"{stmt.target} = {expr_to_code(stmt.value)}"
+def stmt_to_code(
+    stmt: Any, syntax: TargetSyntax = TargetSyntax.PYTHON, remap: dict[str, str] = None
+) -> str:
+    if syntax == TargetSyntax.PYTHON:
+        """Convert a statement model back to source code."""
+        if isinstance(stmt, Assign):
+            if stmt.target == "_":  # Expression statement
+                return expr_to_code(stmt.value)
+            return f"{stmt.target} = {expr_to_code(stmt.value, syntax, remap)}"
 
-    elif isinstance(stmt, AugAssign):
-        op_map = {
-            "Add": "+=",
-            "Sub": "-=",
-            "Mult": "*=",
-            "Div": "/=",
-        }
-        op_str = op_map.get(stmt.op, f"{stmt.op}=")
-        return f"{stmt.target} {op_str} {expr_to_code(stmt.value)}"
+        elif isinstance(stmt, AugAssign):
+            op_map = {
+                "Add": "+=",
+                "Sub": "-=",
+                "Mult": "*=",
+                "Div": "/=",
+            }
+            op_str = op_map.get(stmt.op, f"{stmt.op}=")
+            return f"{stmt.target} {op_str} {expr_to_code(stmt.value, syntax, remap)}"
 
-    elif isinstance(stmt, IfElse):
-        code = [f"if {expr_to_code(stmt.condition)}:"]
-        code.append(_indent("\n".join(stmt_to_code(s) for s in stmt.body)))
-        if stmt.orelse:
-            code.append("else:")
-            code.append(_indent("\n".join(stmt_to_code(s) for s in stmt.orelse)))
-        return "\n".join(code)
+        elif isinstance(stmt, IfElse):
+            code = [f"if {expr_to_code(stmt.condition)}:"]
+            code.append(_indent("\n".join(stmt_to_code(s, syntax, remap) for s in stmt.body)))
+            if stmt.orelse:
+                code.append("else:")
+                code.append(_indent("\n".join(stmt_to_code(s, syntax, remap) for s in stmt.orelse)))
+            return "\n".join(code)
 
-    elif isinstance(stmt, ForLoop):
-        code = [f"for {stmt.target} in {expr_to_code(stmt.iter)}:"]
-        code.append(_indent("\n".join(stmt_to_code(s) for s in stmt.body)))
-        return "\n".join(code)
+        elif isinstance(stmt, ForLoop):
+            code = [f"for {stmt.target} in {expr_to_code(stmt.iter)}:"]
+            code.append(_indent("\n".join(stmt_to_code(s, syntax, remap) for s in stmt.body)))
+            return "\n".join(code)
 
-    elif isinstance(stmt, Return):
-        return f"return {expr_to_code(stmt.value)}"
+        elif isinstance(stmt, Return):
+            return f"return {expr_to_code(stmt.value, syntax, remap)}"
 
-    elif isinstance(stmt, TupleUnpack):
-        targets = ", ".join(stmt.targets)
-        if len(stmt.values) == 1:
-            # Single expression that evaluates to a tuple
-            return f"{targets} = {expr_to_code(stmt.values[0])}"
-        else:
-            # Multiple expressions
-            values = ", ".join(expr_to_code(v) for v in stmt.values)
-            return f"{targets} = {values}"
-
-    else:
-        raise ValueError(f"Unsupported statement type: {type(stmt)}")
-
-
-def model_to_function(func: Function) -> str:
-    """Convert a Function model back to Python code."""
-    # Build the function signature
-    args_with_defaults = []
-    for arg in func.args:
-        if arg in func.defaults:
-            default_val = func.defaults[arg]
-            if isinstance(default_val, int | float | bool | str):
-                args_with_defaults.append(f"{arg}={default_val}")
+        elif isinstance(stmt, TupleUnpack):
+            targets = ", ".join(stmt.targets)
+            if len(stmt.values) == 1:
+                # Single expression that evaluates to a tuple
+                return f"{targets} = {expr_to_code(stmt.values[0], syntax, remap)}"
             else:
-                args_with_defaults.append(f"{arg}={expr_to_code(default_val)}")
+                # Multiple expressions
+                values = ", ".join(expr_to_code(v, syntax, remap) for v in stmt.values)
+                return f"{targets} = {values}"
         else:
-            args_with_defaults.append(arg)
+            raise ValueError(f"Unsupported statement type: {type(stmt)}")
 
-    signature = f"def {func.name}({', '.join(args_with_defaults)}):"
+    raise NotImplementedError("Statement translation is not available for other syntax types yet")
 
-    # Convert the function body
-    body_lines = []
-    for stmt in func.body:
-        line = stmt_to_code(stmt)
-        body_lines.append(line)
 
-    body = "\n".join(body_lines) if body_lines else "pass"
-    return f"{signature}\n{_indent(body)}"
+def model_to_function(
+    func: Function, syntax: TargetSyntax = TargetSyntax.PYTHON, remap: dict[str, str] = None
+) -> str:
+    if syntax == TargetSyntax.PYTHON:
+        """Convert a Function model back to source code."""
+        # Build the function signature
+        args_with_defaults = []
+        for arg in func.args:
+            if arg in func.defaults:
+                default_val = func.defaults[arg]
+                if isinstance(default_val, (int, float, str, bool)):
+                    args_with_defaults.append(f"{arg}={default_val}")
+                else:
+                    args_with_defaults.append(f"{arg}={expr_to_code(default_val, syntax, remap)}")
+            else:
+                args_with_defaults.append(arg)
+
+        signature = f"def {func.name}({', '.join(args_with_defaults)}):"
+
+        # Convert the function body
+        body_lines = []
+        for stmt in func.body:
+            line = stmt_to_code(stmt)
+            body_lines.append(line)
+
+        body = "\n".join(body_lines) if body_lines else "pass"
+        return f"{signature}\n{_indent(body)}"
+
+    raise NotImplementedError("Function translation is not available for other syntax types yet")

--- a/flow360/component/simulation/blueprint/codegen/parser.py
+++ b/flow360/component/simulation/blueprint/codegen/parser.py
@@ -224,7 +224,7 @@ def function_to_model(
     return Function(name=name, args=args, body=body, defaults=defaults)
 
 
-def expression_to_model(
+def expr_to_model(
     source: str,
     ctx: EvaluationContext,
 ) -> Expression:

--- a/flow360/component/simulation/blueprint/utils/operators.py
+++ b/flow360/component/simulation/blueprint/utils/operators.py
@@ -2,6 +2,8 @@ import operator
 from collections.abc import Callable
 from typing import Any, Union
 
+from .types import TargetSyntax
+
 
 class OpInfo:
     """Class to hold operator information."""

--- a/flow360/component/simulation/blueprint/utils/types.py
+++ b/flow360/component/simulation/blueprint/utils/types.py
@@ -1,0 +1,7 @@
+from enum import Enum
+
+
+class TargetSyntax(Enum):
+    PYTHON = ("python",)
+    CPP = ("cpp",)
+    # Possibly other languages in the future if needed...

--- a/flow360/component/simulation/services.py
+++ b/flow360/component/simulation/services.py
@@ -62,8 +62,6 @@ from flow360.version import __version__
 # Required for correct global scope initialization
 
 
-
-
 unit_system_map = {
     "SI": SI_unit_system,
     "CGS": CGS_unit_system,

--- a/tests/simulation/test_expressions.py
+++ b/tests/simulation/test_expressions.py
@@ -473,3 +473,20 @@ def test_error_message():
         assert "line" in validation_errors[0]["ctx"]
         assert "column" in validation_errors[0]["ctx"]
         assert validation_errors[0]["ctx"]["column"] == 11
+
+
+def test_solver_translation():
+    class TestModel(Flow360BaseModel):
+        field: ValueOrExpression[float] = pd.Field()
+
+    x = UserVariable(name="x", value=4)
+
+    model = TestModel(field=(x // 3) ** 2)
+
+    assert isinstance(model.field, Expression)
+    assert model.field.evaluate() == 1
+    assert str(model.field) == "(x // 3) ** 2"
+
+    solver_code = model.field.to_solver_code()
+
+    assert solver_code == "pow(floor(x / 3), 2)"


### PR DESCRIPTION
This is a PR that modifies the blueprint code generator module to allow converting python expressions to C++-like syntax. 

We can now call `expression.to_solver_code()` which returns a valid C++ rvalue expression. Some python features like range calls, list comprehensions are not supported for now, but wherever possible operators are being converted, so for example for a python expression initialized as `expr=(x // 3) ** 2` calling `expr.to_solver_code()` will yield `pow(floor(x / 3), 2)`

Solver variables can be remapped to their C++ solver equivalent at the time of declaration like so:

```
mut = SolverVariable(name="solution.mut", solver_name="mut", value=float("NaN"))
```

which will be reflected in the generated C++ code.

Some things to consider which are still not implemented:

1. Unit stripping and unit system conversion - before sending the code to the solver we need to get rid of all units and swap them for conversion factors instead - this can probably be done by splitting the code by whitespaces and operator delimiters to obtain all operands, but I haven't implemented anything yet.
2. Vector operations - how do we handle vector operations? In #946 we introduce numpy interop which works great in python, but if we want to do the same in C++ we should probably define a vector type supporting vector algebra on the solver side, e.g. `np.dot(a, np.array([0, 0, 1]))` could convert to `Vec3::dot(a, Vec3{0, 0, 1})`. I guess we need to ask somebody in the solver team for opinion on this.
