### PR TITLE
[25.5][FXC-1886] Fix incorrect dimensional output when liquid op is used

### DIFF
--- a/flow360/component/simulation/conversion.py
+++ b/flow360/component/simulation/conversion.py
@@ -157,11 +157,11 @@ def unit_converter(dimension, params, required_by: List[str] = None) -> u.UnitSy
             if params.operating_condition.velocity_magnitude.value != 0:
                 return (
                     params.operating_condition.velocity_magnitude / LIQUID_IMAGINARY_FREESTREAM_MACH
-                )
+                ).to("m/s")
             return (
                 params.operating_condition.reference_velocity_magnitude
                 / LIQUID_IMAGINARY_FREESTREAM_MACH
-            )
+            ).to("m/s")
         require(["operating_condition", "thermal_state", "temperature"], required_by, params)
         base_velocity = params.operating_condition.thermal_state.speed_of_sound.to("m/s").v.item()
         return base_velocity
@@ -180,7 +180,7 @@ def unit_converter(dimension, params, required_by: List[str] = None) -> u.UnitSy
 
     def get_base_density():
         if params.operating_condition.type_name == "LiquidOperatingCondition":
-            return params.operating_condition.material.density
+            return params.operating_condition.material.density.to("kg/m**3")
         require(["operating_condition", "thermal_state", "density"], required_by, params)
         base_density = params.operating_condition.thermal_state.density.to("kg/m**3").v.item()
 

--- a/flow360/component/simulation/framework/updater_utils.py
+++ b/flow360/component/simulation/framework/updater_utils.py
@@ -37,6 +37,15 @@ def compare_dicts(dict1, dict2, atol=1e-15, rtol=1e-10, ignore_keys=None):
 
 def compare_values(value1, value2, atol=1e-15, rtol=1e-10, ignore_keys=None):
     """Check two values are same or not"""
+    # Handle numerical comparisons first (including int vs float)
+    if isinstance(value1, Number) and isinstance(value2, Number):
+        return np.isclose(value1, value2, rtol, atol)
+
+    # Handle type mismatches for non-numerical types
+    # pylint: disable=unidiomatic-typecheck
+    if type(value1) != type(value2):
+        return False
+
     if isinstance(value1, Number) and isinstance(value2, Number):
         return np.isclose(value1, value2, rtol, atol)
     if isinstance(value1, dict) and isinstance(value2, dict):
@@ -51,7 +60,14 @@ def compare_lists(list1, list2, atol=1e-15, rtol=1e-10, ignore_keys=None):
     if len(list1) != len(list2):
         return False
 
-    if list1 and not isinstance(list1[0], dict):
+    # Only sort if the lists contain simple comparable types (not dicts, lists, etc.)
+    def is_simple_type(item):
+        return isinstance(item, (str, int, float, bool)) or (
+            isinstance(item, Number) and not isinstance(item, (dict, list))
+        )
+
+    if list1 and all(is_simple_type(item) for item in list1):
+        print(f"list1 {list1}, list2 {list2}")
         list1, list2 = sorted(list1), sorted(list2)
 
     for item1, item2 in zip(list1, list2):

--- a/flow360/component/simulation/outputs/output_fields.py
+++ b/flow360/component/simulation/outputs/output_fields.py
@@ -258,19 +258,21 @@ _FIELD_TYPE_INFO = {
 
 # Predefined UDF expressions
 PREDEFINED_UDF_EXPRESSIONS = {
-    "velocity": "velocity[0] = primitiveVars[1];"
-    + "velocity[1] = primitiveVars[2];"
-    + "velocity[2] = primitiveVars[3];",
+    "velocity": "velocity[0] = primitiveVars[1] * velocityScale;"
+    + "velocity[1] = primitiveVars[2] * velocityScale;"
+    + "velocity[2] = primitiveVars[3] * velocityScale;",
     "velocity_magnitude": "double velocity[3];"
     + "velocity[0] = primitiveVars[1];"
     + "velocity[1] = primitiveVars[2];"
     + "velocity[2] = primitiveVars[3];"
-    + "velocity_magnitude = magnitude(velocity);",
-    "velocity_x": "velocity_x = primitiveVars[1];",
-    "velocity_y": "velocity_y = primitiveVars[2];",
-    "velocity_z": "velocity_z = primitiveVars[3];",
-    "pressure": "pressure = primitiveVars[4];",
-    "wall_shear_stress_magnitude": "wall_shear_stress_magnitude = magnitude(wallShearStress);",
+    + "velocity_magnitude = magnitude(velocity) * velocityScale;",
+    "velocity_x": "velocity_x = primitiveVars[1] * velocityScale;",
+    "velocity_y": "velocity_y = primitiveVars[2] * velocityScale;",
+    "velocity_z": "velocity_z = primitiveVars[3] * velocityScale;",
+    "pressure": "double gamma = 1.4;pressure = (usingLiquidAsMaterial) ? "
+    + "(primitiveVars[4] - 1.0 / gamma) * (velocityScale * velocityScale) : primitiveVars[4];",
+    "wall_shear_stress_magnitude": "wall_shear_stress_magnitude = "
+    + "magnitude(wallShearStress) * (velocityScale * velocityScale);",
 }
 
 
@@ -330,6 +332,7 @@ def generate_predefined_udf(field_name, params):
 
     if unit is None:
         return base_expr
+    base_expr = base_expr.replace("velocityScale", "1.0")
 
     conversion_factor = params.convert_unit(1.0 * unit, "flow360").v
 

--- a/tests/simulation/outputs/test_output_fields.py
+++ b/tests/simulation/outputs/test_output_fields.py
@@ -24,9 +24,9 @@ def test_generate_field_udf_no_unit(simulation_params):
     result = generate_predefined_udf("velocity", simulation_params)
 
     expected = (
-        "velocity[0] = primitiveVars[1];"
-        "velocity[1] = primitiveVars[2];"
-        "velocity[2] = primitiveVars[3];"
+        "velocity[0] = primitiveVars[1] * velocityScale;"
+        "velocity[1] = primitiveVars[2] * velocityScale;"
+        "velocity[2] = primitiveVars[3] * velocityScale;"
     )
 
     assert result == expected
@@ -38,9 +38,9 @@ def test_generate_field_udf_with_unit(simulation_params):
 
     expected = (
         "double velocity[3];"
-        "velocity[0] = primitiveVars[1];"
-        "velocity[1] = primitiveVars[2];"
-        "velocity[2] = primitiveVars[3];"
+        "velocity[0] = primitiveVars[1] * 1.0;"
+        "velocity[1] = primitiveVars[2] * 1.0;"
+        "velocity[2] = primitiveVars[3] * 1.0;"
         "velocity_m_per_s[0] = velocity[0] * 340.29400580821283;"
         "velocity_m_per_s[1] = velocity[1] * 340.29400580821283;"
         "velocity_m_per_s[2] = velocity[2] * 340.29400580821283;"
@@ -55,7 +55,7 @@ def test_generate_field_udf_velocity_components(simulation_params):
     result = generate_predefined_udf("velocity_x_m_per_s", simulation_params)
     expected = (
         "double velocity_x;"
-        "velocity_x = primitiveVars[1];"
+        "velocity_x = primitiveVars[1] * 1.0;"
         "velocity_x_m_per_s = velocity_x * 340.29400580821283;"
     )
     assert result == expected
@@ -63,7 +63,7 @@ def test_generate_field_udf_velocity_components(simulation_params):
     result = generate_predefined_udf("velocity_y_m_per_s", simulation_params)
     expected = (
         "double velocity_y;"
-        "velocity_y = primitiveVars[2];"
+        "velocity_y = primitiveVars[2] * 1.0;"
         "velocity_y_m_per_s = velocity_y * 340.29400580821283;"
     )
     assert result == expected
@@ -71,7 +71,7 @@ def test_generate_field_udf_velocity_components(simulation_params):
     result = generate_predefined_udf("velocity_z_m_per_s", simulation_params)
     expected = (
         "double velocity_z;"
-        "velocity_z = primitiveVars[3];"
+        "velocity_z = primitiveVars[3] * 1.0;"
         "velocity_z_m_per_s = velocity_z * 340.29400580821283;"
     )
     assert result == expected
@@ -86,7 +86,7 @@ def test_generate_field_velocity_magnitude_no_unit(simulation_params):
         "velocity[0] = primitiveVars[1];"
         "velocity[1] = primitiveVars[2];"
         "velocity[2] = primitiveVars[3];"
-        "velocity_magnitude = magnitude(velocity);"
+        "velocity_magnitude = magnitude(velocity) * velocityScale;"
     )
     assert result == expected
 
@@ -101,7 +101,7 @@ def test_generate_field_udf_velocity_magnitude(simulation_params):
         "velocity[0] = primitiveVars[1];"
         "velocity[1] = primitiveVars[2];"
         "velocity[2] = primitiveVars[3];"
-        "velocity_magnitude = magnitude(velocity);"
+        "velocity_magnitude = magnitude(velocity) * 1.0;"
         "velocity_magnitude_m_per_s = velocity_magnitude * 340.29400580821283;"
     )
     assert result == expected
@@ -111,7 +111,11 @@ def test_generate_field_pressure_no_unit(simulation_params):
     """Test generating UDF expression for pressure fields."""
 
     result = generate_predefined_udf("pressure", simulation_params)
-    expected = "pressure = primitiveVars[4];"
+    expected = (
+        "double gamma = 1.4;"
+        "pressure = (usingLiquidAsMaterial) ? "
+        "(primitiveVars[4] - 1.0 / gamma) * (velocityScale * velocityScale) : primitiveVars[4];"
+    )
     assert result == expected
 
 
@@ -121,7 +125,9 @@ def test_generate_field_udf_pressure(simulation_params):
     result = generate_predefined_udf("pressure_pa", simulation_params)
     expected = (
         "double pressure;"
-        "pressure = primitiveVars[4];"
+        "double gamma = 1.4;"
+        "pressure = (usingLiquidAsMaterial) ? "
+        "(primitiveVars[4] - 1.0 / gamma) * (1.0 * 1.0) : primitiveVars[4];"
         "pressure_pa = pressure * 141855.012726525;"
     )
     assert result == expected
@@ -131,7 +137,7 @@ def test_genereate_field_wall_shear_stress_no_unit(simulation_params):
     """Test generating UDF expression for wall shear stress fields."""
 
     result = generate_predefined_udf("wall_shear_stress_magnitude", simulation_params)
-    expected = "wall_shear_stress_magnitude = magnitude(wallShearStress);"
+    expected = "wall_shear_stress_magnitude = magnitude(wallShearStress) * (velocityScale * velocityScale);"
     assert result == expected
 
 
@@ -141,7 +147,7 @@ def test_generate_field_udf_wall_shear_stress(simulation_params):
     result = generate_predefined_udf("wall_shear_stress_magnitude_pa", simulation_params)
     expected = (
         "double wall_shear_stress_magnitude;"
-        "wall_shear_stress_magnitude = magnitude(wallShearStress);"
+        "wall_shear_stress_magnitude = magnitude(wallShearStress) * (1.0 * 1.0);"
         "wall_shear_stress_magnitude_pa = wall_shear_stress_magnitude * 141855.012726525;"
     )
     assert result == expected
@@ -150,7 +156,7 @@ def test_generate_field_udf_wall_shear_stress(simulation_params):
 def test_generate_field_udf_precedence(simulation_params):
     """Test that longer matching keys take precedence."""
     result = generate_predefined_udf("velocity_x", simulation_params)
-    expected = "velocity_x = primitiveVars[1];"
+    expected = "velocity_x = primitiveVars[1] * velocityScale;"
     assert result == expected
 
 

--- a/tests/simulation/translator/ref/Flow360_liquid.json
+++ b/tests/simulation/translator/ref/Flow360_liquid.json
@@ -1,101 +1,101 @@
 {
-    "freestream": {
-        "alphaAngle": 5.0,
-        "betaAngle": 2.0,
-        "Mach": 0.05,
-        "Temperature": -1,
-        "muRef": 4.554545454545455e-09
-    },
-    "timeStepping": {
-        "CFL": {
-            "type": "adaptive",
-            "min": 0.1,
-            "max": 10000.0,
-            "maxRelativeChange": 1.0,
-            "convergenceLimitingFactor": 0.25
-        },
-        "physicalSteps": 1,
-        "orderOfAccuracy": 2,
-        "maxPseudoSteps": 2000,
-        "timeStepSize": "inf"
-    },
-    "navierStokesSolver": {
-        "absoluteTolerance": 1e-10,
-        "relativeTolerance": 0.0,
-        "orderOfAccuracy": 2,
-        "linearSolver": {
-            "maxIterations": 30
-        },
-        "CFLMultiplier": 1.0,
-        "kappaMUSCL": -1.0,
-        "numericalDissipationFactor": 1.0,
-        "limitVelocity": false,
-        "limitPressureDensity": false,
-        "lowMachPreconditioner": true,
-        "updateJacobianFrequency": 4,
-        "maxForceJacUpdatePhysicalSteps": 0,
-        "lowMachPreconditionerThreshold": 0.05,
-        "modelType": "Compressible",
-        "equationEvalFrequency": 1
-    },
-    "turbulenceModelSolver": {
-        "absoluteTolerance": 1e-08,
-        "relativeTolerance": 0.0,
-        "orderOfAccuracy": 2,
-        "linearSolver": {
-            "maxIterations": 20
-        },
-        "CFLMultiplier": 2.0,
-        "reconstructionGradientLimiter": 0.5,
-        "quadraticConstitutiveRelation": false,
-        "updateJacobianFrequency": 4,
-        "maxForceJacUpdatePhysicalSteps": 0,
-        "rotationCorrection": false,
-        "equationEvalFrequency": 4,
-        "modelType": "SpalartAllmaras",
-        "modelConstants": {
-            "C_DES": 0.72,
-            "C_d": 8.0,
-            "C_cb1": 0.1355,
-            "C_cb2": 0.622,
-            "C_sigma": 0.6666666666666666,
-            "C_v1": 7.1,
-            "C_vonKarman": 0.41,
-            "C_w2": 0.3,
-            "C_t3": 1.2,
-            "C_t4": 0.5,
-            "C_min_rd": 10.0
-        },
-        "DDES": false,
-        "ZDES": false,
-        "gridSizeForLES": "maxEdgeLength"
-    },
-    "initialCondition": {
-        "type": "initialCondition",
-        "rho": "rho",
-        "u": "u",
-        "v": "v",
-        "w": "w",
-        "p": "p"
-    },
     "boundaries": {
         "fluid/body": {
-            "type": "NoSlipWall",
             "heatFlux": 0.0,
-            "roughnessHeight": 0.0
+            "roughnessHeight": 0.0,
+            "type": "NoSlipWall"
         },
         "fluid/farfield": {
             "type": "Freestream"
         }
     },
+    "freestream": {
+        "Mach": 0.05,
+        "Temperature": -1,
+        "alphaAngle": 5.0,
+        "betaAngle": 2.0,
+        "muRef": 4.554545454545455e-09
+    },
+    "initialCondition": {
+        "p": "p",
+        "rho": "rho",
+        "type": "initialCondition",
+        "u": "u",
+        "v": "v",
+        "w": "w"
+    },
+    "navierStokesSolver": {
+        "CFLMultiplier": 1.0,
+        "absoluteTolerance": 1e-10,
+        "equationEvalFrequency": 1,
+        "kappaMUSCL": -1.0,
+        "limitPressureDensity": false,
+        "limitVelocity": false,
+        "linearSolver": {
+            "maxIterations": 30
+        },
+        "lowMachPreconditioner": true,
+        "lowMachPreconditionerThreshold": 0.05,
+        "maxForceJacUpdatePhysicalSteps": 0,
+        "modelType": "Compressible",
+        "numericalDissipationFactor": 1.0,
+        "orderOfAccuracy": 2,
+        "relativeTolerance": 0.0,
+        "updateJacobianFrequency": 4
+    },
+    "outputRescale": {
+        "velocityScale": 20.0
+    },
+    "timeStepping": {
+        "CFL": {
+            "convergenceLimitingFactor": 0.25,
+            "max": 10000.0,
+            "maxRelativeChange": 1.0,
+            "min": 0.1,
+            "type": "adaptive"
+        },
+        "maxPseudoSteps": 2000,
+        "orderOfAccuracy": 2,
+        "physicalSteps": 1,
+        "timeStepSize": "inf"
+    },
+    "turbulenceModelSolver": {
+        "CFLMultiplier": 2.0,
+        "DDES": false,
+        "ZDES": false,
+        "absoluteTolerance": 1e-08,
+        "equationEvalFrequency": 4,
+        "gridSizeForLES": "maxEdgeLength",
+        "linearSolver": {
+            "maxIterations": 20
+        },
+        "maxForceJacUpdatePhysicalSteps": 0,
+        "modelConstants": {
+            "C_DES": 0.72,
+            "C_cb1": 0.1355,
+            "C_cb2": 0.622,
+            "C_d": 8.0,
+            "C_min_rd": 10.0,
+            "C_sigma": 0.6666666666666666,
+            "C_t3": 1.2,
+            "C_t4": 0.5,
+            "C_v1": 7.1,
+            "C_vonKarman": 0.41,
+            "C_w2": 0.3
+        },
+        "modelType": "SpalartAllmaras",
+        "orderOfAccuracy": 2,
+        "quadraticConstitutiveRelation": false,
+        "reconstructionGradientLimiter": 0.5,
+        "relativeTolerance": 0.0,
+        "rotationCorrection": false,
+        "updateJacobianFrequency": 4
+    },
     "userDefinedFields": [
         {
-            "expression": "double velocity[3];velocity[0] = primitiveVars[1];velocity[1] = primitiveVars[2];velocity[2] = primitiveVars[3];velocity_magnitude = magnitude(velocity);",
+            "expression": "double velocity[3];velocity[0] = primitiveVars[1];velocity[1] = primitiveVars[2];velocity[2] = primitiveVars[3];velocity_magnitude = magnitude(velocity) * velocityScale;",
             "name": "velocity_magnitude"
         }
     ],
-    "usingLiquidAsMaterial": true,
-    "outputRescale": {
-        "velocityScale": 20.0
-    }
+    "usingLiquidAsMaterial": true
 }

--- a/tests/simulation/translator/ref/Flow360_liquid_rotation_dd.json
+++ b/tests/simulation/translator/ref/Flow360_liquid_rotation_dd.json
@@ -1,105 +1,107 @@
 {
-    "freestream": {
-        "alphaAngle": 5.0,
-        "betaAngle": 2.0,
-        "Mach": 0.05,
-        "Temperature": -1,
-        "muRef": 4.554545454545455e-09
-    },
-    "timeStepping": {
-        "CFL": {
-            "type": "adaptive",
-            "min": 0.1,
-            "max": 1000000.0,
-            "maxRelativeChange": 50.0,
-            "convergenceLimitingFactor": 1.0
-        },
-        "physicalSteps": 100,
-        "orderOfAccuracy": 2,
-        "maxPseudoSteps": 20,
-        "timeStepSize": 80.0
-    },
-    "navierStokesSolver": {
-        "absoluteTolerance": 1e-10,
-        "relativeTolerance": 0.0,
-        "orderOfAccuracy": 2,
-        "linearSolver": {
-            "maxIterations": 30
-        },
-        "CFLMultiplier": 1.0,
-        "kappaMUSCL": -1.0,
-        "numericalDissipationFactor": 1.0,
-        "limitVelocity": false,
-        "limitPressureDensity": false,
-        "lowMachPreconditioner": true,
-        "updateJacobianFrequency": 4,
-        "maxForceJacUpdatePhysicalSteps": 0,
-        "lowMachPreconditionerThreshold": 0.05,
-        "modelType": "Compressible",
-        "equationEvalFrequency": 1
-    },
-    "turbulenceModelSolver": {
-        "absoluteTolerance": 1e-08,
-        "relativeTolerance": 0.0,
-        "orderOfAccuracy": 2,
-        "linearSolver": {
-            "maxIterations": 20
-        },
-        "CFLMultiplier": 2.0,
-        "reconstructionGradientLimiter": 0.5,
-        "quadraticConstitutiveRelation": false,
-        "updateJacobianFrequency": 4,
-        "maxForceJacUpdatePhysicalSteps": 0,
-        "rotationCorrection": false,
-        "equationEvalFrequency": 4,
-        "modelType": "SpalartAllmaras",
-        "modelConstants": {
-            "C_DES": 0.72,
-            "C_d": 8.0,
-            "C_cb1": 0.1355,
-            "C_cb2": 0.622,
-            "C_sigma": 0.6666666666666666,
-            "C_v1": 7.1,
-            "C_vonKarman": 0.41,
-            "C_w2": 0.3,
-            "C_t3": 1.2,
-            "C_t4": 0.5,
-            "C_min_rd": 10.0
-        },
-        "DDES": false,
-        "ZDES": false,
-        "gridSizeForLES": "maxEdgeLength"
-    },
-    "initialCondition": {
-        "type": "initialCondition",
-        "rho": "rho",
-        "u": "u",
-        "v": "v",
-        "w": "w",
-        "p": "p"
-    },
     "boundaries": {
         "fluid/body": {
-            "type": "NoSlipWall",
             "heatFlux": 0.0,
-            "roughnessHeight": 0.0
+            "roughnessHeight": 0.0,
+            "type": "NoSlipWall"
         },
         "fluid/farfield": {
             "type": "Freestream"
         }
     },
+    "freestream": {
+        "Mach": 0.05,
+        "Temperature": -1,
+        "alphaAngle": 5.0,
+        "betaAngle": 2.0,
+        "muRef": 4.554545454545455e-09
+    },
+    "initialCondition": {
+        "p": "p",
+        "rho": "rho",
+        "type": "initialCondition",
+        "u": "u",
+        "v": "v",
+        "w": "w"
+    },
+    "navierStokesSolver": {
+        "CFLMultiplier": 1.0,
+        "absoluteTolerance": 1e-10,
+        "equationEvalFrequency": 1,
+        "kappaMUSCL": -1.0,
+        "limitPressureDensity": false,
+        "limitVelocity": false,
+        "linearSolver": {
+            "maxIterations": 30
+        },
+        "lowMachPreconditioner": true,
+        "lowMachPreconditionerThreshold": 0.05,
+        "maxForceJacUpdatePhysicalSteps": 0,
+        "modelType": "Compressible",
+        "numericalDissipationFactor": 1.0,
+        "orderOfAccuracy": 2,
+        "relativeTolerance": 0.0,
+        "updateJacobianFrequency": 4
+    },
+    "outputRescale": {
+        "velocityScale": 20.0
+    },
+    "timeStepping": {
+        "CFL": {
+            "convergenceLimitingFactor": 1.0,
+            "max": 1000000.0,
+            "maxRelativeChange": 50.0,
+            "min": 0.1,
+            "type": "adaptive"
+        },
+        "maxPseudoSteps": 20,
+        "orderOfAccuracy": 2,
+        "physicalSteps": 100,
+        "timeStepSize": 80.0
+    },
+    "turbulenceModelSolver": {
+        "CFLMultiplier": 2.0,
+        "DDES": false,
+        "ZDES": false,
+        "absoluteTolerance": 1e-08,
+        "equationEvalFrequency": 4,
+        "gridSizeForLES": "maxEdgeLength",
+        "linearSolver": {
+            "maxIterations": 20
+        },
+        "maxForceJacUpdatePhysicalSteps": 0,
+        "modelConstants": {
+            "C_DES": 0.72,
+            "C_cb1": 0.1355,
+            "C_cb2": 0.622,
+            "C_d": 8.0,
+            "C_min_rd": 10.0,
+            "C_sigma": 0.6666666666666666,
+            "C_t3": 1.2,
+            "C_t4": 0.5,
+            "C_v1": 7.1,
+            "C_vonKarman": 0.41,
+            "C_w2": 0.3
+        },
+        "modelType": "SpalartAllmaras",
+        "orderOfAccuracy": 2,
+        "quadraticConstitutiveRelation": false,
+        "reconstructionGradientLimiter": 0.5,
+        "relativeTolerance": 0.0,
+        "rotationCorrection": false,
+        "updateJacobianFrequency": 4
+    },
     "userDefinedFields": [
         {
-            "expression": "double velocity[3];velocity[0] = primitiveVars[1];velocity[1] = primitiveVars[2];velocity[2] = primitiveVars[3];velocity_magnitude = magnitude(velocity);",
+            "expression": "double velocity[3];velocity[0] = primitiveVars[1];velocity[1] = primitiveVars[2];velocity[2] = primitiveVars[3];velocity_magnitude = magnitude(velocity) * velocityScale;",
             "name": "velocity_magnitude"
         }
     ],
     "usingLiquidAsMaterial": true,
-    "outputRescale": {
-        "velocityScale": 20.0
-    },
     "volumeZones": {
         "zone_zone_1": {
+            "isRotatingReferenceFrame": false,
+            "modelType": "FluidDynamics",
             "referenceFrame": {
                 "axisOfRotation": [
                     0.6,
@@ -112,9 +114,7 @@
                     0.01
                 ],
                 "thetaRadians": "-180/pi * atan(2 * 3.00 * 20.00 * 2.00/180*pi * cos(2.00/180*pi * sin(0.05877271 * (0.005 * t))) * cos(0.05877271 * (0.005 * t)) / 200.00) + 2 * 2.00 * sin(0.05877271 * (0.005 * t)) - 2.00 * sin(0.05877271 * (0.005 * t))"
-            },
-            "modelType": "FluidDynamics",
-            "isRotatingReferenceFrame": false
+            }
         }
     }
 }

--- a/tests/simulation/translator/test_output_translation.py
+++ b/tests/simulation/translator/test_output_translation.py
@@ -33,12 +33,10 @@ from flow360.component.simulation.outputs.outputs import (
     VolumeOutput,
 )
 from flow360.component.simulation.primitives import Surface
+from flow360.component.simulation.services import simulation_to_case_json
 from flow360.component.simulation.simulation_params import SimulationParams
 from flow360.component.simulation.time_stepping.time_stepping import Unsteady
-from flow360.component.simulation.translator.solver_translator import (
-    get_solver_json,
-    translate_output,
-)
+from flow360.component.simulation.translator.solver_translator import translate_output
 from flow360.component.simulation.unit_system import SI_unit_system
 
 
@@ -1063,7 +1061,6 @@ def test_dimensioned_output_fields_translation():
             ],
         )
 
-    # solver_json = get_solver_json(param, mesh_unit=1.0 * u.m)
     solver_json, _ = simulation_to_case_json(param, mesh_unit=1.0 * u.m)
     expected_fields_v = [
         "velocity",
@@ -1089,78 +1086,50 @@ def test_dimensioned_output_fields_translation():
 
     ref = {
         "userDefinedFields": [
-            {"name": "pressure", "expression": "pressure = primitiveVars[4];"},
+            {"name": "my_field", "expression": "1+1"},
             {
-                "name": "velocity_m_per_s",
-                "expression": "double velocity[3];"
-                "velocity[0] = primitiveVars[1];"
-                "velocity[1] = primitiveVars[2];"
-                "velocity[2] = primitiveVars[3];"
-                "velocity_m_per_s[0] = velocity[0] * 340.29400580821283;"
-                "velocity_m_per_s[1] = velocity[1] * 340.29400580821283;"
-                "velocity_m_per_s[2] = velocity[2] * 340.29400580821283;",
-            },
-            {
-                "name": "wall_shear_stress_magnitude",
-                "expression": "wall_shear_stress_magnitude = magnitude(wallShearStress);",
-            },
-            {
-                "name": "velocity_magnitude",
-                "expression": "double velocity[3]"
-                "velocity[0] = primitiveVars[1]"
-                "velocity[1] = primitiveVars[2]"
-                "velocity[2] = primitiveVars[3]"
-                "velocity_magnitude = magnitude(velocity)",
-            },
-            {
-                "name": "velocity",
-                "expression": "velocity[0] = primitiveVars[1]"
-                "velocity[1] = primitiveVars[2]"
-                "velocity[2] = primitiveVars[3]",
-            },
-            {
-                "name": "wall_shear_stress_magnitude_pa",
-                "expression": "double wall_shear_stress_magnitude"
-                "wall_shear_stress_magnitude = magnitude(wallShearStress)"
-                "wall_shear_stress_magnitude_pa = wall_shear_stress_magnitude * 141855.012726525",
-            },
-            {
-                "name": "velocity_y_m_per_s",
-                "expression": "double velocity_y"
-                "velocity_y = primitiveVars[2]"
-                "velocity_y_m_per_s = velocity_y * 340.29400580821283",
-            },
-            {
-                "name": "velocity_x_m_per_s",
-                "expression": "double velocity_x"
-                "velocity_x = primitiveVars[1]"
-                "velocity_x_m_per_s = velocity_x * 340.29400580821283",
-            },
-            {
-                "name": "velocity_magnitude_m_per_s",
-                "expression": "double velocity_magnitude"
-                "double velocity[3]"
-                "velocity[0] = primitiveVars[1]"
-                "velocity[1] = primitiveVars[2]"
-                "velocity[2] = primitiveVars[3]"
-                "velocity_magnitude = magnitude(velocity)"
-                "velocity_magnitude_m_per_s = velocity_magnitude * 340.29400580821283",
+                "name": "pressure",
+                "expression": "double gamma = 1.4;pressure = (usingLiquidAsMaterial) ? (primitiveVars[4] - 1.0 / gamma) * (velocityScale * velocityScale) : primitiveVars[4];",
             },
             {
                 "name": "pressure_pa",
-                "expression": "double pressure"
-                "pressure = primitiveVars[4]"
-                "pressure_pa = pressure * 141855.012726525",
+                "expression": "double pressure;double gamma = 1.4;pressure = (usingLiquidAsMaterial) ? (primitiveVars[4] - 1.0 / gamma) * (1.0 * 1.0) : primitiveVars[4];pressure_pa = pressure * 141855.012726525;",
+            },
+            {
+                "name": "velocity",
+                "expression": "velocity[0] = primitiveVars[1] * velocityScale;velocity[1] = primitiveVars[2] * velocityScale;velocity[2] = primitiveVars[3] * velocityScale;",
+            },
+            {
+                "name": "velocity_m_per_s",
+                "expression": "double velocity[3];velocity[0] = primitiveVars[1] * 1.0;velocity[1] = primitiveVars[2] * 1.0;velocity[2] = primitiveVars[3] * 1.0;velocity_m_per_s[0] = velocity[0] * 340.29400580821283;velocity_m_per_s[1] = velocity[1] * 340.29400580821283;velocity_m_per_s[2] = velocity[2] * 340.29400580821283;",
+            },
+            {
+                "name": "velocity_magnitude",
+                "expression": "double velocity[3];velocity[0] = primitiveVars[1];velocity[1] = primitiveVars[2];velocity[2] = primitiveVars[3];velocity_magnitude = magnitude(velocity) * velocityScale;",
+            },
+            {
+                "name": "velocity_magnitude_m_per_s",
+                "expression": "double velocity_magnitude;double velocity[3];velocity[0] = primitiveVars[1];velocity[1] = primitiveVars[2];velocity[2] = primitiveVars[3];velocity_magnitude = magnitude(velocity) * 1.0;velocity_magnitude_m_per_s = velocity_magnitude * 340.29400580821283;",
+            },
+            {
+                "name": "velocity_x_m_per_s",
+                "expression": "double velocity_x;velocity_x = primitiveVars[1] * 1.0;velocity_x_m_per_s = velocity_x * 340.29400580821283;",
+            },
+            {
+                "name": "velocity_y_m_per_s",
+                "expression": "double velocity_y;velocity_y = primitiveVars[2] * 1.0;velocity_y_m_per_s = velocity_y * 340.29400580821283;",
             },
             {
                 "name": "velocity_z_m_per_s",
-                "expression": "double velocity_z"
-                "velocity_z = primitiveVars[3]"
-                "velocity_z_m_per_s = velocity_z * 340.29400580821283",
+                "expression": "double velocity_z;velocity_z = primitiveVars[3] * 1.0;velocity_z_m_per_s = velocity_z * 340.29400580821283;",
             },
             {
-                "name": "my_field",
-                "expression": "1+1",
+                "name": "wall_shear_stress_magnitude",
+                "expression": "wall_shear_stress_magnitude = magnitude(wallShearStress) * (velocityScale * velocityScale);",
+            },
+            {
+                "name": "wall_shear_stress_magnitude_pa",
+                "expression": "double wall_shear_stress_magnitude;wall_shear_stress_magnitude = magnitude(wallShearStress) * (1.0 * 1.0);wall_shear_stress_magnitude_pa = wall_shear_stress_magnitude * 141855.012726525;",
             },
         ]
     }
@@ -1168,8 +1137,10 @@ def test_dimensioned_output_fields_translation():
     solver_user_defined_fields = {}
     solver_user_defined_fields["userDefinedFields"] = solver_json["userDefinedFields"]
 
-    print(solver_user_defined_fields["userDefinedFields"])
-    assert compare_values(solver_user_defined_fields, ref)
+    assert compare_values(
+        sorted(solver_user_defined_fields["userDefinedFields"], key=lambda d: d["name"]),
+        sorted(ref["userDefinedFields"], key=lambda d: d["name"]),
+    )
 
 
 @pytest.fixture()

--- a/tests/simulation/translator/test_output_translation.py
+++ b/tests/simulation/translator/test_output_translation.py
@@ -3,6 +3,7 @@ import json
 import pytest
 
 import flow360.component.simulation.units as u
+from flow360.component.simulation.framework.updater_utils import compare_values
 from flow360.component.simulation.operating_condition.operating_condition import (
     AerospaceCondition,
 )
@@ -94,7 +95,7 @@ def test_volume_output(volume_output_config, avg_volume_output_config):
         param = SimulationParams(outputs=[volume_output_config[0]])
     translated = {"boundaries": {}}
     translated = translate_output(param, translated)
-    assert sorted(volume_output_config[1].items()) == sorted(translated["volumeOutput"].items())
+    assert compare_values(volume_output_config[1], translated["volumeOutput"])
 
     ##:: timeAverageVolumeOutput only
     with SI_unit_system:
@@ -104,7 +105,7 @@ def test_volume_output(volume_output_config, avg_volume_output_config):
         )
     translated = {"boundaries": {}}
     translated = translate_output(param, translated)
-    assert sorted(avg_volume_output_config[1].items()) == sorted(translated["volumeOutput"].items())
+    assert compare_values(avg_volume_output_config[1], translated["volumeOutput"])
 
     ##:: timeAverageVolumeOutput and volumeOutput
     with SI_unit_system:
@@ -126,7 +127,7 @@ def test_volume_output(volume_output_config, avg_volume_output_config):
             "startAverageIntegrationStep": 1,
         }
     }
-    assert sorted(ref["volumeOutput"].items()) == sorted(translated["volumeOutput"].items())
+    assert compare_values(ref["volumeOutput"], translated["volumeOutput"])
 
 
 @pytest.fixture()
@@ -191,7 +192,7 @@ def test_surface_output(
         param = SimulationParams(outputs=surface_output_config[0])
     translated = {"boundaries": {}}
     translated = translate_output(param, translated)
-    assert sorted(surface_output_config[1].items()) == sorted(translated["surfaceOutput"].items())
+    assert compare_values(surface_output_config[1], translated["surfaceOutput"])
 
     ##:: timeAverageSurfaceOutput and surfaceOutput
     with SI_unit_system:
@@ -219,7 +220,7 @@ def test_surface_output(
         },
         "writeSingleFile": False,
     }
-    assert sorted(ref.items()) == sorted(translated["surfaceOutput"].items())
+    assert compare_values(ref, translated["surfaceOutput"])
 
 
 @pytest.fixture()
@@ -308,7 +309,7 @@ def test_slice_output(
     translated = {"boundaries": {}}
     translated = translate_output(param, translated)
 
-    assert sorted(sliceoutput_config[1].items()) == sorted(translated["sliceOutput"].items())
+    assert compare_values(sliceoutput_config[1], translated["sliceOutput"])
 
 
 @pytest.fixture()
@@ -392,9 +393,7 @@ def test_isosurface_output(
     translated = {"boundaries": {}}
     translated = translate_output(param, translated)
 
-    assert sorted(isosurface_output_config[1].items()) == sorted(
-        translated["isoSurfaceOutput"].items()
-    )
+    assert compare_values(isosurface_output_config[1], translated["isoSurfaceOutput"])
 
 
 @pytest.fixture()
@@ -727,7 +726,7 @@ def test_surface_probe_output():
 
     translated = {"boundaries": {}}
     translated = translate_output(param, translated)
-    assert sorted(param_with_ref[1].items()) == sorted(translated["surfaceMonitorOutput"].items())
+    assert compare_values(param_with_ref[1], translated["surfaceMonitorOutput"])
 
 
 def test_monitor_output(
@@ -746,7 +745,7 @@ def test_monitor_output(
 
     translated = {"boundaries": {}}
     translated = translate_output(param, translated)
-    assert sorted(probe_output_config[1].items()) == sorted(translated["monitorOutput"].items())
+    assert compare_values(probe_output_config[1], translated["monitorOutput"])
 
     ##:: monitorOutput with line probes
     with SI_unit_system:
@@ -755,9 +754,7 @@ def test_monitor_output(
 
     translated = {"boundaries": {}}
     translated = translate_output(param, translated)
-    assert sorted(probe_output_with_point_array[1].items()) == sorted(
-        translated["monitorOutput"].items()
-    )
+    assert compare_values(probe_output_with_point_array[1], translated["monitorOutput"])
 
     ##:: surfaceIntegral
     with SI_unit_system:
@@ -772,9 +769,7 @@ def test_monitor_output(
 
     translated = {"boundaries": {}}
     translated = translate_output(param, translated)
-    assert sorted(surface_integral_output_config[1].items()) == sorted(
-        translated["monitorOutput"].items()
-    )
+    assert compare_values(surface_integral_output_config[1], translated["monitorOutput"])
 
     ##:: surfaceIntegral and probeMonitor with global probe settings
     with SI_unit_system:
@@ -845,7 +840,7 @@ def test_monitor_output(
         },
         "outputFields": [],
     }
-    assert sorted(ref.items()) == sorted(translated["monitorOutput"].items())
+    assert compare_values(ref, translated["monitorOutput"])
 
 
 @pytest.fixture()
@@ -908,9 +903,7 @@ def test_acoustic_output(aeroacoustic_output_config, aeroacoustic_output_permeab
     param = param._preprocess(mesh_unit=1 * u.m, exclude=["models"])
     translated = translate_output(param, translated)
 
-    assert sorted(aeroacoustic_output_config[1].items()) == sorted(
-        translated["aeroacousticOutput"].items()
-    )
+    assert compare_values(aeroacoustic_output_config[1], translated["aeroacousticOutput"])
 
     with SI_unit_system:
         param = SimulationParams(
@@ -922,9 +915,7 @@ def test_acoustic_output(aeroacoustic_output_config, aeroacoustic_output_permeab
     param = param._preprocess(mesh_unit=1 * u.m, exclude=["models"])
     translated = translate_output(param, translated)
 
-    assert sorted(aeroacoustic_output_permeable_config[1].items()) == sorted(
-        translated["aeroacousticOutput"].items()
-    )
+    assert compare_values(aeroacoustic_output_permeable_config[1], translated["aeroacousticOutput"])
 
 
 def test_surface_slice_output():
@@ -1024,7 +1015,7 @@ def test_surface_slice_output():
     translated = {"boundaries": {}}
     translated = translate_output(param, translated)
     print(json.dumps(translated, indent=4))
-    assert sorted(param_with_ref[1].items()) == sorted(translated["surfaceSliceOutput"].items())
+    assert compare_values(param_with_ref[1], translated["surfaceSliceOutput"])
 
 
 def test_dimensioned_output_fields_translation():
@@ -1072,7 +1063,8 @@ def test_dimensioned_output_fields_translation():
             ],
         )
 
-    solver_json = get_solver_json(param, mesh_unit=1.0 * u.m)
+    # solver_json = get_solver_json(param, mesh_unit=1.0 * u.m)
+    solver_json, _ = simulation_to_case_json(param, mesh_unit=1.0 * u.m)
     expected_fields_v = [
         "velocity",
         "velocity_m_per_s",
@@ -1175,7 +1167,9 @@ def test_dimensioned_output_fields_translation():
 
     solver_user_defined_fields = {}
     solver_user_defined_fields["userDefinedFields"] = solver_json["userDefinedFields"]
-    assert sorted(solver_user_defined_fields) == sorted(ref)
+
+    print(solver_user_defined_fields["userDefinedFields"])
+    assert compare_values(solver_user_defined_fields, ref)
 
 
 @pytest.fixture()
@@ -1237,6 +1231,4 @@ def test_streamline_output(streamline_output_config):
     param = param._preprocess(mesh_unit=1 * u.m, exclude=["models"])
     translated = translate_output(param, translated)
 
-    assert sorted(streamline_output_config[1].items()) == sorted(
-        translated["streamlineOutput"].items()
-    )
+    assert compare_values(streamline_output_config[1], translated["streamlineOutput"])


### PR DESCRIPTION
1. Fix incorrect flow360 unit conversion system in liquid op

2. Fix incorrect predefined udf expression for dimensional output

Hotfix is implemented in #1265