### PR TITLE
Expression validation bundle

### DIFF
--- a/flow360/component/simulation/blueprint/core/context.py
+++ b/flow360/component/simulation/blueprint/core/context.py
@@ -152,3 +152,8 @@ class EvaluationContext:
     def clear(self):
         """Clear user variables from the context."""
         self._values = {name: value for name, value in self._values.items() if "." in name}
+
+    @property
+    def registered_names(self):
+        """Show the registered names in the context."""
+        return list(self._values.keys())

--- a/flow360/component/simulation/user_code/core/context.py
+++ b/flow360/component/simulation/user_code/core/context.py
@@ -15,6 +15,9 @@ def _unit_list():
 
     for _, value in unit_symbols.__dict__.items():
         if isinstance(value, (unyt_array, Unit)):
+            if str(value) == "u.degF" or str(value) == "u.degC":
+                continue
+            print(">>> ADDING UNIT: ", str(value))
             symbols.add(str(value))
 
     return list(symbols)

--- a/flow360/component/simulation/user_code/core/types.py
+++ b/flow360/component/simulation/user_code/core/types.py
@@ -424,7 +424,7 @@ class UserVariable(Variable):
         """
         return hash(self.model_dump_json())
 
-    def in_unit(self, new_unit: Union[str, Unit] = None):
+    def in_units(self, new_unit: Union[str, Unit] = None):
         """Requesting the output of the variable to be in the given (new_unit) units."""
         if isinstance(new_unit, Unit):
             new_unit = str(new_unit)
@@ -448,7 +448,7 @@ class SolverVariable(Variable):
             default_context.set_alias(self.name, self.solver_name)
         return self
 
-    def in_unit(self, new_name: str, new_unit: Union[str, Unit] = None):
+    def in_units(self, new_name: str, new_unit: Union[str, Unit] = None):
         """
         Return a UserVariable that will generate results in the new_unit.
         If new_unit is not specified then the unit will be determined by the unit system.

--- a/flow360/component/simulation/user_code/core/types.py
+++ b/flow360/component/simulation/user_code/core/types.py
@@ -412,7 +412,7 @@ class UserVariable(Variable):
     @classmethod
     def check_valid_user_variable_name(cls, v):
         """Validate a variable identifier (ASCII only)."""
-        # Partial list of C++ keywords; extend as needed
+        # Partial list of keywords; extend as needed
         RESERVED_SYNTAX_KEYWORDS = {  # pylint:disable=invalid-name
             "int",
             "double",
@@ -456,7 +456,7 @@ class UserVariable(Variable):
             item.split(".")[-1] for item in default_context.registered_names if "." in item
         }
         if v in solver_side_names:
-            raise ValueError(f"'{v}' is a reserved solver side variable name.")
+            raise ValueError(f"'{v}' cannot be a reserved solver side variable name.")
 
         return v
 
@@ -584,15 +584,12 @@ class Expression(Flow360BaseModel, Evaluable):
     @pd.model_validator(mode="after")
     def check_output_units_matches_dimensionality(self) -> str:
         """Check that the output units have the same dimensionality as the expression"""
-        print(f"self.output_units: {self.output_units}")
         if not self.output_units:
             return self
         if self.output_units in ("SI_unit_system", "CGS_unit_system", "Imperial_unit_system"):
             return self
         output_units_dimensionality = u.Unit(self.output_units).dimensions
         expression_dimensionality = self.dimensionality
-        print(f"output_units_dimensionality: {output_units_dimensionality}")
-        print(f"expression_dimensionality: {expression_dimensionality}")
         if output_units_dimensionality != expression_dimensionality:
             raise ValueError(
                 f"Output units '{self.output_units}' have different dimensionality "

--- a/flow360/component/simulation/user_code/core/types.py
+++ b/flow360/component/simulation/user_code/core/types.py
@@ -818,6 +818,12 @@ class ValueOrExpression(Expression, Generic[T]):
             except Exception:  # pylint:disable=broad-exception-caught
                 pass
 
+            # Handle list of unyt_quantities:
+            if isinstance(value, list) and all(isinstance(item, unyt_quantity) for item in value):
+                # ensure all items have the same dimensionality
+                if not all(item.units.dimensions == value[0].units.dimensions for item in value):
+                    raise ValueError("All items in the list must have the same dimensionality")
+                return unyt_array(value)
             return value
 
         def _serializer(value, info) -> dict:

--- a/flow360/component/simulation/user_code/core/types.py
+++ b/flow360/component/simulation/user_code/core/types.py
@@ -459,6 +459,7 @@ class SolverVariable(Variable):
             name=new_name,
             value=Expression(expression=self.name),
         )
+        print("The value class name is:", new_variable.value.__class__.__name__)
         new_variable.value.output_units = new_unit  # pylint:disable=assigning-non-slot
         return new_variable
 

--- a/tests/simulation/test_expressions.py
+++ b/tests/simulation/test_expressions.py
@@ -1148,13 +1148,16 @@ def test_project_variables_deserialization():
 
 
 def test_overwriting_project_variables():
-    UserVariable(name="a", value=1)
+    a = UserVariable(name="a", value=1)
 
     with pytest.raises(
         ValueError,
         match="Redeclaring user variable a with new value: 2.0. Previous value: 1.0",
     ):
         UserVariable(name="a", value=2)
+
+    a.value = 2
+    assert a.value == 2
 
 
 def test_unique_dimensionality():
@@ -1187,6 +1190,8 @@ def test_unique_dimensionality():
         ("class", "'class' is a reserved keyword."),
         ("namespace", "'namespace' is a reserved keyword."),
         ("template", "'template' is a reserved keyword."),
+        ("temperature", "'temperature' is a reserved solver side variable name."),
+        ("velocity", "'velocity' is a reserved solver side variable name."),
     ],
 )
 def test_invalid_names_raise(bad_name, expected_msg):

--- a/tests/simulation/test_expressions.py
+++ b/tests/simulation/test_expressions.py
@@ -1169,10 +1169,10 @@ def test_unique_dimensionality():
     with pytest.raises(
         ValueError, match="List must contain only all unyt_quantities or all numbers."
     ):
-        UserVariable(name="a", value=[1 * u.m, 1])
+        UserVariable(name="a", value=[1.0 * u.m, 1.0])
 
-    a = UserVariable(name="a", value=[1 * u.m, 1 * u.mm])
-    assert all(a.value == [1, 0.001] * u.m)
+    a = UserVariable(name="a", value=[1.0 * u.m, 1.0 * u.mm])
+    assert all(a.value == [1.0, 0.001] * u.m)
 
 
 @pytest.mark.parametrize(

--- a/tests/simulation/test_expressions.py
+++ b/tests/simulation/test_expressions.py
@@ -1193,6 +1193,7 @@ def test_unique_dimensionality():
         ("temperature", "'temperature' is a reserved solver side variable name."),
         ("velocity", "'velocity' is a reserved (legacy) output field name."),
         ("rho", "'rho' is a reserved (legacy) output field name."),
+        ("pressure", "'pressure' is a reserved (legacy) output field name."),
     ],
 )
 def test_invalid_names_raise(bad_name, expected_msg):

--- a/tests/simulation/test_expressions.py
+++ b/tests/simulation/test_expressions.py
@@ -1191,7 +1191,8 @@ def test_unique_dimensionality():
         ("namespace", "'namespace' is a reserved keyword."),
         ("template", "'template' is a reserved keyword."),
         ("temperature", "'temperature' is a reserved solver side variable name."),
-        ("velocity", "'velocity' is a reserved solver side variable name."),
+        ("velocity", "'velocity' is a reserved (legacy) output field name."),
+        ("rho", "'rho' is a reserved (legacy) output field name."),
     ],
 )
 def test_invalid_names_raise(bad_name, expected_msg):

--- a/tests/simulation/test_expressions.py
+++ b/tests/simulation/test_expressions.py
@@ -1015,7 +1015,7 @@ def test_to_file_from_file_expression(
             outputs=[
                 VolumeOutput(
                     output_fields=[
-                        solution.mut.in_unit(new_name="mut_in_SI", new_unit="cm**2/min"),
+                        solution.mut.in_units(new_name="mut_in_SI", new_unit="cm**2/min"),
                         constant_variable,
                         constant_array,
                         constant_unyt_quantity,
@@ -1043,14 +1043,14 @@ def test_udf_generator():
         )
     # Scalar output
     result = user_variable_to_udf(
-        solution.mut.in_unit(new_name="mut_in_km", new_unit="km**2/s"), input_params=params
+        solution.mut.in_units(new_name="mut_in_km", new_unit="km**2/s"), input_params=params
     )
     # velocity scale = 100 m/s, length scale = 10m, mut_scale = 1000 m**2/s -> 0.01 *km**2/s
     assert result.expression == "mut_in_km = (mut * 0.001);"
 
     # Vector output
     result = user_variable_to_udf(
-        solution.velocity.in_unit(new_name="velocity_in_SI", new_unit="m/s"), input_params=params
+        solution.velocity.in_units(new_name="velocity_in_SI", new_unit="m/s"), input_params=params
     )
     # velocity scale =  100 m/s,
     assert (
@@ -1060,7 +1060,7 @@ def test_udf_generator():
 
     vel_cross_vec = UserVariable(
         name="vel_cross_vec", value=math.cross(solution.velocity, [1, 2, 3] * u.cm)
-    ).in_unit(new_unit="m*km/s/s")
+    ).in_units(new_unit="m*km/s/s")
     result = user_variable_to_udf(vel_cross_vec, input_params=params)
     assert (
         result.expression
@@ -1069,7 +1069,7 @@ def test_udf_generator():
 
     vel_cross_vec = UserVariable(
         name="vel_cross_vec", value=math.cross(solution.velocity, [1, 2, 3] * u.cm)
-    ).in_unit(new_unit="CGS_unit_system")
+    ).in_units(new_unit="CGS_unit_system")
     assert vel_cross_vec.value.get_output_units(input_params=params) == u.cm**2 / u.s
 
 
@@ -1078,7 +1078,7 @@ def test_project_variables_serialization():
     aaa = UserVariable(
         name="aaa", value=[solution.velocity[0] + ccc, solution.velocity[1], solution.velocity[2]]
     )
-    bbb = UserVariable(name="bbb", value=[aaa[0] + 14 * u.m / u.s, aaa[1], aaa[2]]).in_unit(
+    bbb = UserVariable(name="bbb", value=[aaa[0] + 14 * u.m / u.s, aaa[1], aaa[2]]).in_units(
         new_unit="km/ms"
     )
 

--- a/tests/simulation/test_expressions.py
+++ b/tests/simulation/test_expressions.py
@@ -897,7 +897,7 @@ def test_cross_function_use_case():
 
     print("\n3 (Units defined in components)\n")
     a.value = math.cross([3 * u.m, 2 * u.m, 1 * u.m], [2 * u.m, 2 * u.m, 1 * u.m])
-    assert a.value == [0 * u.m * u.m, -1 * u.m * u.m, 2 * u.m * u.m]
+    assert all(a.value == [0, -1, 2] * u.m * u.m)
 
     print("\n4 Serialized version\n")
     a.value = "math.cross([3, 2, 1] * u.m, solution.coordinate)"
@@ -1164,3 +1164,11 @@ def test_whitelisted_callables():
 
     assert compare_lists(solution_vars, WHITELISTED_CALLABLES["flow360.solution"]["callables"])
     assert compare_lists(control_vars, WHITELISTED_CALLABLES["flow360.control"]["callables"])
+
+
+def test_unique_dimensionality():
+    with pytest.raises(ValueError, match="All items in the list must have the same dimensionality"):
+        UserVariable(name="a", value=[1 * u.m, 1 * u.s])
+
+    a = UserVariable(name="a", value=[1 * u.m, 1 * u.mm])
+    assert all(a.value == [1, 0.001] * u.m)

--- a/tests/simulation/translator/test_output_translation.py
+++ b/tests/simulation/translator/test_output_translation.py
@@ -47,7 +47,7 @@ from flow360.component.simulation.user_code.variables import solution
 
 @pytest.fixture()
 def vel_in_km_per_hr():
-    return solution.velocity.in_unit(new_name="velocity_in_km_per_hr", new_unit=u.km / u.hr)
+    return solution.velocity.in_units(new_name="velocity_in_km_per_hr", new_unit=u.km / u.hr)
 
 
 @pytest.fixture()

--- a/tests/simulation/translator/test_solver_translator.py
+++ b/tests/simulation/translator/test_solver_translator.py
@@ -678,7 +678,9 @@ def test_param_with_user_variables():
                     output_fields=[
                         solution.Mach,
                         solution.velocity,
-                        UserVariable(name="uuu", value=solution.velocity).in_unit(new_unit="km/ms"),
+                        UserVariable(name="uuu", value=solution.velocity).in_units(
+                            new_unit="km/ms"
+                        ),
                         my_var,
                     ],
                 )


### PR DESCRIPTION
- [x] UserVariable names can not be: Syntax keywords (int, double etc).
- [x] UserVariable names can not be: empty.
- [x] UserVariable names must start with a letter (A-Z/a-z) or underscore (_).
- [x] UserVariable names can only contain letters, digits (0-9), or underscore (_).
- [x] UserVariable names cannot be a reserved SolverVariable name.
- [x] UserVariable names cannot be a legacy string output field name.
- [x] UserVariable cannot assign output units for constant values (unyt_array etc).
- [x] UserVariable output units must match its dimensionality.
- [x] Expression must have same dimensionality of each item in the list.
- [x] Renamed in_unit to in_units.
- [x] Disabled use of degF and degR in the `in_units()` as well as in `Expression`.