### PR TITLE
[FLPY-61] Fixed operator overloading when using unyt types as lvalues

### DIFF
--- a/flow360/component/simulation/user_code.py
+++ b/flow360/component/simulation/user_code.py
@@ -24,6 +24,41 @@ _user_variables: set[str] = set()
 _solver_variables: dict[str, str] = {}
 
 
+def __soft_fail_add__(self, other):
+    if not isinstance(other, Expression) and not isinstance(other, Variable):
+        return np.ndarray.__add__(self, other)
+    else:
+        return NotImplemented
+
+
+def __soft_fail_sub__(self, other):
+    if not isinstance(other, Expression) and not isinstance(other, Variable):
+        return np.ndarray.__sub__(self, other)
+    else:
+        return NotImplemented
+
+
+def __soft_fail_mul__(self, other):
+    if not isinstance(other, Expression) and not isinstance(other, Variable):
+        return np.ndarray.__mul__(self, other)
+    else:
+        return NotImplemented
+
+
+def __soft_fail_truediv__(self, other):
+    if not isinstance(other, Expression) and not isinstance(other, Variable):
+        return np.ndarray.__truediv__(self, other)
+    else:
+        return NotImplemented
+
+
+unyt_array.__add__ = __soft_fail_add__
+unyt_array.__sub__ = __soft_fail_sub__
+unyt_array.__mul__ = __soft_fail_mul__
+unyt_array.__truediv__ = __soft_fail_truediv__
+# Possibly other operators too..?
+
+
 def _is_number_string(s: str) -> bool:
     try:
         float(s)

--- a/tests/simulation/test_expressions.py
+++ b/tests/simulation/test_expressions.py
@@ -58,6 +58,8 @@ from flow360.component.simulation.user_code import (
     ValueOrExpression,
 )
 
+import unyt
+
 
 @pytest.fixture(autouse=True)
 def change_test_dir(request, monkeypatch):
@@ -709,9 +711,20 @@ def test_variable_space_init():
     params, errors, _ = validate_model(
         params_as_dict=data, validated_by=ValidationCalledBy.LOCAL, root_item_type="Geometry"
     )
-    from flow360.component.simulation.user_code import _global_ctx, _user_variables
 
     assert errors is None
     evaluated = params.reference_geometry.area.evaluate()
 
     assert evaluated == 1.0 * u.m**2
+
+
+def test_unyt_operator_runtime_overloading():
+    x = UserVariable(name="x", value=10 * u.m + solution.coordinate * u.m)
+
+    with pytest.raises(ValueError):
+        x.value.evaluate()
+
+    y = UserVariable(name="y", value=solution.coordinate * u.m + 10 * u.m)
+
+    with pytest.raises(ValueError):
+        y.value.evaluate()


### PR DESCRIPTION
This was a weird one...

So basically the error comes down to the fact that unyt operators throw exceptions instead of returning the `NotImplemented` singleton when they fail. This prevents python from trying the `__radd__` operator of the other operand (in our case, `Expression.__radd__` which can handle unyt types just fine...). The dirty solution to this is overloading unyt's operators at runtime (see `__soft_fail_*__` functions in `user_code.py`). Seems to work at first glance but I'm not sure how robust it is yet... 

Tests work but it is a bit sketchy, might obfuscate some valid unyt errors if they arise in the context of expression parsing I think? Any ideas on how to improve this are welcome.