### PR TITLE
Update ci to enable merge queue

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,6 +17,7 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ "main" ]
+  merge_group:
   schedule:
     - cron: '22 8 * * 4'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
     branches: [ main, develop, release-candidate/* ]
   pull_request:
     types: [ opened, synchronize, reopened, ready_for_review ]
+  merge_group:
   workflow_call:
 
 jobs:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only adjusts GitHub Actions workflow triggers to also run on `merge_group`, without touching application code or build/test logic.
> 
> **Overview**
> Adds `merge_group` event triggers to the `CodeQL` and `unit testing` GitHub Actions workflows so they execute for GitHub Merge Queue runs in addition to existing `push`/`pull_request` events.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit feac4b832449daa150dee6db420d22dea7f6f9a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->