### PR TITLE
changed mach reynolds to use charcteristic length

### DIFF
--- a/examples/advanced_simulations/aerodynamics/airfoils/2D_30p30n.py
+++ b/examples/advanced_simulations/aerodynamics/airfoils/2D_30p30n.py
@@ -76,8 +76,8 @@ with fl.SI_unit_system:
         ),
         operating_condition=fl.AerospaceCondition.from_mach_reynolds(
             mach=0.17,
-            reynolds=1.71e06,
-            characteristic_length=1 * fl.u.m,
+            reynolds_mesh_unit=1.71e06,
+            project_length_unit=1 * fl.u.m,
             temperature=288.16,
             alpha=8.5 * fl.u.deg,
             beta=0 * fl.u.deg,

--- a/examples/advanced_simulations/aerodynamics/airfoils/2D_30p30n.py
+++ b/examples/advanced_simulations/aerodynamics/airfoils/2D_30p30n.py
@@ -74,10 +74,10 @@ with fl.SI_unit_system:
         reference_geometry=fl.ReferenceGeometry(
             moment_center=[0.25, 0, 0], moment_length=[1, 1, 1], area=0.01
         ),
-        operating_condition=fl.operating_condition_from_mach_reynolds(
+        operating_condition=fl.AerospaceCondition.from_mach_reynolds(
             mach=0.17,
             reynolds=1.71e06,
-            project_length_unit=1 * fl.u.m,
+            characteristic_length=1 * fl.u.m,
             temperature=288.16,
             alpha=8.5 * fl.u.deg,
             beta=0 * fl.u.deg,

--- a/examples/advanced_simulations/aerodynamics/airfoils/2D_crm.py
+++ b/examples/advanced_simulations/aerodynamics/airfoils/2D_crm.py
@@ -74,10 +74,10 @@ with fl.SI_unit_system:
         reference_geometry=fl.ReferenceGeometry(
             moment_center=[0.25, 0, 0], moment_length=[1, 1, 1], area=0.01
         ),
-        operating_condition=fl.operating_condition_from_mach_reynolds(
+        operating_condition=fl.AerospaceCondition.from_mach_reynolds(
             mach=0.2,
             reynolds=5e6,
-            project_length_unit=1 * fl.u.m,
+            characteristic_length=1 * fl.u.m,
             temperature=272.1,
             alpha=16 * fl.u.deg,
             beta=0 * fl.u.deg,

--- a/examples/advanced_simulations/aerodynamics/airfoils/2D_crm.py
+++ b/examples/advanced_simulations/aerodynamics/airfoils/2D_crm.py
@@ -76,8 +76,8 @@ with fl.SI_unit_system:
         ),
         operating_condition=fl.AerospaceCondition.from_mach_reynolds(
             mach=0.2,
-            reynolds=5e6,
-            characteristic_length=1 * fl.u.m,
+            reynolds_mesh_unit=5e6,
+            project_length_unit=1 * fl.u.m,
             temperature=272.1,
             alpha=16 * fl.u.deg,
             beta=0 * fl.u.deg,

--- a/examples/advanced_simulations/aerodynamics/airfoils/2D_gaw2.py
+++ b/examples/advanced_simulations/aerodynamics/airfoils/2D_gaw2.py
@@ -76,8 +76,8 @@ with fl.SI_unit_system:
         ),
         operating_condition=fl.AerospaceCondition.from_mach_reynolds(
             mach=0.13,
-            reynolds=2.2e06,
-            characteristic_length=1 * fl.u.m,
+            reynolds_mesh_unit=2.2e06,
+            project_length_unit=1 * fl.u.m,
             temperature=288.16,
             alpha=4 * fl.u.deg,
             beta=0 * fl.u.deg,

--- a/examples/advanced_simulations/aerodynamics/airfoils/2D_gaw2.py
+++ b/examples/advanced_simulations/aerodynamics/airfoils/2D_gaw2.py
@@ -74,10 +74,10 @@ with fl.SI_unit_system:
         reference_geometry=fl.ReferenceGeometry(
             moment_center=[0.25, 0, 0], moment_length=[1, 1, 1], area=0.01
         ),
-        operating_condition=fl.operating_condition_from_mach_reynolds(
+        operating_condition=fl.AerospaceCondition.from_mach_reynolds(
             mach=0.13,
             reynolds=2.2e06,
-            project_length_unit=1 * fl.u.m,
+            characteristic_length=1 * fl.u.m,
             temperature=288.16,
             alpha=4 * fl.u.deg,
             beta=0 * fl.u.deg,

--- a/examples/advanced_simulations/aerodynamics/user_defined_dynamics/udd_alpha_controller.py
+++ b/examples/advanced_simulations/aerodynamics/user_defined_dynamics/udd_alpha_controller.py
@@ -17,9 +17,9 @@ with fl.SI_unit_system:
             moment_length=[1.47601, 0.80167, 1.47601],
         ),
         operating_condition=fl.AerospaceCondition.from_mach_reynolds(
-            reynolds=11.72e6,
+            reynolds_mesh_unit=11.72e6,
             mach=0.84,
-            characteristic_length=0.80167 * fl.u.m,
+            project_length_unit=0.80167 * fl.u.m,
             temperature=297.78,
             alpha=3.06 * fl.u.deg,
             beta=0 * fl.u.deg,

--- a/examples/advanced_simulations/aerodynamics/user_defined_dynamics/udd_alpha_controller.py
+++ b/examples/advanced_simulations/aerodynamics/user_defined_dynamics/udd_alpha_controller.py
@@ -16,10 +16,10 @@ with fl.SI_unit_system:
             moment_center=[0, 0, 0],
             moment_length=[1.47601, 0.80167, 1.47601],
         ),
-        operating_condition=fl.operating_condition_from_mach_reynolds(
+        operating_condition=fl.AerospaceCondition.from_mach_reynolds(
             reynolds=11.72e6,
             mach=0.84,
-            project_length_unit=0.80167 * fl.u.m,
+            characteristic_length=0.80167 * fl.u.m,
             temperature=297.78,
             alpha=3.06 * fl.u.deg,
             beta=0 * fl.u.deg,

--- a/examples/advanced_simulations/turbomachinery/periodic_BC.py
+++ b/examples/advanced_simulations/turbomachinery/periodic_BC.py
@@ -31,8 +31,8 @@ with fl.SI_unit_system:
     )
     operating_condition = fl.AerospaceCondition.from_mach_reynolds(
         mach=0.13989,
-        reynolds=3200,
-        characteristic_length=1 * fl.u.m,
+        reynolds_mesh_unit=3200,
+        project_length_unit=1 * fl.u.m,
         temperature=298.25 * fl.u.K,
     )
     params = fl.SimulationParams(

--- a/examples/advanced_simulations/turbomachinery/periodic_BC.py
+++ b/examples/advanced_simulations/turbomachinery/periodic_BC.py
@@ -29,10 +29,10 @@ with fl.SI_unit_system:
         normal=[1, 0, 0],
         origin=[294.65, 0, 0] * fl.u.m,
     )
-    operating_condition = fl.operating_condition_from_mach_reynolds(
+    operating_condition = fl.AerospaceCondition.from_mach_reynolds(
         mach=0.13989,
         reynolds=3200,
-        project_length_unit=1 * fl.u.m,
+        characteristic_length=1 * fl.u.m,
         temperature=298.25 * fl.u.K,
     )
     params = fl.SimulationParams(

--- a/examples/basic_simulations/steady/steady_3D_cylinder.py
+++ b/examples/basic_simulations/steady/steady_3D_cylinder.py
@@ -25,8 +25,8 @@ with fl.SI_unit_system:
         reference_geometry=fl.ReferenceGeometry(
             area=340, moment_center=[0, 0, 0], moment_length=[1, 1, 1]
         ),
-        operating_condition=fl.operating_condition_from_mach_reynolds(
-            reynolds=5, mach=0.1, project_length_unit=fl.u.m
+        operating_condition=fl.AerospaceCondition.from_mach_reynolds(
+            reynolds=5, mach=0.1, characteristic_length=fl.u.m
         ),
         time_stepping=fl.Steady(),
         models=[

--- a/examples/basic_simulations/steady/steady_3D_cylinder.py
+++ b/examples/basic_simulations/steady/steady_3D_cylinder.py
@@ -26,7 +26,7 @@ with fl.SI_unit_system:
             area=340, moment_center=[0, 0, 0], moment_length=[1, 1, 1]
         ),
         operating_condition=fl.AerospaceCondition.from_mach_reynolds(
-            reynolds=5, mach=0.1, characteristic_length=fl.u.m
+            reynolds_mesh_unit=5, mach=0.1, project_length_unit=fl.u.m
         ),
         time_stepping=fl.Steady(),
         models=[

--- a/examples/basic_simulations/unsteady/unsteady_2D_cylinder.py
+++ b/examples/basic_simulations/unsteady/unsteady_2D_cylinder.py
@@ -17,7 +17,7 @@ with fl.SI_unit_system:
             area=20, moment_center=[0, 0, 0], moment_length=[1, 1, 1]
         ),
         operating_condition=fl.AerospaceCondition.from_mach_reynolds(
-            reynolds=50, mach=0.1, characteristic_length=fl.u.m
+            reynolds_mesh_unit=50, mach=0.1, project_length_unit=fl.u.m
         ),
         models=[
             fl.Fluid(

--- a/examples/basic_simulations/unsteady/unsteady_2D_cylinder.py
+++ b/examples/basic_simulations/unsteady/unsteady_2D_cylinder.py
@@ -16,8 +16,8 @@ with fl.SI_unit_system:
         reference_geometry=fl.ReferenceGeometry(
             area=20, moment_center=[0, 0, 0], moment_length=[1, 1, 1]
         ),
-        operating_condition=fl.operating_condition_from_mach_reynolds(
-            reynolds=50, mach=0.1, project_length_unit=fl.u.m
+        operating_condition=fl.AerospaceCondition.from_mach_reynolds(
+            reynolds=50, mach=0.1, characteristic_length=fl.u.m
         ),
         models=[
             fl.Fluid(

--- a/examples/post_processing/field_data/volumetric_and_surface.py
+++ b/examples/post_processing/field_data/volumetric_and_surface.py
@@ -21,8 +21,8 @@ with fl.SI_unit_system:
             moment_center=[0, 0, 0],
             moment_length=[1.47602, 0.801672958512342, 1.47602],
         ),
-        operating_condition=fl.operating_condition_from_mach_reynolds(
-            reynolds=14.6e6, mach=0.84, alpha=3.06 * fl.u.deg, project_length_unit=fl.u.m
+        operating_condition=fl.AerospaceCondition.from_mach_reynolds(
+            reynolds=14.6e6, mach=0.84, alpha=3.06 * fl.u.deg, characteristic_length=fl.u.m
         ),
         time_stepping=fl.Steady(
             max_steps=500, CFL=fl.RampCFL(initial=5, final=200, ramp_steps=100)

--- a/examples/post_processing/field_data/volumetric_and_surface.py
+++ b/examples/post_processing/field_data/volumetric_and_surface.py
@@ -22,7 +22,7 @@ with fl.SI_unit_system:
             moment_length=[1.47602, 0.801672958512342, 1.47602],
         ),
         operating_condition=fl.AerospaceCondition.from_mach_reynolds(
-            reynolds=14.6e6, mach=0.84, alpha=3.06 * fl.u.deg, characteristic_length=fl.u.m
+            reynolds_mesh_unit=14.6e6, mach=0.84, alpha=3.06 * fl.u.deg, project_length_unit=fl.u.m
         ),
         time_stepping=fl.Steady(
             max_steps=500, CFL=fl.RampCFL(initial=5, final=200, ramp_steps=100)

--- a/examples/post_processing/monitoring/monitors.py
+++ b/examples/post_processing/monitoring/monitors.py
@@ -14,8 +14,8 @@ with fl.SI_unit_system:
             moment_center=[0, 0, 0],
             moment_length=[1.47602, 0.801672958512342, 1.47602],
         ),
-        operating_condition=fl.operating_condition_from_mach_reynolds(
-            reynolds=14.6e6, mach=0.84, alpha=3.06 * fl.u.deg, project_length_unit=fl.u.m
+        operating_condition=fl.AerospaceCondition.from_mach_reynolds(
+            reynolds=14.6e6, mach=0.84, alpha=3.06 * fl.u.deg, characteristic_length=fl.u.m
         ),
         time_stepping=fl.Steady(max_steps=500),
         models=[

--- a/examples/post_processing/monitoring/monitors.py
+++ b/examples/post_processing/monitoring/monitors.py
@@ -15,7 +15,7 @@ with fl.SI_unit_system:
             moment_length=[1.47602, 0.801672958512342, 1.47602],
         ),
         operating_condition=fl.AerospaceCondition.from_mach_reynolds(
-            reynolds=14.6e6, mach=0.84, alpha=3.06 * fl.u.deg, characteristic_length=fl.u.m
+            reynolds_mesh_unit=14.6e6, mach=0.84, alpha=3.06 * fl.u.deg, project_length_unit=fl.u.m
         ),
         time_stepping=fl.Steady(max_steps=500),
         models=[

--- a/examples/tutorials/notebooks/notebook_tutorial_2D_crm.ipynb
+++ b/examples/tutorials/notebooks/notebook_tutorial_2D_crm.ipynb
@@ -911,7 +911,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "48bb6d71-298a-442e-80ff-9f6170ac6aab",
    "metadata": {},
    "outputs": [

--- a/examples/tutorials/notebooks/notebook_tutorial_2D_crm.ipynb
+++ b/examples/tutorials/notebooks/notebook_tutorial_2D_crm.ipynb
@@ -950,11 +950,11 @@
     "        # Create operating conditions using mach and reynolds number\n",
     "        operating_condition=fl.AerospaceCondition.from_mach_reynolds(\n",
     "            mach=0.2,\n",
-    "            reynolds=5e6,\n",
+    "            reynolds_mesh_unit=5e6,\n",
     "            temperature=272.1,\n",
     "            alpha=16 * fl.u.deg,\n",
     "            beta=0 * fl.u.deg,\n",
-    "            characteristic_length=1 * fl.u.m,\n",
+    "            project_length_unit=1 * fl.u.m,\n",
     "        ),\n",
     "    )"
    ]

--- a/examples/tutorials/notebooks/notebook_tutorial_2D_crm.ipynb
+++ b/examples/tutorials/notebooks/notebook_tutorial_2D_crm.ipynb
@@ -14,7 +14,7 @@
     "\n",
     "We will walk through all the steps such as importing modules, creating a project and assigning simulation parameters.\n",
     "\n",
-    "Additionally, we will use the function `fl.operating_condition_from_mach_reynolds()`, which is often utilized when running workshop cases and allows us to define operating conditions using mach and reynolds number.\n",
+    "Additionally, we will use the function `fl.AerospaceCondition.from_mach_reynolds()`, which is often utilized when running workshop cases and allows us to define operating conditions using mach and reynolds number.\n",
     "\n",
     "In order to get a closer look at how we describe each parameter, we will first split the simulation parameters into smaller parts, which will be assembled later on."
    ]
@@ -906,12 +906,12 @@
    "metadata": {},
    "source": [
     "### Operating condition\n",
-    "Next up is the definition of flow conditions with the help of `fl.operating_condition_from_mach_reynolds()` function, which does not require knowledge of air properties in desired conditions and instead allows the usage of mach number in conjunction with reynolds number. This is particularly useful for conducting workshop cases as we can easily simulate flow conditions for different values of reynolds number. Viscosity as well as density are going to be automatically calculated based on input parameters."
+    "Next up is the definition of flow conditions with the help of `fl.AerospaceCondition.from_mach_reynolds()` function, which does not require knowledge of air properties in desired conditions and instead allows the usage of mach number in conjunction with reynolds number. This is particularly useful for conducting workshop cases as we can easily simulate flow conditions for different values of reynolds number. Viscosity as well as density are going to be automatically calculated based on input parameters."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "48bb6d71-298a-442e-80ff-9f6170ac6aab",
    "metadata": {},
    "outputs": [
@@ -948,13 +948,13 @@
     "with fl.SI_unit_system:\n",
     "    operating_condition_params = fl.SimulationParams(\n",
     "        # Create operating conditions using mach and reynolds number\n",
-    "        operating_condition=fl.operating_condition_from_mach_reynolds(\n",
+    "        operating_condition=fl.AerospaceCondition.from_mach_reynolds(\n",
     "            mach=0.2,\n",
     "            reynolds=5e6,\n",
     "            temperature=272.1,\n",
     "            alpha=16 * fl.u.deg,\n",
     "            beta=0 * fl.u.deg,\n",
-    "            project_length_unit=1 * fl.u.m,\n",
+    "            characteristic_length=1 * fl.u.m,\n",
     "        ),\n",
     "    )"
    ]

--- a/flow360/component/simulation/operating_condition/operating_condition.py
+++ b/flow360/component/simulation/operating_condition/operating_condition.py
@@ -400,7 +400,8 @@ class AerospaceCondition(MultiConstructorBaseModel):
         reynolds : PositiveFloat
             Freestream Reynolds number defined with mesh unit (must be positive).
         characteristic_length: LengthType.Positive
-            Length dimension that is used to define the scale of the system, for example, chord length.
+            Characteristic length scale of the system used to compute the Reynolds number
+            (e.g., the chord length of an airfoil). This value must be positive.
         alpha : AngleType, optional
             Angle of attack. Default is 0 degrees.
         beta : AngleType, optional

--- a/flow360/component/simulation/operating_condition/operating_condition.py
+++ b/flow360/component/simulation/operating_condition/operating_condition.py
@@ -244,8 +244,8 @@ class AerospaceConditionCache(Flow360BaseModel):
     """[INTERNAL] Cache for AerospaceCondition inputs"""
 
     mach: Optional[pd.NonNegativeFloat] = None
-    reynolds: Optional[pd.PositiveFloat] = None
-    characteristic_length: Optional[LengthType.Positive] = None
+    reynolds_mesh_unit: Optional[pd.PositiveFloat] = None
+    project_length_unit: Optional[LengthType.Positive] = None
     alpha: Optional[AngleType] = None
     beta: Optional[AngleType] = None
     temperature: Optional[AbsoluteTemperatureType] = None
@@ -379,8 +379,8 @@ class AerospaceCondition(MultiConstructorBaseModel):
     def from_mach_reynolds(
         cls,
         mach: pd.PositiveFloat,
-        reynolds: pd.PositiveFloat,
-        characteristic_length: LengthType.Positive,
+        reynolds_mesh_unit: pd.PositiveFloat,
+        project_length_unit: LengthType.Positive,
         alpha: Optional[AngleType] = 0 * u.deg,
         beta: Optional[AngleType] = 0 * u.deg,
         temperature: AbsoluteTemperatureType = 288.15 * u.K,
@@ -397,11 +397,12 @@ class AerospaceCondition(MultiConstructorBaseModel):
         ----------
         mach : NonNegativeFloat
             Freestream Mach number (must be non-negative).
-        reynolds : PositiveFloat
-            Freestream Reynolds number defined with mesh unit (must be positive).
-        characteristic_length: LengthType.Positive
-            Characteristic length scale of the system used to compute the Reynolds number
-            (e.g., the chord length of an airfoil). This value must be positive.
+        reynolds_mesh_unit : PositiveFloat
+            Freestream Reynolds number scaled to mesh unit (must be positive).
+            For example if the mesh unit is 1 mm, the reynolds_mesh_unit should be
+            equal to a Reynolds number that has the characteristic length of 1 mm.
+        project_length_unit: LengthType.Positive
+            Project length unit used to compute the density (must be positive).
         alpha : AngleType, optional
             Angle of attack. Default is 0 degrees.
         beta : AngleType, optional
@@ -422,8 +423,8 @@ class AerospaceCondition(MultiConstructorBaseModel):
 
         >>> condition = fl.AerospaceCondition.from_mach_reynolds(
         ...     mach=0.85,
-        ...     reynolds=1e6,
-        ...     characteristic_length=1 * u.mm,
+        ...     reynolds_mesh_unit=1e6,
+        ...     project_length_unit=1 * u.mm,
         ...     temperature=288.15 * u.K,
         ...     alpha=2.0 * u.deg,
         ...     beta=0.0 * u.deg,
@@ -442,9 +443,9 @@ class AerospaceCondition(MultiConstructorBaseModel):
         velocity = mach * material.get_speed_of_sound(temperature)
 
         density = (
-            reynolds
+            reynolds_mesh_unit
             * material.get_dynamic_viscosity(temperature)
-            / (velocity * characteristic_length)
+            / (velocity * project_length_unit)
         )
 
         thermal_state = ThermalState(temperature=temperature, density=density)

--- a/flow360/component/simulation/operating_condition/operating_condition.py
+++ b/flow360/component/simulation/operating_condition/operating_condition.py
@@ -245,7 +245,7 @@ class AerospaceConditionCache(Flow360BaseModel):
 
     mach: Optional[pd.NonNegativeFloat] = None
     reynolds: Optional[pd.PositiveFloat] = None
-    project_length_unit: Optional[LengthType.Positive] = None
+    characteristic_length: Optional[LengthType.Positive] = None
     alpha: Optional[AngleType] = None
     beta: Optional[AngleType] = None
     temperature: Optional[AbsoluteTemperatureType] = None
@@ -380,7 +380,7 @@ class AerospaceCondition(MultiConstructorBaseModel):
         cls,
         mach: pd.PositiveFloat,
         reynolds: pd.PositiveFloat,
-        project_length_unit: LengthType.Positive,
+        characteristic_length: LengthType.Positive,
         alpha: Optional[AngleType] = 0 * u.deg,
         beta: Optional[AngleType] = 0 * u.deg,
         temperature: AbsoluteTemperatureType = 288.15 * u.K,
@@ -399,8 +399,8 @@ class AerospaceCondition(MultiConstructorBaseModel):
             Freestream Mach number (must be non-negative).
         reynolds : PositiveFloat
             Freestream Reynolds number defined with mesh unit (must be positive).
-        project_length_unit: LengthType.Positive
-            Project length unit.
+        characteristic_length: LengthType.Positive
+            Length dimension that is used to define the scale of the system, for example, chord length.
         alpha : AngleType, optional
             Angle of attack. Default is 0 degrees.
         beta : AngleType, optional
@@ -419,10 +419,10 @@ class AerospaceCondition(MultiConstructorBaseModel):
         -------
         Example usage:
 
-        >>> condition = operating_condition_from_mach_reynolds(
+        >>> condition = fl.AerospaceCondition.from_mach_reynolds(
         ...     mach=0.85,
         ...     reynolds=1e6,
-        ...     project_length_unit=1 * u.mm,
+        ...     characteristic_length=1 * u.mm,
         ...     temperature=288.15 * u.K,
         ...     alpha=2.0 * u.deg,
         ...     beta=0.0 * u.deg,
@@ -443,7 +443,7 @@ class AerospaceCondition(MultiConstructorBaseModel):
         density = (
             reynolds
             * material.get_dynamic_viscosity(temperature)
-            / (velocity * project_length_unit)
+            / (velocity * characteristic_length)
         )
 
         thermal_state = ThermalState(temperature=temperature, density=density)

--- a/tests/simulation/framework/test_multi_constructor_model.py
+++ b/tests/simulation/framework/test_multi_constructor_model.py
@@ -55,7 +55,7 @@ def get_aerospace_condition_using_from_mach_reynolds():
     return AerospaceCondition.from_mach_reynolds(
         mach=0.8,
         reynolds=1e6,
-        project_length_unit=u.m,
+        characteristic_length=u.m,
         alpha=5 * u.deg,
         temperature=290 * u.K,
     )

--- a/tests/simulation/framework/test_multi_constructor_model.py
+++ b/tests/simulation/framework/test_multi_constructor_model.py
@@ -54,8 +54,8 @@ def get_aerospace_condition_using_from_mach():
 def get_aerospace_condition_using_from_mach_reynolds():
     return AerospaceCondition.from_mach_reynolds(
         mach=0.8,
-        reynolds=1e6,
-        characteristic_length=u.m,
+        reynolds_mesh_unit=1e6,
+        project_length_unit=u.m,
         alpha=5 * u.deg,
         temperature=290 * u.K,
     )

--- a/tests/simulation/params/test_simulation_params.py
+++ b/tests/simulation/params/test_simulation_params.py
@@ -350,7 +350,7 @@ def test_mach_reynolds_op_cond():
         temperature=288.15 * u.K,
         alpha=2.0 * u.deg,
         beta=0.0 * u.deg,
-        project_length_unit=u.m,
+        characteristic_length=u.m,
     )
     assertions.assertAlmostEqual(condition.thermal_state.dynamic_viscosity.value, 1.78929763e-5)
     assertions.assertAlmostEqual(condition.thermal_state.density.value, 1.31452332)
@@ -361,7 +361,7 @@ def test_mach_reynolds_op_cond():
         temperature=288.15 * u.K,
         alpha=2.0 * u.deg,
         beta=0.0 * u.deg,
-        project_length_unit=u.m,
+        characteristic_length=u.m,
         reference_mach=0.4,
     )
     assertions.assertAlmostEqual(condition.thermal_state.density.value, 1.31452332)
@@ -371,7 +371,7 @@ def test_mach_reynolds_op_cond():
             mach=0.2,
             reynolds=0,
             temperature=288.15 * u.K,
-            project_length_unit=u.m,
+            characteristic_length=u.m,
         )
 
 

--- a/tests/simulation/params/test_simulation_params.py
+++ b/tests/simulation/params/test_simulation_params.py
@@ -346,22 +346,22 @@ def test_subsequent_param_with_different_unit_system():
 def test_mach_reynolds_op_cond():
     condition = AerospaceCondition.from_mach_reynolds(
         mach=0.2,
-        reynolds=5e6,
+        reynolds_mesh_unit=5e6,
         temperature=288.15 * u.K,
         alpha=2.0 * u.deg,
         beta=0.0 * u.deg,
-        characteristic_length=u.m,
+        project_length_unit=u.m,
     )
     assertions.assertAlmostEqual(condition.thermal_state.dynamic_viscosity.value, 1.78929763e-5)
     assertions.assertAlmostEqual(condition.thermal_state.density.value, 1.31452332)
 
     condition = AerospaceCondition.from_mach_reynolds(
         mach=0.2,
-        reynolds=5e6,
+        reynolds_mesh_unit=5e6,
         temperature=288.15 * u.K,
         alpha=2.0 * u.deg,
         beta=0.0 * u.deg,
-        characteristic_length=u.m,
+        project_length_unit=u.m,
         reference_mach=0.4,
     )
     assertions.assertAlmostEqual(condition.thermal_state.density.value, 1.31452332)
@@ -369,9 +369,9 @@ def test_mach_reynolds_op_cond():
     with pytest.raises(ValueError, match="Input should be greater than 0"):
         condition = AerospaceCondition.from_mach_reynolds(
             mach=0.2,
-            reynolds=0,
+            reynolds_mesh_unit=0,
             temperature=288.15 * u.K,
-            characteristic_length=u.m,
+            project_length_unit=u.m,
         )
 
 

--- a/tests/simulation/translator/utils/tutorial_2dcrm_param_generator.py
+++ b/tests/simulation/translator/utils/tutorial_2dcrm_param_generator.py
@@ -30,7 +30,7 @@ def get_2dcrm_tutorial_param():
                 temperature=272.1 * u.K,
                 alpha=16 * u.deg,
                 beta=0 * u.deg,
-                project_length_unit=1 * u.m,
+                characteristic_length=1 * u.m,
             ),
             models=[
                 Wall(surfaces=[my_wall]),
@@ -58,7 +58,7 @@ def get_2dcrm_tutorial_param_deg_c():
                 temperature=-1.05 * u.degC,
                 alpha=16 * u.deg,
                 beta=0 * u.deg,
-                project_length_unit=1 * u.m,
+                characteristic_length=1 * u.m,
             ),
             models=[
                 Wall(surfaces=[my_wall]),
@@ -86,7 +86,7 @@ def get_2dcrm_tutorial_param_deg_f():
                 temperature=30.11 * u.degF,
                 alpha=16 * u.deg,
                 beta=0 * u.deg,
-                project_length_unit=1 * u.m,
+                characteristic_length=1 * u.m,
             ),
             models=[
                 Wall(surfaces=[my_wall]),

--- a/tests/simulation/translator/utils/tutorial_2dcrm_param_generator.py
+++ b/tests/simulation/translator/utils/tutorial_2dcrm_param_generator.py
@@ -26,11 +26,11 @@ def get_2dcrm_tutorial_param():
             ),
             operating_condition=AerospaceCondition.from_mach_reynolds(
                 mach=0.2,
-                reynolds=5e6,
+                reynolds_mesh_unit=5e6,
                 temperature=272.1 * u.K,
                 alpha=16 * u.deg,
                 beta=0 * u.deg,
-                characteristic_length=1 * u.m,
+                project_length_unit=1 * u.m,
             ),
             models=[
                 Wall(surfaces=[my_wall]),
@@ -54,11 +54,11 @@ def get_2dcrm_tutorial_param_deg_c():
             ),
             operating_condition=AerospaceCondition.from_mach_reynolds(
                 mach=0.2,
-                reynolds=5e6,
+                reynolds_mesh_unit=5e6,
                 temperature=-1.05 * u.degC,
                 alpha=16 * u.deg,
                 beta=0 * u.deg,
-                characteristic_length=1 * u.m,
+                project_length_unit=1 * u.m,
             ),
             models=[
                 Wall(surfaces=[my_wall]),
@@ -82,11 +82,11 @@ def get_2dcrm_tutorial_param_deg_f():
             ),
             operating_condition=AerospaceCondition.from_mach_reynolds(
                 mach=0.2,
-                reynolds=5e6,
+                reynolds_mesh_unit=5e6,
                 temperature=30.11 * u.degF,
                 alpha=16 * u.deg,
                 beta=0 * u.deg,
-                characteristic_length=1 * u.m,
+                project_length_unit=1 * u.m,
             ),
             models=[
                 Wall(surfaces=[my_wall]),


### PR DESCRIPTION
I think characteristic_length is a better name than reference_length since it won't get confused with the one for moments and is also more common definition used in defining Reynolds number globally I believe.

- project_length_unit was renamed to characteristic_length
- fixed unittests
- fixed previously ommited operating_condition_from_mach_reynolds() calls

For reference, here is a Wikipedia page where it is also called characteristic length.
![image](https://github.com/user-attachments/assets/a88531d3-8d2b-4fd4-9b6c-5568815548e1)
