### PR TITLE
Add support for Axisymmetric Sliding Interfaces

### DIFF
--- a/examples/advanced_simulations/aerodynamics/dynamic_derivatives/dynamic_derivatives.py
+++ b/examples/advanced_simulations/aerodynamics/dynamic_derivatives/dynamic_derivatives.py
@@ -31,7 +31,7 @@ with fl.SI_unit_system:
         outer_radius=1.0,
         height=2.5,
     )
-    sliding_interface = fl.RotationCylinder(
+    sliding_interface = fl.RotationVolume(
         spacing_axial=0.04,
         spacing_radial=0.04,
         spacing_circumferential=0.04,

--- a/examples/advanced_simulations/rotorcraft/isolated_propeller.py
+++ b/examples/advanced_simulations/rotorcraft/isolated_propeller.py
@@ -12,13 +12,21 @@ geometry.group_faces_by_tag("faceName")
 
 with fl.SI_unit_system:
     rotating_cylinder = fl.Cylinder(
-        name="Rotating zone", center=[0, 0, 0], axis=[1, 0, 0], outer_radius=2, height=0.8
+        name="Rotating zone",
+        center=[0, 0, 0],
+        axis=[1, 0, 0],
+        outer_radius=2,
+        height=0.8,
     )
     refinement_cylinder = fl.Cylinder(
-        name="Refinement zone", center=[1.9, 0, 0], axis=[1, 0, 0], outer_radius=2, height=4
+        name="Refinement zone",
+        center=[1.9, 0, 0],
+        axis=[1, 0, 0],
+        outer_radius=2,
+        height=4,
     )
     slice = fl.Slice(name="Slice", normal=[1, 0, 0], origin=[0.6, 0, 0])
-    volume_zone_rotating_cylinder = fl.RotationCylinder(
+    volume_zone_rotating_cylinder = fl.RotationVolume(
         name="Rotation cylinder",
         spacing_axial=0.05,
         spacing_radial=0.05,
@@ -30,11 +38,14 @@ with fl.SI_unit_system:
     params = fl.SimulationParams(
         meshing=fl.MeshingParams(
             defaults=fl.MeshingDefaults(
-                surface_max_edge_length=1, boundary_layer_first_layer_thickness=0.1 * fl.u.mm
+                surface_max_edge_length=1,
+                boundary_layer_first_layer_thickness=0.1 * fl.u.mm,
             ),
             refinements=[
                 fl.UniformRefinement(
-                    name="Uniform refinement", spacing=0.025, entities=[refinement_cylinder]
+                    name="Uniform refinement",
+                    spacing=0.025,
+                    entities=[refinement_cylinder],
                 )
             ],
             volume_zones=[farfield, volume_zone_rotating_cylinder],
@@ -63,7 +74,10 @@ with fl.SI_unit_system:
             step_size=0.0025,
             max_pseudo_steps=35,
             CFL=fl.AdaptiveCFL(
-                min=0.1, max=10000, max_relative_change=1, convergence_limiting_factor=0.5
+                min=0.1,
+                max=10000,
+                max_relative_change=1,
+                convergence_limiting_factor=0.5,
             ),
         ),
         outputs=[

--- a/examples/post_processing/field_data/time_averaged_isosurfaces.py
+++ b/examples/post_processing/field_data/time_averaged_isosurfaces.py
@@ -13,13 +13,21 @@ geometry.group_faces_by_tag("faceName")
 
 with fl.SI_unit_system:
     rotating_cylinder = fl.Cylinder(
-        name="Rotating zone", center=[0, 0, 0], axis=[1, 0, 0], outer_radius=2, height=0.8
+        name="Rotating zone",
+        center=[0, 0, 0],
+        axis=[1, 0, 0],
+        outer_radius=2,
+        height=0.8,
     )
     refinement_cylinder = fl.Cylinder(
-        name="Refinement zone", center=[1.9, 0, 0], axis=[1, 0, 0], outer_radius=2, height=4
+        name="Refinement zone",
+        center=[1.9, 0, 0],
+        axis=[1, 0, 0],
+        outer_radius=2,
+        height=4,
     )
     slice = fl.Slice(name="Slice", normal=[1, 0, 0], origin=[0.6, 0, 0])
-    volume_zone_rotating_cylinder = fl.RotationCylinder(
+    volume_zone_rotating_cylinder = fl.RotationVolume(
         name="Rotation cylinder",
         spacing_axial=0.05,
         spacing_radial=0.05,
@@ -31,11 +39,14 @@ with fl.SI_unit_system:
     params = fl.SimulationParams(
         meshing=fl.MeshingParams(
             defaults=fl.MeshingDefaults(
-                surface_max_edge_length=1, boundary_layer_first_layer_thickness=0.1 * fl.u.mm
+                surface_max_edge_length=1,
+                boundary_layer_first_layer_thickness=0.1 * fl.u.mm,
             ),
             refinements=[
                 fl.UniformRefinement(
-                    name="Uniform refinement", spacing=0.025, entities=[refinement_cylinder]
+                    name="Uniform refinement",
+                    spacing=0.025,
+                    entities=[refinement_cylinder],
                 )
             ],
             volume_zones=[farfield, volume_zone_rotating_cylinder],
@@ -64,7 +75,10 @@ with fl.SI_unit_system:
             step_size=0.0025,
             max_pseudo_steps=35,
             CFL=fl.AdaptiveCFL(
-                min=0.1, max=10000, max_relative_change=1, convergence_limiting_factor=0.5
+                min=0.1,
+                max=10000,
+                max_relative_change=1,
+                convergence_limiting_factor=0.5,
             ),
         ),
         outputs=[

--- a/flow360/__init__.py
+++ b/flow360/__init__.py
@@ -31,7 +31,7 @@ from flow360.component.simulation.meshing_param.params import (
 from flow360.component.simulation.meshing_param.volume_params import (
     AutomatedFarfield,
     AxisymmetricRefinement,
-    RotationCylinder,
+    RotationVolume,
     UniformRefinement,
     UserDefinedFarfield,
 )
@@ -198,7 +198,7 @@ __all__ = [
     "SurfaceRefinement",
     "AutomatedFarfield",
     "AxisymmetricRefinement",
-    "RotationCylinder",
+    "RotationVolume",
     "UniformRefinement",
     "SurfaceEdgeRefinement",
     "HeightBasedRefinement",

--- a/flow360/component/simulation/framework/base_model.py
+++ b/flow360/component/simulation/framework/base_model.py
@@ -39,7 +39,9 @@ def _preprocess_nested_list(value, required_by, params, exclude, registry_lookup
         if isinstance(item, list):
             # Recursively process nested lists.
             new_list.append(
-                _preprocess_nested_list(item, new_required_by, params, exclude, registry_lookup)
+                _preprocess_nested_list(
+                    item, new_required_by, params, exclude, registry_lookup
+                )
             )
         elif isinstance(item, Flow360BaseModel):
             # Process Flow360BaseModel instances.
@@ -185,12 +187,17 @@ class Flow360BaseModel(pd.BaseModel):
         if cls.model_config["require_one_of"]:
             set_values = [key for key, v in values.items() if v is not None]
             aliases = [
-                cls._get_field_alias(field_name=name) for name in cls.model_config["require_one_of"]
+                cls._get_field_alias(field_name=name)
+                for name in cls.model_config["require_one_of"]
             ]
             aliases = [item for item in aliases if item is not None]
-            intersection = list(set(set_values) & set(cls.model_config["require_one_of"] + aliases))
+            intersection = list(
+                set(set_values) & set(cls.model_config["require_one_of"] + aliases)
+            )
             if len(intersection) == 0:
-                raise ValueError(f"One of {cls.model_config['require_one_of']} is required.")
+                raise ValueError(
+                    f"One of {cls.model_config['require_one_of']} is required."
+                )
         return values
 
     # pylint: disable=no-self-argument
@@ -220,7 +227,10 @@ class Flow360BaseModel(pd.BaseModel):
             field2_alias = cls._get_field_alias(field_name=conflicting_field.field2)
             conflicting_field2_value = values.get(field2_alias, None)
 
-        if conflicting_field1_value is not None and conflicting_field2_value is not None:
+        if (
+            conflicting_field1_value is not None
+            and conflicting_field2_value is not None
+        ):
             raise ValueError(
                 f"{conflicting_field.field1} and {conflicting_field.field2} cannot be specified at the same time."
             )
@@ -276,7 +286,10 @@ class Flow360BaseModel(pd.BaseModel):
         for field_name, field in cls.model_fields.items():
             # Ignore discriminator validators
             # pylint: disable=comparison-with-callable
-            if get_origin(field.annotation) == Literal and field_name in DISCRIMINATOR_NAMES:
+            if (
+                get_origin(field.annotation) == Literal
+                and field_name in DISCRIMINATOR_NAMES
+            ):
                 need_to_rebuild = True
                 continue
 
@@ -342,7 +355,9 @@ class Flow360BaseModel(pd.BaseModel):
                     if ctx.get("relevant_for") is None:
                         # Enforce the relevant_for to be a list for consistency
                         ctx["relevant_for"] = (
-                            relevant_for if isinstance(relevant_for, list) else [relevant_for]
+                            relevant_for
+                            if isinstance(relevant_for, list)
+                            else [relevant_for]
                         )
                     validation_errors[i]["ctx"] = ctx
             raise pd.ValidationError.from_exception_data(
@@ -359,7 +374,9 @@ class Flow360BaseModel(pd.BaseModel):
     def copy(self, update=None, **kwargs) -> Flow360BaseModel:
         """Copy a Flow360BaseModel.  With ``deep=True`` as default."""
         if "deep" in kwargs and kwargs["deep"] is False:
-            raise ValueError("Can't do shallow copy of component, set `deep=True` in copy().")
+            raise ValueError(
+                "Can't do shallow copy of component, set `deep=True` in copy()."
+            )
         new_copy = pd.BaseModel.model_copy(self, update=update, deep=True, **kwargs)
         data = new_copy.model_dump()
         return self.model_validate(data)
@@ -422,7 +439,9 @@ class Flow360BaseModel(pd.BaseModel):
         elif ".yaml" in filename:
             model_dict = cls._dict_from_yaml(filename=filename)
         else:
-            raise Flow360FileError(f"File must be *.json or *.yaml type, given {filename}")
+            raise Flow360FileError(
+                f"File must be *.json or *.yaml type, given {filename}"
+            )
 
         model_dict = cls._handle_dict_with_hash(model_dict)
         return model_dict
@@ -642,7 +661,10 @@ class Flow360BaseModel(pd.BaseModel):
             required_by = []
 
         solver_values = self._nondimensionalization(
-            params=params, exclude=exclude, required_by=required_by, registry_lookup=registry_lookup
+            params=params,
+            exclude=exclude,
+            required_by=required_by,
+            registry_lookup=registry_lookup,
         )
         for property_name, value in self.__dict__.items():
             if property_name in exclude:

--- a/flow360/component/simulation/framework/base_model.py
+++ b/flow360/component/simulation/framework/base_model.py
@@ -39,9 +39,7 @@ def _preprocess_nested_list(value, required_by, params, exclude, registry_lookup
         if isinstance(item, list):
             # Recursively process nested lists.
             new_list.append(
-                _preprocess_nested_list(
-                    item, new_required_by, params, exclude, registry_lookup
-                )
+                _preprocess_nested_list(item, new_required_by, params, exclude, registry_lookup)
             )
         elif isinstance(item, Flow360BaseModel):
             # Process Flow360BaseModel instances.
@@ -187,17 +185,12 @@ class Flow360BaseModel(pd.BaseModel):
         if cls.model_config["require_one_of"]:
             set_values = [key for key, v in values.items() if v is not None]
             aliases = [
-                cls._get_field_alias(field_name=name)
-                for name in cls.model_config["require_one_of"]
+                cls._get_field_alias(field_name=name) for name in cls.model_config["require_one_of"]
             ]
             aliases = [item for item in aliases if item is not None]
-            intersection = list(
-                set(set_values) & set(cls.model_config["require_one_of"] + aliases)
-            )
+            intersection = list(set(set_values) & set(cls.model_config["require_one_of"] + aliases))
             if len(intersection) == 0:
-                raise ValueError(
-                    f"One of {cls.model_config['require_one_of']} is required."
-                )
+                raise ValueError(f"One of {cls.model_config['require_one_of']} is required.")
         return values
 
     # pylint: disable=no-self-argument
@@ -227,10 +220,7 @@ class Flow360BaseModel(pd.BaseModel):
             field2_alias = cls._get_field_alias(field_name=conflicting_field.field2)
             conflicting_field2_value = values.get(field2_alias, None)
 
-        if (
-            conflicting_field1_value is not None
-            and conflicting_field2_value is not None
-        ):
+        if conflicting_field1_value is not None and conflicting_field2_value is not None:
             raise ValueError(
                 f"{conflicting_field.field1} and {conflicting_field.field2} cannot be specified at the same time."
             )
@@ -286,10 +276,7 @@ class Flow360BaseModel(pd.BaseModel):
         for field_name, field in cls.model_fields.items():
             # Ignore discriminator validators
             # pylint: disable=comparison-with-callable
-            if (
-                get_origin(field.annotation) == Literal
-                and field_name in DISCRIMINATOR_NAMES
-            ):
+            if get_origin(field.annotation) == Literal and field_name in DISCRIMINATOR_NAMES:
                 need_to_rebuild = True
                 continue
 
@@ -355,9 +342,7 @@ class Flow360BaseModel(pd.BaseModel):
                     if ctx.get("relevant_for") is None:
                         # Enforce the relevant_for to be a list for consistency
                         ctx["relevant_for"] = (
-                            relevant_for
-                            if isinstance(relevant_for, list)
-                            else [relevant_for]
+                            relevant_for if isinstance(relevant_for, list) else [relevant_for]
                         )
                     validation_errors[i]["ctx"] = ctx
             raise pd.ValidationError.from_exception_data(
@@ -374,9 +359,7 @@ class Flow360BaseModel(pd.BaseModel):
     def copy(self, update=None, **kwargs) -> Flow360BaseModel:
         """Copy a Flow360BaseModel.  With ``deep=True`` as default."""
         if "deep" in kwargs and kwargs["deep"] is False:
-            raise ValueError(
-                "Can't do shallow copy of component, set `deep=True` in copy()."
-            )
+            raise ValueError("Can't do shallow copy of component, set `deep=True` in copy().")
         new_copy = pd.BaseModel.model_copy(self, update=update, deep=True, **kwargs)
         data = new_copy.model_dump()
         return self.model_validate(data)
@@ -439,9 +422,7 @@ class Flow360BaseModel(pd.BaseModel):
         elif ".yaml" in filename:
             model_dict = cls._dict_from_yaml(filename=filename)
         else:
-            raise Flow360FileError(
-                f"File must be *.json or *.yaml type, given {filename}"
-            )
+            raise Flow360FileError(f"File must be *.json or *.yaml type, given {filename}")
 
         model_dict = cls._handle_dict_with_hash(model_dict)
         return model_dict

--- a/flow360/component/simulation/meshing_param/params.py
+++ b/flow360/component/simulation/meshing_param/params.py
@@ -18,7 +18,7 @@ from flow360.component.simulation.meshing_param.face_params import (
 from flow360.component.simulation.meshing_param.volume_params import (
     AutomatedFarfield,
     AxisymmetricRefinement,
-    RotationCylinder,
+    RotationVolume,
     UniformRefinement,
     UserDefinedFarfield,
 )
@@ -48,7 +48,7 @@ RefinementTypes = Annotated[
 
 VolumeZonesTypes = Annotated[
     Union[
-        RotationCylinder,
+        RotationVolume,
         AutomatedFarfield,
         UserDefinedFarfield,
         CustomVolume,
@@ -337,7 +337,7 @@ class MeshingParams(Flow360BaseModel):
         usage = EntityUsageMap()
 
         for volume_zone in self.volume_zones if self.volume_zones is not None else []:
-            if isinstance(volume_zone, RotationCylinder):
+            if isinstance(volume_zone, RotationVolume):
                 # pylint: disable=protected-access
                 _ = [
                     usage.add_entity_usage(item, volume_zone.type)

--- a/flow360/component/simulation/meshing_param/params.py
+++ b/flow360/component/simulation/meshing_param/params.py
@@ -18,6 +18,7 @@ from flow360.component.simulation.meshing_param.face_params import (
 from flow360.component.simulation.meshing_param.volume_params import (
     AutomatedFarfield,
     AxisymmetricRefinement,
+    RotationCylinder,
     RotationVolume,
     UniformRefinement,
     UserDefinedFarfield,
@@ -49,6 +50,7 @@ RefinementTypes = Annotated[
 VolumeZonesTypes = Annotated[
     Union[
         RotationVolume,
+        RotationCylinder,
         AutomatedFarfield,
         UserDefinedFarfield,
         CustomVolume,

--- a/flow360/component/simulation/meshing_param/params.py
+++ b/flow360/component/simulation/meshing_param/params.py
@@ -47,7 +47,12 @@ RefinementTypes = Annotated[
 ]
 
 VolumeZonesTypes = Annotated[
-    Union[RotationCylinder, AutomatedFarfield, UserDefinedFarfield, CustomVolume],
+    Union[
+        RotationCylinder,
+        AutomatedFarfield,
+        UserDefinedFarfield,
+        CustomVolume,
+    ],
     pd.Field(discriminator="type"),
 ]
 

--- a/flow360/component/simulation/meshing_param/volume_params.py
+++ b/flow360/component/simulation/meshing_param/volume_params.py
@@ -21,6 +21,7 @@ from flow360.component.simulation.unit_system import LengthType
 from flow360.component.simulation.validation.validation_utils import (
     check_deleted_surface_in_entity_list,
 )
+from flow360.log import log
 
 
 class UniformRefinement(Flow360BaseModel):
@@ -90,7 +91,7 @@ class AxisymmetricRefinement(CylindricalRefinementBase):
     entities: EntityList[Cylinder] = pd.Field()
 
 
-class RotationCylinder(CylindricalRefinementBase):
+class RotationVolume(CylindricalRefinementBase):
     """
     - The mesh on :class:`RotationCylinder` is guaranteed to be concentric.
     - The :class:`RotationCylinder` is designed to enclose other objects, but it can’t intersect with other objects.
@@ -122,12 +123,12 @@ class RotationCylinder(CylindricalRefinementBase):
     # Note: https://www.notion.so/flexcompute/Python-model-design-document-
     # Note: 78d442233fa944e6af8eed4de9541bb1?pvs=4#c2de0b822b844a12aa2c00349d1f68a3
 
-    type: Literal["RotationCylinder"] = pd.Field("RotationCylinder", frozen=True)
-    name: Optional[str] = pd.Field("Rotation cylinder", description="Name to display in the GUI.")
+    type: Literal["RotationVolume"] = pd.Field("RotationVolume", frozen=True)
+    name: Optional[str] = pd.Field("Rotation Volume", description="Name to display in the GUI.")
     entities: EntityList[Cylinder, AxisymmetricBody] = pd.Field()
     enclosed_entities: Optional[EntityList[Cylinder, Surface, AxisymmetricBody]] = pd.Field(
         None,
-        description="Entities enclosed by :class:`RotationCylinder`. "
+        description="Entities enclosed by :class:`RotationVolume`. "
         + "Can be `Surface` and/or other :class:`~flow360.Cylinder`(s) and/or other :class:`~flow360.AxisymmetricBody`(s).",
     )
 
@@ -142,9 +143,7 @@ class RotationCylinder(CylindricalRefinementBase):
         """
         # pylint: disable=protected-access
         if len(values._get_expanded_entities(create_hard_copy=False)) > 1:
-            raise ValueError(
-                "Only single instance is allowed in entities for each RotationCylinder."
-            )
+            raise ValueError("Only single instance is allowed in entities for each RotationVolume.")
         return values
 
     @pd.field_validator("entities", mode="after")
@@ -161,7 +160,7 @@ class RotationCylinder(CylindricalRefinementBase):
         for entity in values.stored_entities:
             if isinstance(entity, Cylinder) and len(entity.name) > max_cylinder_name_length:
                 raise ValueError(
-                    f"The name ({entity.name}) of `Cylinder` entity in `RotationCylinder` "
+                    f"The name ({entity.name}) of `Cylinder` entity in `RotationVolume` "
                     + f"exceeds {max_cylinder_name_length} characters limit."
                 )
         return values

--- a/flow360/component/simulation/meshing_param/volume_params.py
+++ b/flow360/component/simulation/meshing_param/volume_params.py
@@ -49,7 +49,7 @@ class UniformRefinement(Flow360BaseModel):
     spacing: LengthType.Positive = pd.Field(description="The required refinement spacing.")
 
 
-class CylindricalRefinementBase(Flow360BaseModel, metaclass=ABCMeta):
+class AxisymmetricRefinementBase(Flow360BaseModel, metaclass=ABCMeta):
     """Base class for all refinements that requires spacing in axial, radial and circumferential directions."""
 
     # pylint: disable=no-member
@@ -62,7 +62,7 @@ class CylindricalRefinementBase(Flow360BaseModel, metaclass=ABCMeta):
     )
 
 
-class AxisymmetricRefinement(CylindricalRefinementBase):
+class AxisymmetricRefinement(AxisymmetricRefinementBase):
     """
     - The mesh inside the :class:`AxisymmetricRefinement` is semi-structured.
     - The :class:`AxisymmetricRefinement` cannot enclose/intersect with other objects.
@@ -91,7 +91,7 @@ class AxisymmetricRefinement(CylindricalRefinementBase):
     entities: EntityList[Cylinder] = pd.Field()
 
 
-class RotationVolume(CylindricalRefinementBase):
+class RotationVolume(AxisymmetricRefinementBase):
     """
     - The mesh on :class:`RotationCylinder` is guaranteed to be concentric.
     - The :class:`RotationCylinder` is designed to enclose other objects, but it can’t intersect with other objects.

--- a/flow360/component/simulation/primitives.py
+++ b/flow360/component/simulation/primitives.py
@@ -412,6 +412,59 @@ class Cylinder(_VolumeEntityBase):
         return self
 
 
+@final
+class AxisymmetricBody(_VolumeEntityBase):
+    """
+    :class:`AxisymmetricBody` class represents a generic body of revolution in three-dimensional space.
+    It is represented as a list[(Axial Position, Radial Extent)] profile polyline with arbitrary center and axial direction.
+    Expect first and last profile samples to connect to axis, i.e., have radius = 0.
+
+    Example
+    -------
+    >>> fl.AxisymmetricBody(
+    ...     name="cone_frustum_body",
+    ...     center=(0, 0, 0) * fl.u.inch,
+    ...     axis=(0, 0, 1),
+    ...     profile_curve = [(-1, 0), (-1, 1), (1, 2), (1, 0)]
+    ... )
+
+    ====
+    """
+
+    private_attribute_entity_type_name: Literal["AxisymmetricBody"] = pd.Field(
+        "AxisymmetricBody", frozen=True
+    )
+    axis: Axis = pd.Field(description="The axis of the body of revolution.")
+    # pylint: disable=no-member
+    center: LengthType.Point = pd.Field(description="The center point of the body of revolution.")
+    profile_curve: List[LengthType.Array] = pd.Field(
+        description="The (Axial, Radial) profile of the body of revolution."
+    )
+
+    private_attribute_id: str = pd.Field(default_factory=generate_uuid, frozen=True)
+
+    @pd.model_validator(mode="after")
+    def _check_radial_profile_is_positive(self) -> Self:
+        first_point = self.profile_curve[0]
+        if len(first_point) != 2 or first_point[1] != 0:
+            raise ValueError(
+                f"Expect first profile sample to be (Axial, 0.0). Found invalid point: {str(first_point)}."
+            )
+
+        last_point = self.profile_curve[-1]
+        if len(last_point) != 2 or last_point[1] != 0:
+            raise ValueError(
+                f"Expect last profile sample to be (Axial, 0.0). Found invalid point: {str(last_point)}."
+            )
+
+        for profile_point in self.profile_curve[1:-1]:
+            if len(profile_point) != 2 or profile_point[1] < 0:
+                raise ValueError(
+                    f"Expect profile samples to be (Axial, Radial) samples with positive Radial. Found invalid point: {str(profile_point)}."
+                )
+        return self
+
+
 class SurfacePrivateAttributes(Flow360BaseModel):
     """
      Private attributes for Surface.

--- a/flow360/component/simulation/simulation_params.py
+++ b/flow360/component/simulation/simulation_params.py
@@ -27,7 +27,7 @@ from flow360.component.simulation.framework.updater_utils import Flow360Version
 from flow360.component.simulation.meshing_param.params import MeshingParams
 from flow360.component.simulation.meshing_param.volume_params import (
     AutomatedFarfield,
-    RotationCylinder,
+    RotationVolume,
 )
 from flow360.component.simulation.models.surface_models import SurfaceModelTypes
 from flow360.component.simulation.models.volume_models import (
@@ -146,7 +146,8 @@ class _ParamModelBase(Flow360BaseModel):
             if kwarg_unit_system != unit_system_manager.current:
                 raise Flow360RuntimeError(
                     unit_system_inconsistent_msg(
-                        kwarg_unit_system.system_repr(), unit_system_manager.current.system_repr()
+                        kwarg_unit_system.system_repr(),
+                        unit_system_manager.current.system_repr(),
                     )
                 )
 
@@ -177,7 +178,9 @@ class _ParamModelBase(Flow360BaseModel):
         forward_compatibility_mode = Flow360Version(input_version) > Flow360Version(version_to)
         if not forward_compatibility_mode:
             model_dict = updater(
-                version_from=input_version, version_to=version_to, params_as_dict=model_dict
+                version_from=input_version,
+                version_to=version_to,
+                params_as_dict=model_dict,
             )
         return model_dict, forward_compatibility_mode
 
@@ -294,7 +297,8 @@ class SimulationParams(_ParamModelBase):
     # Limitations:
     #    1. No per volume zone output. (single volume output)
     outputs: Optional[List[OutputTypes]] = CaseField(
-        None, description="Output settings. See :ref:`Outputs <outputs>` for more details."
+        None,
+        description="Output settings. See :ref:`Outputs <outputs>` for more details.",
     )
 
     ##:: [INTERNAL USE ONLY] Private attributes that should not be modified manually.
@@ -323,7 +327,10 @@ class SimulationParams(_ParamModelBase):
 
     @pd.validate_call
     def convert_unit(
-        self, value: DimensionedTypes, target_system: str, length_unit: Optional[LengthType] = None
+        self,
+        value: DimensionedTypes,
+        target_system: str,
+        length_unit: Optional[LengthType] = None,
     ):
         """
         Converts a given value to the specified unit system.
@@ -549,7 +556,7 @@ class SimulationParams(_ParamModelBase):
                         "symmetric*",
                         volume.private_attribute_entity.name,
                     )
-                if isinstance(volume, RotationCylinder):
+                if isinstance(volume, RotationVolume):
                     # pylint: disable=fixme
                     # TODO: Implement this
                     pass

--- a/flow360/component/simulation/translator/volume_meshing_translator.py
+++ b/flow360/component/simulation/translator/volume_meshing_translator.py
@@ -8,6 +8,7 @@ from flow360.component.simulation.meshing_param.volume_params import (
     AutomatedFarfield,
     AxisymmetricRefinement,
     AxisymmetricRefinementBase,
+    RotationCylinder,
     RotationVolume,
     UniformRefinement,
     UserDefinedFarfield,
@@ -316,8 +317,17 @@ def get_volume_meshing_json(input_params: SimulationParams, mesh_units):
         entity_injection_func=rotation_cylinder_entity_injector,
         translation_func_rotor_disk_names=rotor_disk_names,
     )
-    if sliding_interfaces:
-        translated["slidingInterfaces"] = sliding_interfaces
+    sliding_interfaces_cylinders = translate_setting_and_apply_to_all_entities(
+        meshing_params.volume_zones,
+        RotationCylinder,
+        rotation_cylinder_translator,
+        to_list=True,
+        entity_injection_func=rotation_cylinder_entity_injector,
+        translation_func_rotor_disk_names=rotor_disk_names,
+    )
+
+    if sliding_interfaces or sliding_interfaces_cylinders:
+        translated["slidingInterfaces"] = sliding_interfaces + sliding_interfaces_cylinders
 
     ##::  Step 6: Get custom volumes
     custom_volumes = _get_custom_volumes(meshing_params.volume_zones)

--- a/flow360/component/simulation/translator/volume_meshing_translator.py
+++ b/flow360/component/simulation/translator/volume_meshing_translator.py
@@ -126,9 +126,7 @@ def rotor_disks_entity_injector(entity: Cylinder):
 
     return {
         "name": entity.name,
-        "innerRadius": 0
-        if entity.inner_radius is None
-        else entity.inner_radius.value.item(),
+        "innerRadius": 0 if entity.inner_radius is None else entity.inner_radius.value.item(),
         "outerRadius": entity.outer_radius.value.item(),
         "thickness": entity.height.value.item(),
         "axisThrust": list(entity.axis),
@@ -141,9 +139,7 @@ def rotation_cylinder_entity_injector(entity: Cylinder | AxisymmetricBody):
     if isinstance(entity, Cylinder):
         return {
             "name": entity.name,
-            "innerRadius": 0
-            if entity.inner_radius is None
-            else entity.inner_radius.value.item(),
+            "innerRadius": 0 if entity.inner_radius is None else entity.inner_radius.value.item(),
             "outerRadius": entity.outer_radius.value.item(),
             "thickness": entity.height.value.item(),
             "axisOfRotation": list(entity.axis),
@@ -152,9 +148,7 @@ def rotation_cylinder_entity_injector(entity: Cylinder | AxisymmetricBody):
     if isinstance(entity, AxisymmetricBody):
         return {
             "name": entity.name,
-            "profileCurve": [
-                list(profile_point.value) for profile_point in entity.profile_curve
-            ],
+            "profileCurve": [list(profile_point.value) for profile_point in entity.profile_curve],
             "axisOfRotation": list(entity.axis),
             "center": list(entity.center.value),
         }
@@ -253,18 +247,12 @@ def get_volume_meshing_json(input_params: SimulationParams, mesh_units):
             "first_layer_thickness",
         )
     else:
-        default_first_layer_thickness = (
-            meshing_params.defaults.boundary_layer_first_layer_thickness
-        )
+        default_first_layer_thickness = meshing_params.defaults.boundary_layer_first_layer_thickness
 
-    translated["volume"]["firstLayerThickness"] = (
-        default_first_layer_thickness.value.item()
-    )
+    translated["volume"]["firstLayerThickness"] = default_first_layer_thickness.value.item()
 
     # growthRate can only be global
-    translated["volume"]["growthRate"] = (
-        meshing_params.defaults.boundary_layer_growth_rate
-    )
+    translated["volume"]["growthRate"] = meshing_params.defaults.boundary_layer_growth_rate
 
     translated["volume"]["gapTreatmentStrength"] = meshing_params.gap_treatment_strength
 
@@ -274,9 +262,7 @@ def get_volume_meshing_json(input_params: SimulationParams, mesh_units):
             number_of_boundary_layers if number_of_boundary_layers is not None else -1
         )
 
-        translated["volume"]["planarFaceTolerance"] = (
-            meshing_params.defaults.planar_face_tolerance
-        )
+        translated["volume"]["planarFaceTolerance"] = meshing_params.defaults.planar_face_tolerance
 
     ##::  Step 4: Get volume refinements (uniform + rotorDisks)
     uniform_refinement_list = translate_setting_and_apply_to_all_entities(

--- a/flow360/component/simulation/translator/volume_meshing_translator.py
+++ b/flow360/component/simulation/translator/volume_meshing_translator.py
@@ -12,7 +12,13 @@ from flow360.component.simulation.meshing_param.volume_params import (
     UniformRefinement,
     UserDefinedFarfield,
 )
-from flow360.component.simulation.primitives import Box, CustomVolume, Cylinder, Surface
+from flow360.component.simulation.primitives import (
+    AxisymmetricBody,
+    Box,
+    CustomVolume,
+    Cylinder,
+    Surface,
+)
 from flow360.component.simulation.simulation_params import SimulationParams
 from flow360.component.simulation.translator.utils import (
     get_global_setting_from_first_instance,
@@ -120,7 +126,9 @@ def rotor_disks_entity_injector(entity: Cylinder):
 
     return {
         "name": entity.name,
-        "innerRadius": 0 if entity.inner_radius is None else entity.inner_radius.value.item(),
+        "innerRadius": 0
+        if entity.inner_radius is None
+        else entity.inner_radius.value.item(),
         "outerRadius": entity.outer_radius.value.item(),
         "thickness": entity.height.value.item(),
         "axisThrust": list(entity.axis),
@@ -128,16 +136,29 @@ def rotor_disks_entity_injector(entity: Cylinder):
     }
 
 
-def rotation_cylinder_entity_injector(entity: Cylinder):
+def rotation_cylinder_entity_injector(entity: Cylinder | AxisymmetricBody):
     """Injector for Cylinder entity in RotationCylinder."""
-    return {
-        "name": entity.name,
-        "innerRadius": 0 if entity.inner_radius is None else entity.inner_radius.value.item(),
-        "outerRadius": entity.outer_radius.value.item(),
-        "thickness": entity.height.value.item(),
-        "axisOfRotation": list(entity.axis),
-        "center": list(entity.center.value),
-    }
+    if isinstance(entity, Cylinder):
+        return {
+            "name": entity.name,
+            "innerRadius": 0
+            if entity.inner_radius is None
+            else entity.inner_radius.value.item(),
+            "outerRadius": entity.outer_radius.value.item(),
+            "thickness": entity.height.value.item(),
+            "axisOfRotation": list(entity.axis),
+            "center": list(entity.center.value),
+        }
+    if isinstance(entity, AxisymmetricBody):
+        return {
+            "name": entity.name,
+            "profileCurve": [
+                list(profile_point.value) for profile_point in entity.profile_curve
+            ],
+            "axisOfRotation": list(entity.axis),
+            "center": list(entity.center.value),
+        }
+    return {}
 
 
 def _get_custom_volumes(volume_zones: list):
@@ -232,12 +253,18 @@ def get_volume_meshing_json(input_params: SimulationParams, mesh_units):
             "first_layer_thickness",
         )
     else:
-        default_first_layer_thickness = meshing_params.defaults.boundary_layer_first_layer_thickness
+        default_first_layer_thickness = (
+            meshing_params.defaults.boundary_layer_first_layer_thickness
+        )
 
-    translated["volume"]["firstLayerThickness"] = default_first_layer_thickness.value.item()
+    translated["volume"]["firstLayerThickness"] = (
+        default_first_layer_thickness.value.item()
+    )
 
     # growthRate can only be global
-    translated["volume"]["growthRate"] = meshing_params.defaults.boundary_layer_growth_rate
+    translated["volume"]["growthRate"] = (
+        meshing_params.defaults.boundary_layer_growth_rate
+    )
 
     translated["volume"]["gapTreatmentStrength"] = meshing_params.gap_treatment_strength
 
@@ -247,7 +274,9 @@ def get_volume_meshing_json(input_params: SimulationParams, mesh_units):
             number_of_boundary_layers if number_of_boundary_layers is not None else -1
         )
 
-        translated["volume"]["planarFaceTolerance"] = meshing_params.defaults.planar_face_tolerance
+        translated["volume"]["planarFaceTolerance"] = (
+            meshing_params.defaults.planar_face_tolerance
+        )
 
     ##::  Step 4: Get volume refinements (uniform + rotorDisks)
     uniform_refinement_list = translate_setting_and_apply_to_all_entities(

--- a/flow360/component/simulation/translator/volume_meshing_translator.py
+++ b/flow360/component/simulation/translator/volume_meshing_translator.py
@@ -7,7 +7,7 @@ from flow360.component.simulation.meshing_param.face_params import (
 from flow360.component.simulation.meshing_param.volume_params import (
     AutomatedFarfield,
     AxisymmetricRefinement,
-    CylindricalRefinementBase,
+    AxisymmetricRefinementBase,
     RotationVolume,
     UniformRefinement,
     UserDefinedFarfield,
@@ -37,7 +37,7 @@ def uniform_refinement_translator(obj: UniformRefinement):
     return {"spacing": obj.spacing.value.item()}
 
 
-def cylindrical_refinement_translator(obj: CylindricalRefinementBase):
+def cylindrical_refinement_translator(obj: AxisymmetricRefinementBase):
     """
     Translate CylindricalRefinementBase. [SlidingInterface + RotorDisks]
     """

--- a/flow360/component/simulation/translator/volume_meshing_translator.py
+++ b/flow360/component/simulation/translator/volume_meshing_translator.py
@@ -8,7 +8,7 @@ from flow360.component.simulation.meshing_param.volume_params import (
     AutomatedFarfield,
     AxisymmetricRefinement,
     CylindricalRefinementBase,
-    RotationCylinder,
+    RotationVolume,
     UniformRefinement,
     UserDefinedFarfield,
 )
@@ -80,7 +80,7 @@ def passive_spacing_translator(obj: PassiveSpacing):
     }
 
 
-def rotation_cylinder_translator(obj: RotationCylinder, rotor_disk_names: list):
+def rotation_cylinder_translator(obj: RotationVolume, rotor_disk_names: list):
     """Setting translation for RotationCylinder."""
     setting = cylindrical_refinement_translator(obj)
     setting["enclosedObjects"] = []
@@ -310,7 +310,7 @@ def get_volume_meshing_json(input_params: SimulationParams, mesh_units):
     ##::  Step 5: Get sliding interfaces ()
     sliding_interfaces = translate_setting_and_apply_to_all_entities(
         meshing_params.volume_zones,
-        RotationCylinder,
+        RotationVolume,
         rotation_cylinder_translator,
         to_list=True,
         entity_injection_func=rotation_cylinder_entity_injector,

--- a/tests/simulation/params/meshing_validation/test_meshing_param_validation.py
+++ b/tests/simulation/params/meshing_validation/test_meshing_param_validation.py
@@ -5,7 +5,7 @@ from flow360.component.simulation.meshing_param.params import MeshingParams
 from flow360.component.simulation.meshing_param.volume_params import (
     AutomatedFarfield,
     AxisymmetricRefinement,
-    RotationCylinder,
+    RotationVolume,
     UniformRefinement,
 )
 from flow360.component.simulation.primitives import AxisymmetricBody, Cylinder, Surface

--- a/tests/simulation/params/meshing_validation/test_meshing_param_validation.py
+++ b/tests/simulation/params/meshing_validation/test_meshing_param_validation.py
@@ -5,6 +5,7 @@ from flow360.component.simulation.meshing_param.params import MeshingParams
 from flow360.component.simulation.meshing_param.volume_params import (
     AutomatedFarfield,
     AxisymmetricRefinement,
+    RotationCylinder,
     RotationVolume,
     UniformRefinement,
 )
@@ -14,9 +15,13 @@ from flow360.component.simulation.unit_system import CGS_unit_system
 
 
 def test_disable_invalid_axisymmetric_body_construction():
+    import re
+
     with pytest.raises(
         pd.ValidationError,
-        match=r"Expect profile samples to be (Axial, Radial) samples with positive Radial. Found invalid point: [-1.  1.  3.] cm.",
+        match=re.escape(
+            "Expect profile samples to be (Axial, Radial) samples with positive Radial. Found invalid point: [-1.  1.  3.] cm."
+        ),
     ):
         with CGS_unit_system:
             cylinder_1 = AxisymmetricBody(
@@ -28,7 +33,9 @@ def test_disable_invalid_axisymmetric_body_construction():
 
     with pytest.raises(
         pd.ValidationError,
-        match="Expect first profile sample to be (Axial, 0.0). Found invalid point: [-1.  1.] cm.",
+        match=re.escape(
+            "Expect first profile sample to be (Axial, 0.0). Found invalid point: [-1.  1.] cm."
+        ),
     ):
         with CGS_unit_system:
             cylinder_1 = AxisymmetricBody(
@@ -40,7 +47,9 @@ def test_disable_invalid_axisymmetric_body_construction():
 
     with pytest.raises(
         pd.ValidationError,
-        match="Expect profile samples to be (Axial, Radial) samples with positive Radial. Found invalid point: [-1.  1.  3.] cm.",
+        match=re.escape(
+            "Expect last profile sample to be (Axial, 0.0). Found invalid point: [1. 1.] cm."
+        ),
     ):
         with CGS_unit_system:
             cylinder_1 = AxisymmetricBody(
@@ -51,338 +60,188 @@ def test_disable_invalid_axisymmetric_body_construction():
             )
 
 
-#
-# def test_disable_multiple_cylinder_in_one_ratataion_cylinder():
-#     with pytest.raises(
-#         pd.ValidationError,
-#         match="Only single instance is allowed in entities for each RotationCylinder.",
-#     ):
-#         with CGS_unit_system:
-#             cylinder_1 = Cylinder(
-#                 name="1",
-#                 outer_radius=12,
-#                 height=2,
-#                 axis=(0, 1, 0),
-#                 center=(0, 5, 0),
-#             )
-#             cylinder_2 = Cylinder(
-#                 name="2",
-#                 outer_radius=2,
-#                 height=2,
-#                 axis=(0, 1, 0),
-#                 center=(0, 5, 0),
-#             )
-#             SimulationParams(
-#                 meshing=MeshingParams(
-#                     volume_zones=[
-#                         RotationCylinder(
-#                             entities=[cylinder_1, cylinder_2],
-#                             spacing_axial=20,
-#                             spacing_radial=0.2,
-#                             spacing_circumferential=20,
-#                             enclosed_entities=[
-#                                 Surface(name="hub"),
-#                             ],
-#                         ),
-#                         AutomatedFarfield(),
-#                     ],
-#                 )
-#             )
-#
-#
-# def test_limit_cylinder_entity_name_length_in_rotation_cylinder():
-#     with pytest.raises(
-#         pd.ValidationError,
-#         match=r"The name \(very_long_cylinder_name\) of `Cylinder` entity in `RotationCylinder`"
-#         + " exceeds 18 characters limit.",
-#     ):
-#         with CGS_unit_system:
-#             cylinder = Cylinder(
-#                 name="very_long_cylinder_name",
-#                 outer_radius=12,
-#                 height=2,
-#                 axis=(0, 1, 0),
-#                 center=(0, 5, 0),
-#             )
-#             SimulationParams(
-#                 meshing=MeshingParams(
-#                     volume_zones=[
-#                         RotationCylinder(
-#                             entities=[cylinder],
-#                             spacing_axial=20,
-#                             spacing_radial=0.2,
-#                             spacing_circumferential=20,
-#                             enclosed_entities=[
-#                                 Surface(name="hub"),
-#                             ],
-#                         ),
-#                         AutomatedFarfield(),
-#                     ],
-#                 )
-#             )
-#
-#
-# def test_reuse_of_same_cylinder():
-#     with pytest.raises(
-#         pd.ValidationError,
-#         match=r"Using Volume entity `I am reused` in `AxisymmetricRefinement`, `RotationCylinder` at the same time is not allowed.",
-#     ):
-#         with CGS_unit_system:
-#             cylinder = Cylinder(
-#                 name="I am reused",
-#                 outer_radius=1,
-#                 height=12,
-#                 axis=(0, 1, 0),
-#                 center=(0, 5, 0),
-#             )
-#             SimulationParams(
-#                 meshing=MeshingParams(
-#                     volume_zones=[
-#                         RotationCylinder(
-#                             entities=[cylinder],
-#                             spacing_axial=20,
-#                             spacing_radial=0.2,
-#                             spacing_circumferential=20,
-#                             enclosed_entities=[
-#                                 Surface(name="hub"),
-#                             ],
-#                         ),
-#                         AutomatedFarfield(),
-#                     ],
-#                     refinements=[
-#                         AxisymmetricRefinement(
-#                             entities=[cylinder],
-#                             spacing_axial=0.1,
-#                             spacing_radial=0.2,
-#                             spacing_circumferential=0.3,
-#                         )
-#                     ],
-#                 )
-#             )
-#
-#     with CGS_unit_system:
-#         cylinder = Cylinder(
-#             name="Okay to reuse",
-#             outer_radius=1,
-#             height=12,
-#             axis=(0, 1, 0),
-#             center=(0, 5, 0),
-#         )
-#         SimulationParams(
-#             meshing=MeshingParams(
-#                 volume_zones=[
-#                     RotationCylinder(
-#                         entities=[cylinder],
-#                         spacing_axial=20,
-#                         spacing_radial=0.2,
-#                         spacing_circumferential=20,
-#                         enclosed_entities=[
-#                             Surface(name="hub"),
-#                         ],
-#                     ),
-#                     AutomatedFarfield(),
-#                 ],
-#                 refinements=[
-#                     UniformRefinement(
-#                         entities=[cylinder],
-#                         spacing=0.1,
-#                     )
-#                 ],
-#             )
-#         )
-#
-#     with pytest.raises(
-#         pd.ValidationError,
-#         match=r"Using Volume entity `I am reused` in `AxisymmetricRefinement`, `UniformRefinement` at the same time is not allowed.",
-#     ):
-#         with CGS_unit_system:
-#             cylinder = Cylinder(
-#                 name="I am reused",
-#                 outer_radius=1,
-#                 height=12,
-#                 axis=(0, 1, 0),
-#                 center=(0, 5, 0),
-#             )
-#             SimulationParams(
-#                 meshing=MeshingParams(
-#                     refinements=[
-#                         UniformRefinement(entities=[cylinder], spacing=0.1),
-#                         AxisymmetricRefinement(
-#                             entities=[cylinder],
-#                             spacing_axial=0.1,
-#                             spacing_radial=0.1,
-#                             spacing_circumferential=0.1,
-#                         ),
-#                     ],
-#                 )
-#             )
-#
-#     with pytest.raises(
-#         pd.ValidationError,
-#         match=r" Volume entity `I am reused` is used multiple times in `UniformRefinement`.",
-#     ):
-#         with CGS_unit_system:
-#             cylinder = Cylinder(
-#                 name="I am reused",
-#                 outer_radius=1,
-#                 height=12,
-#                 axis=(0, 1, 0),
-#                 center=(0, 5, 0),
-#             )
-#             SimulationParams(
-#                 meshing=MeshingParams(
-#                     refinements=[
-#                         UniformRefinement(entities=[cylinder], spacing=0.1),
-#                         UniformRefinement(entities=[cylinder], spacing=0.2),
-#                     ],
-#                 )
-#             )
-#
-#
-# def test_limit_cylinder_entity_name_length_in_rotation_cylinder():
-#     with pytest.raises(
-#         pd.ValidationError,
-#         match=r"The name \(very_long_cylinder_name\) of `Cylinder` entity in `RotationCylinder`"
-#         + " exceeds 18 characters limit.",
-#     ):
-#         with CGS_unit_system:
-#             cylinder = Cylinder(
-#                 name="very_long_cylinder_name",
-#                 outer_radius=12,
-#                 height=2,
-#                 axis=(0, 1, 0),
-#                 center=(0, 5, 0),
-#             )
-#             SimulationParams(
-#                 meshing=MeshingParams(
-#                     volume_zones=[
-#                         RotationCylinder(
-#                             entities=[cylinder],
-#                             spacing_axial=20,
-#                             spacing_radial=0.2,
-#                             spacing_circumferential=20,
-#                             enclosed_entities=[
-#                                 Surface(name="hub"),
-#                             ],
-#                         ),
-#                         AutomatedFarfield(),
-#                     ],
-#                 )
-#             )
-#
-#
-# def test_reuse_of_same_cylinder():
-#     with pytest.raises(
-#         pd.ValidationError,
-#         match=r"Using Volume entity `I am reused` in `AxisymmetricRefinement`, `RotationCylinder` at the same time is not allowed.",
-#     ):
-#         with CGS_unit_system:
-#             cylinder = Cylinder(
-#                 name="I am reused",
-#                 outer_radius=1,
-#                 height=12,
-#                 axis=(0, 1, 0),
-#                 center=(0, 5, 0),
-#             )
-#             SimulationParams(
-#                 meshing=MeshingParams(
-#                     volume_zones=[
-#                         RotationCylinder(
-#                             entities=[cylinder],
-#                             spacing_axial=20,
-#                             spacing_radial=0.2,
-#                             spacing_circumferential=20,
-#                             enclosed_entities=[
-#                                 Surface(name="hub"),
-#                             ],
-#                         ),
-#                         AutomatedFarfield(),
-#                     ],
-#                     refinements=[
-#                         AxisymmetricRefinement(
-#                             entities=[cylinder],
-#                             spacing_axial=0.1,
-#                             spacing_radial=0.2,
-#                             spacing_circumferential=0.3,
-#                         )
-#                     ],
-#                 )
-#             )
-#
-#     with CGS_unit_system:
-#         cylinder = Cylinder(
-#             name="Okay to reuse",
-#             outer_radius=1,
-#             height=12,
-#             axis=(0, 1, 0),
-#             center=(0, 5, 0),
-#         )
-#         SimulationParams(
-#             meshing=MeshingParams(
-#                 volume_zones=[
-#                     RotationCylinder(
-#                         entities=[cylinder],
-#                         spacing_axial=20,
-#                         spacing_radial=0.2,
-#                         spacing_circumferential=20,
-#                         enclosed_entities=[
-#                             Surface(name="hub"),
-#                         ],
-#                     ),
-#                     AutomatedFarfield(),
-#                 ],
-#                 refinements=[
-#                     UniformRefinement(
-#                         entities=[cylinder],
-#                         spacing=0.1,
-#                     )
-#                 ],
-#             )
-#         )
-#
-#     with pytest.raises(
-#         pd.ValidationError,
-#         match=r"Using Volume entity `I am reused` in `AxisymmetricRefinement`, `UniformRefinement` at the same time is not allowed.",
-#     ):
-#         with CGS_unit_system:
-#             cylinder = Cylinder(
-#                 name="I am reused",
-#                 outer_radius=1,
-#                 height=12,
-#                 axis=(0, 1, 0),
-#                 center=(0, 5, 0),
-#             )
-#             SimulationParams(
-#                 meshing=MeshingParams(
-#                     refinements=[
-#                         UniformRefinement(entities=[cylinder], spacing=0.1),
-#                         AxisymmetricRefinement(
-#                             entities=[cylinder],
-#                             spacing_axial=0.1,
-#                             spacing_radial=0.1,
-#                             spacing_circumferential=0.1,
-#                         ),
-#                     ],
-#                 )
-#             )
-#
-#     with pytest.raises(
-#         pd.ValidationError,
-#         match=r" Volume entity `I am reused` is used multiple times in `UniformRefinement`.",
-#     ):
-#         with CGS_unit_system:
-#             cylinder = Cylinder(
-#                 name="I am reused",
-#                 outer_radius=1,
-#                 height=12,
-#                 axis=(0, 1, 0),
-#                 center=(0, 5, 0),
-#             )
-#             SimulationParams(
-#                 meshing=MeshingParams(
-#                     refinements=[
-#                         UniformRefinement(entities=[cylinder], spacing=0.1),
-#                         UniformRefinement(entities=[cylinder], spacing=0.2),
-#                     ],
-#                 )
-#             )
+def test_disable_multiple_cylinder_in_one_ratataion_cylinder():
+    with pytest.raises(
+        pd.ValidationError,
+        match="Only single instance is allowed in entities for each `RotationVolume`.",
+    ):
+        with CGS_unit_system:
+            cylinder_1 = Cylinder(
+                name="1",
+                outer_radius=12,
+                height=2,
+                axis=(0, 1, 0),
+                center=(0, 5, 0),
+            )
+            cylinder_2 = Cylinder(
+                name="2",
+                outer_radius=2,
+                height=2,
+                axis=(0, 1, 0),
+                center=(0, 5, 0),
+            )
+            SimulationParams(
+                meshing=MeshingParams(
+                    volume_zones=[
+                        RotationCylinder(
+                            entities=[cylinder_1, cylinder_2],
+                            spacing_axial=20,
+                            spacing_radial=0.2,
+                            spacing_circumferential=20,
+                            enclosed_entities=[
+                                Surface(name="hub"),
+                            ],
+                        ),
+                        AutomatedFarfield(),
+                    ],
+                )
+            )
+
+
+def test_limit_cylinder_entity_name_length_in_rotation_cylinder():
+    with pytest.raises(
+        pd.ValidationError,
+        match=r"The name \(very_long_cylinder_name\) of `Cylinder` entity in `RotationVolume`"
+        + " exceeds 18 characters limit.",
+    ):
+        with CGS_unit_system:
+            cylinder = Cylinder(
+                name="very_long_cylinder_name",
+                outer_radius=12,
+                height=2,
+                axis=(0, 1, 0),
+                center=(0, 5, 0),
+            )
+            SimulationParams(
+                meshing=MeshingParams(
+                    volume_zones=[
+                        RotationCylinder(
+                            entities=[cylinder],
+                            spacing_axial=20,
+                            spacing_radial=0.2,
+                            spacing_circumferential=20,
+                            enclosed_entities=[
+                                Surface(name="hub"),
+                            ],
+                        ),
+                        AutomatedFarfield(),
+                    ],
+                )
+            )
+
+
+def test_reuse_of_same_cylinder():
+    with pytest.raises(
+        pd.ValidationError,
+        match=r"Using Volume entity `I am reused` in `AxisymmetricRefinement`, `RotationCylinder` at the same time is not allowed.",
+    ):
+        with CGS_unit_system:
+            cylinder = Cylinder(
+                name="I am reused",
+                outer_radius=1,
+                height=12,
+                axis=(0, 1, 0),
+                center=(0, 5, 0),
+            )
+            SimulationParams(
+                meshing=MeshingParams(
+                    volume_zones=[
+                        RotationCylinder(
+                            entities=[cylinder],
+                            spacing_axial=20,
+                            spacing_radial=0.2,
+                            spacing_circumferential=20,
+                            enclosed_entities=[
+                                Surface(name="hub"),
+                            ],
+                        ),
+                        AutomatedFarfield(),
+                    ],
+                    refinements=[
+                        AxisymmetricRefinement(
+                            entities=[cylinder],
+                            spacing_axial=0.1,
+                            spacing_radial=0.2,
+                            spacing_circumferential=0.3,
+                        )
+                    ],
+                )
+            )
+
+    with CGS_unit_system:
+        cylinder = Cylinder(
+            name="Okay to reuse",
+            outer_radius=1,
+            height=12,
+            axis=(0, 1, 0),
+            center=(0, 5, 0),
+        )
+        SimulationParams(
+            meshing=MeshingParams(
+                volume_zones=[
+                    RotationCylinder(
+                        entities=[cylinder],
+                        spacing_axial=20,
+                        spacing_radial=0.2,
+                        spacing_circumferential=20,
+                        enclosed_entities=[
+                            Surface(name="hub"),
+                        ],
+                    ),
+                    AutomatedFarfield(),
+                ],
+                refinements=[
+                    UniformRefinement(
+                        entities=[cylinder],
+                        spacing=0.1,
+                    )
+                ],
+            )
+        )
+
+    with pytest.raises(
+        pd.ValidationError,
+        match=r"Using Volume entity `I am reused` in `AxisymmetricRefinement`, `UniformRefinement` at the same time is not allowed.",
+    ):
+        with CGS_unit_system:
+            cylinder = Cylinder(
+                name="I am reused",
+                outer_radius=1,
+                height=12,
+                axis=(0, 1, 0),
+                center=(0, 5, 0),
+            )
+            SimulationParams(
+                meshing=MeshingParams(
+                    refinements=[
+                        UniformRefinement(entities=[cylinder], spacing=0.1),
+                        AxisymmetricRefinement(
+                            entities=[cylinder],
+                            spacing_axial=0.1,
+                            spacing_radial=0.1,
+                            spacing_circumferential=0.1,
+                        ),
+                    ],
+                )
+            )
+
+    with pytest.raises(
+        pd.ValidationError,
+        match=r" Volume entity `I am reused` is used multiple times in `UniformRefinement`.",
+    ):
+        with CGS_unit_system:
+            cylinder = Cylinder(
+                name="I am reused",
+                outer_radius=1,
+                height=12,
+                axis=(0, 1, 0),
+                center=(0, 5, 0),
+            )
+            SimulationParams(
+                meshing=MeshingParams(
+                    refinements=[
+                        UniformRefinement(entities=[cylinder], spacing=0.1),
+                        UniformRefinement(entities=[cylinder], spacing=0.2),
+                    ],
+                )
+            )

--- a/tests/simulation/params/meshing_validation/test_meshing_param_validation.py
+++ b/tests/simulation/params/meshing_validation/test_meshing_param_validation.py
@@ -8,193 +8,381 @@ from flow360.component.simulation.meshing_param.volume_params import (
     RotationCylinder,
     UniformRefinement,
 )
-from flow360.component.simulation.primitives import Cylinder, Surface
+from flow360.component.simulation.primitives import AxisymmetricBody, Cylinder, Surface
 from flow360.component.simulation.simulation_params import SimulationParams
 from flow360.component.simulation.unit_system import CGS_unit_system
 
 
-def test_disable_multiple_cylinder_in_one_ratataion_cylinder():
+def test_disable_invalid_axisymmetric_body_construction():
     with pytest.raises(
         pd.ValidationError,
-        match="Only single instance is allowed in entities for each RotationCylinder.",
+        match=r"Expect profile samples to be (Axial, Radial) samples with positive Radial. Found invalid point: [-1.  1.  3.] cm.",
     ):
         with CGS_unit_system:
-            cylinder_1 = Cylinder(
+            cylinder_1 = AxisymmetricBody(
                 name="1",
-                outer_radius=12,
-                height=2,
-                axis=(0, 1, 0),
+                axis=(0, 0, 1),
                 center=(0, 5, 0),
-            )
-            cylinder_2 = Cylinder(
-                name="2",
-                outer_radius=2,
-                height=2,
-                axis=(0, 1, 0),
-                center=(0, 5, 0),
-            )
-            SimulationParams(
-                meshing=MeshingParams(
-                    volume_zones=[
-                        RotationCylinder(
-                            entities=[cylinder_1, cylinder_2],
-                            spacing_axial=20,
-                            spacing_radial=0.2,
-                            spacing_circumferential=20,
-                            enclosed_entities=[
-                                Surface(name="hub"),
-                            ],
-                        ),
-                        AutomatedFarfield(),
-                    ],
-                )
-            )
-
-
-def test_limit_cylinder_entity_name_length_in_rotation_cylinder():
-    with pytest.raises(
-        pd.ValidationError,
-        match=r"The name \(very_long_cylinder_name\) of `Cylinder` entity in `RotationCylinder`"
-        + " exceeds 18 characters limit.",
-    ):
-        with CGS_unit_system:
-            cylinder = Cylinder(
-                name="very_long_cylinder_name",
-                outer_radius=12,
-                height=2,
-                axis=(0, 1, 0),
-                center=(0, 5, 0),
-            )
-            SimulationParams(
-                meshing=MeshingParams(
-                    volume_zones=[
-                        RotationCylinder(
-                            entities=[cylinder],
-                            spacing_axial=20,
-                            spacing_radial=0.2,
-                            spacing_circumferential=20,
-                            enclosed_entities=[
-                                Surface(name="hub"),
-                            ],
-                        ),
-                        AutomatedFarfield(),
-                    ],
-                )
-            )
-
-
-def test_reuse_of_same_cylinder():
-    with pytest.raises(
-        pd.ValidationError,
-        match=r"Using Volume entity `I am reused` in `AxisymmetricRefinement`, `RotationCylinder` at the same time is not allowed.",
-    ):
-        with CGS_unit_system:
-            cylinder = Cylinder(
-                name="I am reused",
-                outer_radius=1,
-                height=12,
-                axis=(0, 1, 0),
-                center=(0, 5, 0),
-            )
-            SimulationParams(
-                meshing=MeshingParams(
-                    volume_zones=[
-                        RotationCylinder(
-                            entities=[cylinder],
-                            spacing_axial=20,
-                            spacing_radial=0.2,
-                            spacing_circumferential=20,
-                            enclosed_entities=[
-                                Surface(name="hub"),
-                            ],
-                        ),
-                        AutomatedFarfield(),
-                    ],
-                    refinements=[
-                        AxisymmetricRefinement(
-                            entities=[cylinder],
-                            spacing_axial=0.1,
-                            spacing_radial=0.2,
-                            spacing_circumferential=0.3,
-                        )
-                    ],
-                )
-            )
-
-    with CGS_unit_system:
-        cylinder = Cylinder(
-            name="Okay to reuse",
-            outer_radius=1,
-            height=12,
-            axis=(0, 1, 0),
-            center=(0, 5, 0),
-        )
-        SimulationParams(
-            meshing=MeshingParams(
-                volume_zones=[
-                    RotationCylinder(
-                        entities=[cylinder],
-                        spacing_axial=20,
-                        spacing_radial=0.2,
-                        spacing_circumferential=20,
-                        enclosed_entities=[
-                            Surface(name="hub"),
-                        ],
-                    ),
-                    AutomatedFarfield(),
-                ],
-                refinements=[
-                    UniformRefinement(
-                        entities=[cylinder],
-                        spacing=0.1,
-                    )
-                ],
-            )
-        )
-
-    with pytest.raises(
-        pd.ValidationError,
-        match=r"Using Volume entity `I am reused` in `AxisymmetricRefinement`, `UniformRefinement` at the same time is not allowed.",
-    ):
-        with CGS_unit_system:
-            cylinder = Cylinder(
-                name="I am reused",
-                outer_radius=1,
-                height=12,
-                axis=(0, 1, 0),
-                center=(0, 5, 0),
-            )
-            SimulationParams(
-                meshing=MeshingParams(
-                    refinements=[
-                        UniformRefinement(entities=[cylinder], spacing=0.1),
-                        AxisymmetricRefinement(
-                            entities=[cylinder],
-                            spacing_axial=0.1,
-                            spacing_radial=0.1,
-                            spacing_circumferential=0.1,
-                        ),
-                    ],
-                )
+                profile_curve=[(-1, 0), (-1, 1, 3), (1, 1), (1, 0)],
             )
 
     with pytest.raises(
         pd.ValidationError,
-        match=r" Volume entity `I am reused` is used multiple times in `UniformRefinement`.",
+        match="Expect first profile sample to be (Axial, 0.0). Found invalid point: [-1.  1.] cm.",
     ):
         with CGS_unit_system:
-            cylinder = Cylinder(
-                name="I am reused",
-                outer_radius=1,
-                height=12,
-                axis=(0, 1, 0),
+            cylinder_1 = AxisymmetricBody(
+                name="1",
+                axis=(0, 0, 1),
                 center=(0, 5, 0),
+                profile_curve=[(-1, 1), (1, 2)],
             )
-            SimulationParams(
-                meshing=MeshingParams(
-                    refinements=[
-                        UniformRefinement(entities=[cylinder], spacing=0.1),
-                        UniformRefinement(entities=[cylinder], spacing=0.2),
-                    ],
-                )
+
+    with pytest.raises(
+        pd.ValidationError,
+        match="Expect profile samples to be (Axial, Radial) samples with positive Radial. Found invalid point: [-1.  1.  3.] cm.",
+    ):
+        with CGS_unit_system:
+            cylinder_1 = AxisymmetricBody(
+                name="1",
+                axis=(0, 0, 1),
+                center=(0, 5, 0),
+                profile_curve=[(-1, 0), (-1, 1), (1, 1)],
             )
+
+
+#
+# def test_disable_multiple_cylinder_in_one_ratataion_cylinder():
+#     with pytest.raises(
+#         pd.ValidationError,
+#         match="Only single instance is allowed in entities for each RotationCylinder.",
+#     ):
+#         with CGS_unit_system:
+#             cylinder_1 = Cylinder(
+#                 name="1",
+#                 outer_radius=12,
+#                 height=2,
+#                 axis=(0, 1, 0),
+#                 center=(0, 5, 0),
+#             )
+#             cylinder_2 = Cylinder(
+#                 name="2",
+#                 outer_radius=2,
+#                 height=2,
+#                 axis=(0, 1, 0),
+#                 center=(0, 5, 0),
+#             )
+#             SimulationParams(
+#                 meshing=MeshingParams(
+#                     volume_zones=[
+#                         RotationCylinder(
+#                             entities=[cylinder_1, cylinder_2],
+#                             spacing_axial=20,
+#                             spacing_radial=0.2,
+#                             spacing_circumferential=20,
+#                             enclosed_entities=[
+#                                 Surface(name="hub"),
+#                             ],
+#                         ),
+#                         AutomatedFarfield(),
+#                     ],
+#                 )
+#             )
+#
+#
+# def test_limit_cylinder_entity_name_length_in_rotation_cylinder():
+#     with pytest.raises(
+#         pd.ValidationError,
+#         match=r"The name \(very_long_cylinder_name\) of `Cylinder` entity in `RotationCylinder`"
+#         + " exceeds 18 characters limit.",
+#     ):
+#         with CGS_unit_system:
+#             cylinder = Cylinder(
+#                 name="very_long_cylinder_name",
+#                 outer_radius=12,
+#                 height=2,
+#                 axis=(0, 1, 0),
+#                 center=(0, 5, 0),
+#             )
+#             SimulationParams(
+#                 meshing=MeshingParams(
+#                     volume_zones=[
+#                         RotationCylinder(
+#                             entities=[cylinder],
+#                             spacing_axial=20,
+#                             spacing_radial=0.2,
+#                             spacing_circumferential=20,
+#                             enclosed_entities=[
+#                                 Surface(name="hub"),
+#                             ],
+#                         ),
+#                         AutomatedFarfield(),
+#                     ],
+#                 )
+#             )
+#
+#
+# def test_reuse_of_same_cylinder():
+#     with pytest.raises(
+#         pd.ValidationError,
+#         match=r"Using Volume entity `I am reused` in `AxisymmetricRefinement`, `RotationCylinder` at the same time is not allowed.",
+#     ):
+#         with CGS_unit_system:
+#             cylinder = Cylinder(
+#                 name="I am reused",
+#                 outer_radius=1,
+#                 height=12,
+#                 axis=(0, 1, 0),
+#                 center=(0, 5, 0),
+#             )
+#             SimulationParams(
+#                 meshing=MeshingParams(
+#                     volume_zones=[
+#                         RotationCylinder(
+#                             entities=[cylinder],
+#                             spacing_axial=20,
+#                             spacing_radial=0.2,
+#                             spacing_circumferential=20,
+#                             enclosed_entities=[
+#                                 Surface(name="hub"),
+#                             ],
+#                         ),
+#                         AutomatedFarfield(),
+#                     ],
+#                     refinements=[
+#                         AxisymmetricRefinement(
+#                             entities=[cylinder],
+#                             spacing_axial=0.1,
+#                             spacing_radial=0.2,
+#                             spacing_circumferential=0.3,
+#                         )
+#                     ],
+#                 )
+#             )
+#
+#     with CGS_unit_system:
+#         cylinder = Cylinder(
+#             name="Okay to reuse",
+#             outer_radius=1,
+#             height=12,
+#             axis=(0, 1, 0),
+#             center=(0, 5, 0),
+#         )
+#         SimulationParams(
+#             meshing=MeshingParams(
+#                 volume_zones=[
+#                     RotationCylinder(
+#                         entities=[cylinder],
+#                         spacing_axial=20,
+#                         spacing_radial=0.2,
+#                         spacing_circumferential=20,
+#                         enclosed_entities=[
+#                             Surface(name="hub"),
+#                         ],
+#                     ),
+#                     AutomatedFarfield(),
+#                 ],
+#                 refinements=[
+#                     UniformRefinement(
+#                         entities=[cylinder],
+#                         spacing=0.1,
+#                     )
+#                 ],
+#             )
+#         )
+#
+#     with pytest.raises(
+#         pd.ValidationError,
+#         match=r"Using Volume entity `I am reused` in `AxisymmetricRefinement`, `UniformRefinement` at the same time is not allowed.",
+#     ):
+#         with CGS_unit_system:
+#             cylinder = Cylinder(
+#                 name="I am reused",
+#                 outer_radius=1,
+#                 height=12,
+#                 axis=(0, 1, 0),
+#                 center=(0, 5, 0),
+#             )
+#             SimulationParams(
+#                 meshing=MeshingParams(
+#                     refinements=[
+#                         UniformRefinement(entities=[cylinder], spacing=0.1),
+#                         AxisymmetricRefinement(
+#                             entities=[cylinder],
+#                             spacing_axial=0.1,
+#                             spacing_radial=0.1,
+#                             spacing_circumferential=0.1,
+#                         ),
+#                     ],
+#                 )
+#             )
+#
+#     with pytest.raises(
+#         pd.ValidationError,
+#         match=r" Volume entity `I am reused` is used multiple times in `UniformRefinement`.",
+#     ):
+#         with CGS_unit_system:
+#             cylinder = Cylinder(
+#                 name="I am reused",
+#                 outer_radius=1,
+#                 height=12,
+#                 axis=(0, 1, 0),
+#                 center=(0, 5, 0),
+#             )
+#             SimulationParams(
+#                 meshing=MeshingParams(
+#                     refinements=[
+#                         UniformRefinement(entities=[cylinder], spacing=0.1),
+#                         UniformRefinement(entities=[cylinder], spacing=0.2),
+#                     ],
+#                 )
+#             )
+#
+#
+# def test_limit_cylinder_entity_name_length_in_rotation_cylinder():
+#     with pytest.raises(
+#         pd.ValidationError,
+#         match=r"The name \(very_long_cylinder_name\) of `Cylinder` entity in `RotationCylinder`"
+#         + " exceeds 18 characters limit.",
+#     ):
+#         with CGS_unit_system:
+#             cylinder = Cylinder(
+#                 name="very_long_cylinder_name",
+#                 outer_radius=12,
+#                 height=2,
+#                 axis=(0, 1, 0),
+#                 center=(0, 5, 0),
+#             )
+#             SimulationParams(
+#                 meshing=MeshingParams(
+#                     volume_zones=[
+#                         RotationCylinder(
+#                             entities=[cylinder],
+#                             spacing_axial=20,
+#                             spacing_radial=0.2,
+#                             spacing_circumferential=20,
+#                             enclosed_entities=[
+#                                 Surface(name="hub"),
+#                             ],
+#                         ),
+#                         AutomatedFarfield(),
+#                     ],
+#                 )
+#             )
+#
+#
+# def test_reuse_of_same_cylinder():
+#     with pytest.raises(
+#         pd.ValidationError,
+#         match=r"Using Volume entity `I am reused` in `AxisymmetricRefinement`, `RotationCylinder` at the same time is not allowed.",
+#     ):
+#         with CGS_unit_system:
+#             cylinder = Cylinder(
+#                 name="I am reused",
+#                 outer_radius=1,
+#                 height=12,
+#                 axis=(0, 1, 0),
+#                 center=(0, 5, 0),
+#             )
+#             SimulationParams(
+#                 meshing=MeshingParams(
+#                     volume_zones=[
+#                         RotationCylinder(
+#                             entities=[cylinder],
+#                             spacing_axial=20,
+#                             spacing_radial=0.2,
+#                             spacing_circumferential=20,
+#                             enclosed_entities=[
+#                                 Surface(name="hub"),
+#                             ],
+#                         ),
+#                         AutomatedFarfield(),
+#                     ],
+#                     refinements=[
+#                         AxisymmetricRefinement(
+#                             entities=[cylinder],
+#                             spacing_axial=0.1,
+#                             spacing_radial=0.2,
+#                             spacing_circumferential=0.3,
+#                         )
+#                     ],
+#                 )
+#             )
+#
+#     with CGS_unit_system:
+#         cylinder = Cylinder(
+#             name="Okay to reuse",
+#             outer_radius=1,
+#             height=12,
+#             axis=(0, 1, 0),
+#             center=(0, 5, 0),
+#         )
+#         SimulationParams(
+#             meshing=MeshingParams(
+#                 volume_zones=[
+#                     RotationCylinder(
+#                         entities=[cylinder],
+#                         spacing_axial=20,
+#                         spacing_radial=0.2,
+#                         spacing_circumferential=20,
+#                         enclosed_entities=[
+#                             Surface(name="hub"),
+#                         ],
+#                     ),
+#                     AutomatedFarfield(),
+#                 ],
+#                 refinements=[
+#                     UniformRefinement(
+#                         entities=[cylinder],
+#                         spacing=0.1,
+#                     )
+#                 ],
+#             )
+#         )
+#
+#     with pytest.raises(
+#         pd.ValidationError,
+#         match=r"Using Volume entity `I am reused` in `AxisymmetricRefinement`, `UniformRefinement` at the same time is not allowed.",
+#     ):
+#         with CGS_unit_system:
+#             cylinder = Cylinder(
+#                 name="I am reused",
+#                 outer_radius=1,
+#                 height=12,
+#                 axis=(0, 1, 0),
+#                 center=(0, 5, 0),
+#             )
+#             SimulationParams(
+#                 meshing=MeshingParams(
+#                     refinements=[
+#                         UniformRefinement(entities=[cylinder], spacing=0.1),
+#                         AxisymmetricRefinement(
+#                             entities=[cylinder],
+#                             spacing_axial=0.1,
+#                             spacing_radial=0.1,
+#                             spacing_circumferential=0.1,
+#                         ),
+#                     ],
+#                 )
+#             )
+#
+#     with pytest.raises(
+#         pd.ValidationError,
+#         match=r" Volume entity `I am reused` is used multiple times in `UniformRefinement`.",
+#     ):
+#         with CGS_unit_system:
+#             cylinder = Cylinder(
+#                 name="I am reused",
+#                 outer_radius=1,
+#                 height=12,
+#                 axis=(0, 1, 0),
+#                 center=(0, 5, 0),
+#             )
+#             SimulationParams(
+#                 meshing=MeshingParams(
+#                     refinements=[
+#                         UniformRefinement(entities=[cylinder], spacing=0.1),
+#                         UniformRefinement(entities=[cylinder], spacing=0.2),
+#                     ],
+#                 )
+#             )

--- a/tests/simulation/translator/test_volume_meshing_translator.py
+++ b/tests/simulation/translator/test_volume_meshing_translator.py
@@ -13,7 +13,7 @@ from flow360.component.simulation.meshing_param.params import (
 from flow360.component.simulation.meshing_param.volume_params import (
     AutomatedFarfield,
     AxisymmetricRefinement,
-    RotationCylinder,
+    RotationVolume,
     UniformRefinement,
     UserDefinedFarfield,
 )
@@ -169,7 +169,7 @@ def get_test_param():
                         ],
                     ),
                     UserDefinedFarfield(),
-                    RotationCylinder(
+                    RotationVolume(
                         name="we_do_not_use_this_anyway",
                         entities=inner_cylinder,
                         spacing_axial=20 * u.cm,
@@ -182,27 +182,27 @@ def get_test_param():
                             Surface(name="blade3"),
                         ],
                     ),
-                    RotationCylinder(
+                    RotationVolume(
                         entities=mid_cylinder,
                         spacing_axial=20 * u.cm,
                         spacing_radial=0.2,
                         spacing_circumferential=20 * u.cm,
                         enclosed_entities=[inner_cylinder],
                     ),
-                    RotationCylinder(
+                    RotationVolume(
                         entities=cylinder_2,
                         spacing_axial=20 * u.cm,
                         spacing_radial=0.2,
                         spacing_circumferential=20 * u.cm,
                         enclosed_entities=[rotor_disk_cylinder],
                     ),
-                    RotationCylinder(
+                    RotationVolume(
                         entities=cylinder_3,
                         spacing_axial=20 * u.cm,
                         spacing_radial=0.2,
                         spacing_circumferential=20 * u.cm,
                     ),
-                    RotationCylinder(
+                    RotationVolume(
                         entities=cylinder_outer,
                         spacing_axial=40 * u.cm,
                         spacing_radial=0.4,
@@ -214,7 +214,7 @@ def get_test_param():
                             cylinder_3,
                         ],
                     ),
-                    RotationCylinder(
+                    RotationVolume(
                         entities=cone_frustum,
                         spacing_axial=40 * u.cm,
                         spacing_radial=0.4,

--- a/tests/simulation/translator/test_volume_meshing_translator.py
+++ b/tests/simulation/translator/test_volume_meshing_translator.py
@@ -348,7 +348,7 @@ def test_param_to_json(get_test_param, get_surface_mesh):
             },
             {
                 "name": "cone",
-                "axisOfRotation": [1.0, 0.0, 1.0],
+                "axisOfRotation": [0.7071067811865476, 0.0, 0.7071067811865476],
                 "center": [0.0, 0.0, 0.0],
                 "profileCurve": [[-1.0, 0.0], [-1.0, 1.0], [1.0, 2.0], [1.0, 0.0]],
                 "spacingAxial": 0.4,

--- a/tests/simulation/translator/test_volume_meshing_translator.py
+++ b/tests/simulation/translator/test_volume_meshing_translator.py
@@ -17,7 +17,13 @@ from flow360.component.simulation.meshing_param.volume_params import (
     UniformRefinement,
     UserDefinedFarfield,
 )
-from flow360.component.simulation.primitives import Box, CustomVolume, Cylinder, Surface
+from flow360.component.simulation.primitives import (
+    AxisymmetricBody,
+    Box,
+    CustomVolume,
+    Cylinder,
+    Surface,
+)
 from flow360.component.simulation.simulation_params import SimulationParams
 from flow360.component.simulation.translator.volume_meshing_translator import (
     get_volume_meshing_json,
@@ -98,7 +104,12 @@ def get_test_param():
             center=(0, 5, 0),
         )
         cylinder_3 = Cylinder(
-            name="3", inner_radius=1.5, outer_radius=2, height=2, axis=(0, 1, 0), center=(0, -5, 0)
+            name="3",
+            inner_radius=1.5,
+            outer_radius=2,
+            height=2,
+            axis=(0, 1, 0),
+            center=(0, -5, 0),
         )
         cylinder_outer = Cylinder(
             name="outer",
@@ -108,6 +119,13 @@ def get_test_param():
             axis=(1, 0, 0),
             center=(0, 0, 0),
         )
+        cone_frustum = AxisymmetricBody(
+            name="cone",
+            axis=(1, 0, 1),
+            center=(0, 0, 0),
+            profile_curve=[(-1, 0), (-1, 1), (1, 2), (1, 0)],
+        )
+
         param = SimulationParams(
             meshing=MeshingParams(
                 refinement_factor=1.45,
@@ -134,8 +152,12 @@ def get_test_param():
                         spacing_radial=0.2,
                         spacing_circumferential=20 * u.cm,
                     ),
-                    PassiveSpacing(entities=[Surface(name="passive1")], type="projected"),
-                    PassiveSpacing(entities=[Surface(name="passive2")], type="unchanged"),
+                    PassiveSpacing(
+                        entities=[Surface(name="passive1")], type="projected"
+                    ),
+                    PassiveSpacing(
+                        entities=[Surface(name="passive2")], type="unchanged"
+                    ),
                     BoundaryLayer(
                         entities=[Surface(name="boundary1")],
                         first_layer_thickness=0.5 * u.m,
@@ -145,7 +167,10 @@ def get_test_param():
                 volume_zones=[
                     CustomVolume(
                         name="custom_volume-1",
-                        boundaries=[Surface(name="interface1"), Surface(name="interface2")],
+                        boundaries=[
+                            Surface(name="interface1"),
+                            Surface(name="interface2"),
+                        ],
                     ),
                     UserDefinedFarfield(),
                     RotationCylinder(
@@ -193,6 +218,12 @@ def get_test_param():
                             cylinder_3,
                         ],
                     ),
+                    RotationCylinder(
+                        entities=cone_frustum,
+                        spacing_axial=40 * u.cm,
+                        spacing_radial=0.4,
+                        spacing_circumferential=20 * u.cm,
+                    ),
                 ],
             ),
             private_attribute_asset_cache=AssetCache(use_inhouse_mesher=True),
@@ -214,7 +245,11 @@ def test_param_to_json(get_test_param, get_surface_mesh):
             "numBoundaryLayers": -1,
         },
         "faces": {
-            "boundary1": {"firstLayerThickness": 0.5, "type": "aniso", "growthRate": 1.3},
+            "boundary1": {
+                "firstLayerThickness": 0.5,
+                "type": "aniso",
+                "growthRate": 1.3,
+            },
             "passive1": {"type": "projectAnisoSpacing"},
             "passive2": {"type": "none"},
         },
@@ -314,6 +349,16 @@ def test_param_to_json(get_test_param, get_surface_mesh):
                     "slidingInterface-2",
                     "slidingInterface-3",
                 ],
+            },
+            {
+                "name": "cone",
+                "axisOfRotation": [1.0, 0.0, 1.0],
+                "center": [0.0, 0.0, 0.0],
+                "profileCurve": [[-1.0, 0.0], [-1.0, 1.0], [1.0, 2.0], [1.0, 0.0]],
+                "spacingAxial": 0.4,
+                "spacingCircumferential": 0.2,
+                "spacingRadial": 0.4,
+                "enclosedObjects": [],
             },
         ],
         "zones": [

--- a/tests/simulation/translator/test_volume_meshing_translator.py
+++ b/tests/simulation/translator/test_volume_meshing_translator.py
@@ -13,6 +13,7 @@ from flow360.component.simulation.meshing_param.params import (
 from flow360.component.simulation.meshing_param.volume_params import (
     AutomatedFarfield,
     AxisymmetricRefinement,
+    RotationCylinder,
     RotationVolume,
     UniformRefinement,
     UserDefinedFarfield,

--- a/tests/simulation/translator/test_volume_meshing_translator.py
+++ b/tests/simulation/translator/test_volume_meshing_translator.py
@@ -152,12 +152,8 @@ def get_test_param():
                         spacing_radial=0.2,
                         spacing_circumferential=20 * u.cm,
                     ),
-                    PassiveSpacing(
-                        entities=[Surface(name="passive1")], type="projected"
-                    ),
-                    PassiveSpacing(
-                        entities=[Surface(name="passive2")], type="unchanged"
-                    ),
+                    PassiveSpacing(entities=[Surface(name="passive1")], type="projected"),
+                    PassiveSpacing(entities=[Surface(name="passive2")], type="unchanged"),
                     BoundaryLayer(
                         entities=[Surface(name="boundary1")],
                         first_layer_thickness=0.5 * u.m,

--- a/tools/integrations/schema_generation_v2.py
+++ b/tools/integrations/schema_generation_v2.py
@@ -19,7 +19,7 @@ from flow360.component.simulation.meshing_param.params import (
 )
 from flow360.component.simulation.meshing_param.volume_params import (
     AutomatedFarfield,
-    RotationCylinder,
+    RotationVolume,
     UniformRefinement,
 )
 from flow360.component.simulation.models.material import SolidMaterial
@@ -147,7 +147,10 @@ def write_schemas(type_obj: Type[Flow360BaseModel], folder_name, file_suffix="")
     file_suffix_part = f"-{file_suffix}" if file_suffix else ""
     write_to_file(
         os.path.join(
-            here, data_folder, folder_name, f"json-schema-{version_postfix}{file_suffix_part}.json"
+            here,
+            data_folder,
+            folder_name,
+            f"json-schema-{version_postfix}{file_suffix_part}.json",
         ),
         schema,
     )
@@ -161,7 +164,6 @@ def write_example(
     additional_fields: dict = {},
     exclude=None,
 ):
-
     if isinstance(obj, dict):
         data = obj
     elif isinstance(obj, Flow360BaseModel):
@@ -228,7 +230,7 @@ with SI_unit_system:
             SurfaceEdgeRefinement(edges=[edge], method=AspectRatioBasedRefinement(value=2)),
         ],
         volume_zones=[
-            RotationCylinder(
+            RotationVolume(
                 entities=my_cylinder_1,
                 spacing_axial=0.1 * u.m,
                 spacing_radial=0.12 * u.m,
@@ -400,7 +402,9 @@ write_example(
 
 with SI_unit_system:
     ac = AerospaceCondition.from_mach(
-        mach=0.8, alpha=1 * u.deg, thermal_state=ThermalState(temperature=100 * u.K, density=2)
+        mach=0.8,
+        alpha=1 * u.deg,
+        thermal_state=ThermalState(temperature=100 * u.K, density=2),
     )
 write_example(
     ac,


### PR DESCRIPTION
- Creates AxisymmetricBody entity for bodies of revolution generated from (Axial, Radial) polyline profiles with arbitrary center and rotation axis.
- Creates a RotationVolume class to represent rotation zones associated either with Cylinder or AxisymmetricBody types
- RotationCylinder (old interface) is retained with a deprecation warning, asking users to move to the RotationVolume object. This may be removed at a future date.