### PR TITLE
[FXC-5125] Use inline model without private_attribute_id for computing processor hash

### DIFF
--- a/tests/simulation/translator/data/simulation_stopping_criterion.json
+++ b/tests/simulation/translator/data/simulation_stopping_criterion.json
@@ -218,7 +218,7 @@
                 "value": 0.0,
                 "units": "m"
             },
-            "private_attribute_id": "wallBC"
+            "private_attribute_id": "wallBC1"
         },
         {
             "type": "SlipWall",
@@ -247,6 +247,32 @@
                 ]
             },
             "name": "Freestream"
+        },
+        {
+            "type": "Wall",
+            "entities": {
+                "stored_entities": [
+                    {
+                        "private_attribute_entity_type_name": "Surface",
+                        "name": "4",
+                        "private_attribute_sub_components": []
+                    }
+                ]
+            },
+            "private_attribute_id": "wallBC",
+            "name": "wing",
+            "use_wall_function": false,
+            "heat_spec": {
+                "value": {
+                    "value": 0.0,
+                    "units": "W/m**2"
+                },
+                "type_name": "HeatFlux"
+            },
+            "roughness_height": {
+                "value": 0.0,
+                "units": "m"
+            }
         }
     ],
     "time_stepping": {

--- a/tests/simulation/translator/ref/Flow360_om6wing_stopping_criterion_and_moving_statistic.json
+++ b/tests/simulation/translator/ref/Flow360_om6wing_stopping_criterion_and_moving_statistic.json
@@ -10,6 +10,11 @@
         },
         "3": {
             "type": "Freestream"
+        },
+        "4": {
+            "heatFlux": 0.0,
+            "roughnessHeight": 0.0,
+            "type": "NoSlipWall"
         }
     },
     "freestream": {
@@ -97,7 +102,7 @@
     },
     "runControl": {
         "externalProcessMonitorOutput": true,
-        "monitorProcessorHash": "bc5ac70ee2692e2a051b0867dad9c0057ac1b6d58995389d41ca850fb6c39b5b",
+        "monitorProcessorHash": "396038f897af72de2eb89b96a33c0d8d954bff330ce054f0714b06fe669c0744",
         "stoppingCriteria": [
             {
                 "monitoredColumn": "point_legacy1_Point1_Helicity_mean",

--- a/tests/simulation/translator/test_solver_translator.py
+++ b/tests/simulation/translator/test_solver_translator.py
@@ -472,7 +472,7 @@ def test_om6wing_with_stopping_criterion_and_moving_statistic(get_om6Wing_tutori
         monitor_field=mass_flow_rate,
         tolerance_window_size=3,
     )
-    wallBC = Wall(name="wing", surfaces=[Surface(name="1")], private_attribute_id="wallBC")
+    wallBC = Wall(name="wing", surfaces=[Surface(name="4")], private_attribute_id="wallBC")
     force_output = ForceOutput(
         name="force_wallBC",
         models=[wallBC],
@@ -486,10 +486,11 @@ def test_om6wing_with_stopping_criterion_and_moving_statistic(get_om6Wing_tutori
         monitor_output=force_output,
         monitor_field="CL",
     )
+    params.models.append(wallBC)
     params.run_control = RunControl(stopping_criteria=[criterion1, criterion2, criterion3])
     params.outputs.extend([probe_output, mass_flow_rate_integral, force_output])
     translate_and_compare(
-        get_om6Wing_tutorial_param,
+        params,
         mesh_unit=0.8059 * u.m,
         ref_json_file="Flow360_om6wing_stopping_criterion_and_moving_statistic.json",
         debug=False,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Shifts monitor semaphore hash generation to be based on full `ForceOutput` model content rather than `private_attribute_id`.
> 
> - In `solver_translator.calculate_monitor_semaphore_hash`, resolve `ForceOutput.models` to actual models from `params.models`, serialize with `dump_dict`, remove `privateAttributeId`/`privateAttributeInputCache` via `recursive_remove_key`, and hash these JSON strings plus `output_fields` and any `moving_statistic`
> - Add helper `get_force_output_models` and import `recursive_remove_key`
> - Update tests and fixtures: add explicit `Wall` model with surface `"4"`, include it in `params.models`, adjust surface IDs, and update expected `monitorProcessorHash` and boundary refs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed105e9adfb09c1da564335b0c88898f66933656. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->