### PR TITLE
SurfaceEdgeRefinement validation check

### DIFF
--- a/flow360/component/simulation/meshing_param/edge_params.py
+++ b/flow360/component/simulation/meshing_param/edge_params.py
@@ -12,6 +12,7 @@ from flow360.component.simulation.validation.validation_context import (
     get_validation_info,
 )
 
+
 class AngleBasedRefinement(Flow360BaseModel):
     """
     Surface edge refinement by specifying curvature resolution angle.

--- a/flow360/component/simulation/meshing_param/edge_params.py
+++ b/flow360/component/simulation/meshing_param/edge_params.py
@@ -8,7 +8,9 @@ from flow360.component.simulation.framework.base_model import Flow360BaseModel
 from flow360.component.simulation.framework.entity_base import EntityList
 from flow360.component.simulation.primitives import Edge
 from flow360.component.simulation.unit_system import AngleType, LengthType
-
+from flow360.component.simulation.validation.validation_context import (
+    get_validation_info,
+)
 
 class AngleBasedRefinement(Flow360BaseModel):
     """
@@ -104,3 +106,13 @@ class SurfaceEdgeRefinement(Flow360BaseModel):
         description="Method for determining the spacing. See :class:`AngleBasedRefinement`,"
         " :class:`HeightBasedRefinement`, :class:`AspectRatioBasedRefinement`, :class:`ProjectAnisoSpacing`",
     )
+
+    @pd.model_validator(mode="after")
+    def ensure_not_geometry_ai(self):
+        """Ensure that geometry AI is disabled when using this feature."""
+        validation_info = get_validation_info()
+        if validation_info is None:
+            return self
+        if validation_info.use_geometry_AI:
+            raise ValueError("SurfaceEdgeRefinement is not currently supported with geometry AI.")
+        return self

--- a/tests/simulation/params/test_validators_params.py
+++ b/tests/simulation/params/test_validators_params.py
@@ -11,13 +11,13 @@ from flow360.component.simulation.entity_info import (
     VolumeMeshEntityInfo,
 )
 from flow360.component.simulation.framework.param_utils import AssetCache
+from flow360.component.simulation.meshing_param.edge_params import (
+    HeightBasedRefinement,
+    SurfaceEdgeRefinement,
+)
 from flow360.component.simulation.meshing_param.face_params import (
     BoundaryLayer,
     GeometryRefinement,
-)
-from flow360.component.simulation.meshing_param.edge_params import (
-    SurfaceEdgeRefinement,
-    HeightBasedRefinement,
 )
 from flow360.component.simulation.meshing_param.params import (
     MeshingDefaults,
@@ -83,10 +83,10 @@ from flow360.component.simulation.outputs.outputs import (
     VolumeOutput,
 )
 from flow360.component.simulation.primitives import (
-    Edge,
     Box,
     CustomVolume,
     Cylinder,
+    Edge,
     GenericVolume,
     GhostCircularPlane,
     GhostSphere,
@@ -2064,6 +2064,7 @@ def test_geometry_AI_only_features():
         errors[0]["msg"] == "Value error, Geometry accuracy is required when geometry AI is used."
     )
 
+
 def test_geometry_AI_unsupported_features():
     with SI_unit_system:
         params = SimulationParams(
@@ -2076,8 +2077,7 @@ def test_geometry_AI_unsupported_features():
                 ),
                 refinements=[
                     SurfaceEdgeRefinement(
-                        edges=[Edge(name="edge0001")],
-                        method=HeightBasedRefinement(value=1e-4)
+                        edges=[Edge(name="edge0001")], method=HeightBasedRefinement(value=1e-4)
                     )
                 ],
             ),
@@ -2096,6 +2096,7 @@ def test_geometry_AI_unsupported_features():
         errors[0]["msg"]
         == "Value error, SurfaceEdgeRefinement is not currently supported with geometry AI."
     )
+
 
 def test_redefined_user_defined_fields():
 


### PR DESCRIPTION
Added validation check to ensure that SurfaceEdgeRefinement cannot be used when GAI is enabled.