### PR TITLE
Add an option to specify BETDisk's name in Flow360 converter

### DIFF
--- a/flow360/component/simulation/migration/BETDisk.py
+++ b/flow360/component/simulation/migration/BETDisk.py
@@ -16,7 +16,12 @@ from flow360.log import log
 
 
 def _parse_flow360_bet_disk_dict(
-    *, flow360_bet_disk_dict: dict, mesh_unit, freestream_temperature, bet_disk_index: int = 0
+    *,
+    flow360_bet_disk_dict: dict,
+    mesh_unit,
+    freestream_temperature,
+    bet_disk_index: int = 0,
+    bet_disk_name: str = None,
 ):
     """
     Read in the provided Flow360 BETDisk config.
@@ -65,7 +70,11 @@ def _parse_flow360_bet_disk_dict(
     ]
 
     cylinder_dict = {
-        "name": f"bet_cylinder{bet_disk_index+1}",
+        "name": (
+            f"bet_cylinder{bet_disk_index+1}"
+            if not bet_disk_name
+            else f"bet_cylinder_{bet_disk_name}"
+        ),
         "axis": flow360_bet_disk_dict["axisOfRotation"],
         "center": flow360_bet_disk_dict["centerOfRotation"] * mesh_unit,
         "inner_radius": 0 * mesh_unit,
@@ -78,6 +87,8 @@ def _parse_flow360_bet_disk_dict(
         for key, value in flow360_bet_disk_dict.items()
         if key not in keys_to_remove
     }
+
+    updated_bet_dict["name"] = f"BETDisk_{bet_disk_index+1}" if not bet_disk_name else bet_disk_name
 
     updated_bet_dict["twists"] = [
         {
@@ -135,6 +146,7 @@ def read_single_v1_BETDisk(
     file_path: str,
     mesh_unit: LengthType.NonNegative,  # pylint: disable = no-member
     freestream_temperature: AbsoluteTemperatureType,
+    bet_disk_name: str = "BETDisk",
 ) -> BETDisk:
     """
     Constructs a single :class: `BETDisk` instance from a given V1 (legacy) Flow360 input.
@@ -145,8 +157,10 @@ def read_single_v1_BETDisk(
         Path to Flow360 JSON file that contains a **single** BETDisk setting.
     mesh_unit: LengthType.NonNegative
         Length unit used for LengthType BETDisk parameters.
-    time_unit: TimeType.Positive
-        Time unit used for non-dimensionalization.
+    freestream_temperature: AbsoluteTemperatureType
+        Freestream temperature.
+    bet_disk_name: str
+        The name for the BETDisk object.
 
     Returns
     -------
@@ -155,12 +169,13 @@ def read_single_v1_BETDisk(
 
     Examples
     --------
-    Create a BET disk with an XROTOR file.
+    Create a BET disk from flow360.json.
 
     >>> param = fl.BETDisk.from_flow360(
-    ...     file=fl.Flow360File(file_name="flow360.json")),
-    ...     mesh_unit=param.length_unit,
-    ...     time_unit=param.time_unit,
+    ...     file_path="flow360.json",
+    ...     mesh_unit=1 * fl.u.m,
+    ...     freestream_temperature = 288.15 * fl.u.K,
+    ...     bet_disk_name: str = "BETDisk"
     ... )
     """
 
@@ -169,6 +184,7 @@ def read_single_v1_BETDisk(
             flow360_bet_disk_dict=_load_flow360_json(file_path=file_path),
             mesh_unit=mesh_unit,
             freestream_temperature=freestream_temperature,
+            bet_disk_name=bet_disk_name,
         )
 
         return BETDisk(**bet_disk_dict, entities=Cylinder(**cylinder_dict))
@@ -193,17 +209,17 @@ def read_all_v1_BETDisks(
         Path to the Flow360.json file.
     mesh_unit: LengthType.NonNegative
         Length unit used for LengthType BETDisk parameters.
-    time_unit: TimeType.Positive
-        Time unit used for non-dimensionalization.
+    freestream_temperature: AbsoluteTemperatureType
+        Freestream temperature.
 
     Examples
     --------
-    Create a BET disk with an XROTOR file.
+    Create a BET disk from flow360.json.
 
     >>> param = fl.BETDisk.from_flow360(
-    ...     file=fl.Flow360File(file_name="flow360.json")),
-    ...     mesh_unit=param.length_unit,
-    ...     time_unit=param.time_unit,
+    ...     file_path="flow360.json",
+    ...     mesh_unit=1 * fl.u.m,
+    ...     freestream_temperature = 288.15 * fl.u.K,
     ... )
     """
 

--- a/flow360/component/simulation/migration/BETDisk.py
+++ b/flow360/component/simulation/migration/BETDisk.py
@@ -71,7 +71,7 @@ def _parse_flow360_bet_disk_dict(
 
     cylinder_dict = {
         "name": (
-            f"bet_cylinder{bet_disk_index+1}"
+            f"bet_cylinder_{bet_disk_index+1}"
             if not bet_disk_name
             else f"bet_cylinder_{bet_disk_name}"
         ),

--- a/tests/simulation/converter/ref/ref_single_bet_disk.json
+++ b/tests/simulation/converter/ref/ref_single_bet_disk.json
@@ -439,7 +439,7 @@
                     "units": "cm",
                     "value": 0.0
                 },
-                "name": "bet_cylinder1",
+                "name": "bet_cylinder_MyBETDisk",
                 "outer_radius": {
                     "units": "cm",
                     "value": 150.0
@@ -458,7 +458,7 @@
         0.0
     ],
     "n_loading_nodes": 20,
-    "name": "BET disk",
+    "name": "MyBETDisk",
     "number_of_blades": 3,
     "omega": {
         "units": "rad/s",
@@ -496,7 +496,7 @@
                         "units": "cm",
                         "value": 0.0
                     },
-                    "name": "bet_cylinder1",
+                    "name": "bet_cylinder_MyBETDisk",
                     "outer_radius": {
                         "units": "cm",
                         "value": 150.0
@@ -514,7 +514,7 @@
         "initial_blade_direction": null,
         "length_unit": null,
         "n_loading_nodes": 20,
-        "name": "BET disk",
+        "name": "MyBETDisk",
         "number_of_blades": 3,
         "omega": {
             "value": 156.5352426717779,

--- a/tests/simulation/converter/test_bet_disk_flow360_converter.py
+++ b/tests/simulation/converter/test_bet_disk_flow360_converter.py
@@ -24,6 +24,7 @@ def test_single_flow360_bet_convert(atol=1e-15, rtol=1e-10, debug=False):
         file_path="./data/single_flow360_bet_disk.json",
         mesh_unit=1 * u.cm,
         freestream_temperature=288.15 * u.K,
+        bet_disk_name="MyBETDisk",
     )
     assert isinstance(disk, BETDisk)
     disk = disk.model_dump_json()
@@ -80,6 +81,8 @@ def test_full_flow360_bet_convert():
 
     assert isinstance(list_of_disks, list)
     assert len(list_of_disks) == 2
+    assert list_of_disks[0].name == "BETDisk_1"
+    assert list_of_disks[1].name == "BETDisk_2"
     assert list_of_disks[0].entities.stored_entities[0].name == "bet_cylinder1"
     assert list_of_disks[1].entities.stored_entities[0].name == "bet_cylinder2"
     assert all([isinstance(item, BETDisk) for item in list_of_disks])

--- a/tests/simulation/converter/test_bet_disk_flow360_converter.py
+++ b/tests/simulation/converter/test_bet_disk_flow360_converter.py
@@ -65,7 +65,9 @@ def test_single_flow360_bet_convert(atol=1e-15, rtol=1e-10, debug=False):
 
         try:
             read_single_v1_BETDisk(
-                file_path=temp_file_name, mesh_unit=1 * u.cm, freestream_temperature=288.15 * u.K
+                file_path=temp_file_name,
+                mesh_unit=1 * u.cm,
+                freestream_temperature=288.15 * u.K,
             )
         finally:
             os.remove(temp_file_name)
@@ -83,8 +85,8 @@ def test_full_flow360_bet_convert():
     assert len(list_of_disks) == 2
     assert list_of_disks[0].name == "BETDisk_1"
     assert list_of_disks[1].name == "BETDisk_2"
-    assert list_of_disks[0].entities.stored_entities[0].name == "bet_cylinder1"
-    assert list_of_disks[1].entities.stored_entities[0].name == "bet_cylinder2"
+    assert list_of_disks[0].entities.stored_entities[0].name == "bet_cylinder_1"
+    assert list_of_disks[1].entities.stored_entities[0].name == "bet_cylinder_2"
     assert all([isinstance(item, BETDisk) for item in list_of_disks])
 
     with pytest.raises(


### PR DESCRIPTION
This is to help ensure we have unique BET Disk names and unique BET Cylinder names