### PR TITLE
Jim/update dynamic derivatives

### DIFF
--- a/examples/advanced_simulations/aerodynamics/dynamic_derivatives/dynamic_derivatives.py
+++ b/examples/advanced_simulations/aerodynamics/dynamic_derivatives/dynamic_derivatives.py
@@ -1,3 +1,9 @@
+'''
+Example script for calculating dynamic derivatives using sliding interfaces in Flow360
+See documentation for more information:
+ https://docs.flexcompute.com/projects/flow360/en/latest/tutorials/DynamicDerivatives/DynamicDerivatives.html
+'''
+
 import math
 
 import flow360 as fl


### PR DESCRIPTION
I have updated the dynamic derivatives example to use Adaptive CFL instead of ramp CFL. This allows us to do away with the steady state initialization step. 
It makes the whole process quite simpler.

See matching PR in documentation 