### PR TITLE
feat(FXC-6541): support multiple surface outputs with different frequ…

### DIFF
--- a/flow360/component/simulation/translator/solver_translator.py
+++ b/flow360/component/simulation/translator/solver_translator.py
@@ -547,7 +547,7 @@ def translate_volume_output(
 
 def translate_imported_surface_output(
     output_params: list,
-    surface_output_class: Union[SurfaceOutput, TimeAverageSurfaceOutput],
+    surface_output_class: Union[Type[SurfaceOutput], Type[TimeAverageSurfaceOutput]],
     coordinate_system_manager=None,
 ):
     """Translate imported surface output settings."""
@@ -570,22 +570,23 @@ def translate_imported_surface_output(
     return imported_surface_output
 
 
-def translate_surface_output(
-    output_params: list,
-    surface_output_class: Union[SurfaceOutput, TimeAverageSurfaceOutput],
-    translated: dict,
+def _translate_single_surface_output(
+    output_instance,
+    surface_output_class: Union[Type[SurfaceOutput], Type[TimeAverageSurfaceOutput]],
 ):
-    """Translate surface output settings."""
-
-    assert "boundaries" in translated  #  "Boundaries must be translated before surface output"
+    """Translate a single SurfaceOutput instance to solver config dict."""
+    is_average = surface_output_class is TimeAverageSurfaceOutput
+    # Wrap in a list because init_output_base and translate_setting_and_apply_to_all_entities
+    # expect a list of outputs to iterate over.
+    single_list = [output_instance]
 
     surface_output = init_output_base(
-        output_params,
+        single_list,
         surface_output_class,
-        is_average=surface_output_class is TimeAverageSurfaceOutput,
+        is_average=is_average,
     )
     surface_output["surfaces"] = translate_setting_and_apply_to_all_entities(
-        output_params,
+        single_list,
         surface_output_class,
         translation_func=translate_output_fields,
         to_list=False,
@@ -597,12 +598,29 @@ def translate_surface_output(
             MirroredSurface,
         ),
     )
-    surface_output["writeSingleFile"] = get_global_setting_from_first_instance(
-        output_params,
-        surface_output_class,
-        "write_single_file",
-    )
+    surface_output["writeSingleFile"] = output_instance.write_single_file
+    surface_output["name"] = "" if output_instance.has_default_name else output_instance.name
     return surface_output
+
+
+def translate_surface_output(
+    output_params: list,
+    surface_output_class: Union[Type[SurfaceOutput], Type[TimeAverageSurfaceOutput]],
+    translated: dict,
+):
+    """Translate surface output settings.
+
+    Returns a list of per-instance solver config dicts (one per SurfaceOutput instance).
+    ``translated`` is required only as a precondition guard: boundaries must already
+    be translated before surface outputs so downstream lookups resolve correctly.
+    """
+    assert "boundaries" in translated, "Boundaries must be translated before surface output"
+
+    return [
+        _translate_single_surface_output(obj, surface_output_class)
+        for obj in output_params
+        if is_exact_instance(obj, surface_output_class)
+    ]
 
 
 def translate_slice_output(
@@ -1162,9 +1180,9 @@ def translate_output(input_params: SimulationParams, translated: dict):
     ]
     for output_class, output_key in surface_output_configs:
         if has_instance_in_list(outputs, output_class):
-            surface_output = translate_surface_output(outputs, output_class, translated)
-            if surface_output:
-                translated[output_key] = add_unused_output_settings_for_comparison(surface_output)
+            configs = translate_surface_output(outputs, output_class, translated)
+            configs.sort(key=lambda c: c["name"])
+            translated[output_key] = [add_unused_output_settings_for_comparison(c) for c in configs]
 
     ##:: Step3: Get translated["sliceOutput"]
     slice_output_configs = [

--- a/flow360/component/simulation/translator/solver_translator.py
+++ b/flow360/component/simulation/translator/solver_translator.py
@@ -599,7 +599,8 @@ def _translate_single_surface_output(
         ),
     )
     surface_output["writeSingleFile"] = output_instance.write_single_file
-    surface_output["name"] = "" if output_instance.has_default_name else output_instance.name
+    default_name = type(output_instance).model_fields["name"].default
+    surface_output["name"] = "" if output_instance.name == default_name else output_instance.name
     return surface_output
 
 

--- a/tests/simulation/service/test_integration_metadata.py
+++ b/tests/simulation/service/test_integration_metadata.py
@@ -217,5 +217,5 @@ def test_update_zone_info_from_geometry_with_missing_symmetric():
     translated = get_solver_json(param, mesh_unit="m")
     assert BOUNDARY_FULL_NAME_WHEN_NOT_FOUND not in translated["boundaries"]  # Silently removed
     assert (
-        BOUNDARY_FULL_NAME_WHEN_NOT_FOUND not in translated["surfaceOutput"]["surfaces"]
+        BOUNDARY_FULL_NAME_WHEN_NOT_FOUND not in translated["surfaceOutput"][0]["surfaces"]
     )  # Silently removed

--- a/tests/simulation/translator/ref/Flow360_CHT_three_cylinders.json
+++ b/tests/simulation/translator/ref/Flow360_CHT_three_cylinders.json
@@ -91,60 +91,76 @@
     "runControl": {
         "externalProcessMonitorOutput": false
     },
-    "surfaceOutput": {
-        "animationFrequency": -1,
-        "animationFrequencyOffset": 0,
-        "animationFrequencyTimeAverage": -1,
-        "animationFrequencyTimeAverageOffset": 0,
-        "outputFields": [],
-        "outputFormat": "paraview",
-        "startAverageIntegrationStep": -1,
-        "surfaces": {
-            "fluid/Interface_solid-1": {
-                "outputFields": [
-                    "Cp",
-                    "primitiveVars",
-                    "T",
-                    "heatFlux",
-                    "lowMachPreconditionerSensor"
-                ]
+    "surfaceOutput": [
+        {
+            "animationFrequency": -1,
+            "animationFrequencyOffset": 0,
+            "animationFrequencyTimeAverage": -1,
+            "animationFrequencyTimeAverageOffset": 0,
+            "name": "",
+            "outputFields": [],
+            "outputFormat": "paraview",
+            "startAverageIntegrationStep": -1,
+            "surfaces": {
+                "fluid/Interface_solid-1": {
+                    "outputFields": [
+                        "Cp",
+                        "primitiveVars",
+                        "T",
+                        "heatFlux",
+                        "lowMachPreconditionerSensor"
+                    ]
+                },
+                "fluid/Interface_solid-2": {
+                    "outputFields": [
+                        "Cp",
+                        "primitiveVars",
+                        "T",
+                        "heatFlux",
+                        "lowMachPreconditionerSensor"
+                    ]
+                },
+                "fluid/Interface_solid-3": {
+                    "outputFields": [
+                        "Cp",
+                        "primitiveVars",
+                        "T",
+                        "heatFlux",
+                        "lowMachPreconditionerSensor"
+                    ]
+                }
             },
-            "fluid/Interface_solid-2": {
-                "outputFields": [
-                    "Cp",
-                    "primitiveVars",
-                    "T",
-                    "heatFlux",
-                    "lowMachPreconditionerSensor"
-                ]
-            },
-            "fluid/Interface_solid-3": {
-                "outputFields": [
-                    "Cp",
-                    "primitiveVars",
-                    "T",
-                    "heatFlux",
-                    "lowMachPreconditionerSensor"
-                ]
-            },
-            "solid-1/Interface_fluid": {
-                "outputFields": [
-                    "T"
-                ]
-            },
-            "solid-2/Interface_fluid": {
-                "outputFields": [
-                    "T"
-                ]
-            },
-            "solid-3/Interface_fluid": {
-                "outputFields": [
-                    "T"
-                ]
-            }
+            "writeSingleFile": false
         },
-        "writeSingleFile": false
-    },
+        {
+            "animationFrequency": -1,
+            "animationFrequencyOffset": 0,
+            "animationFrequencyTimeAverage": -1,
+            "animationFrequencyTimeAverageOffset": 0,
+            "name": "",
+            "outputFields": [],
+            "outputFormat": "paraview",
+            "startAverageIntegrationStep": -1,
+            "surfaces": {
+                "solid-1/Interface_fluid": {
+                    "outputFields": [
+                        "T"
+                    ]
+                },
+                "solid-2/Interface_fluid": {
+                    "outputFields": [
+                        "T"
+                    ]
+                },
+                "solid-3/Interface_fluid": {
+                    "outputFields": [
+                        "T"
+                    ]
+                }
+            },
+            "writeSingleFile": false
+        }
+    ],
     "thermallyPerfectGasModel": {
         "temperatureRanges": [
             {

--- a/tests/simulation/translator/ref/Flow360_NestedCylindersSRF.json
+++ b/tests/simulation/translator/ref/Flow360_NestedCylindersSRF.json
@@ -63,34 +63,37 @@
     "runControl": {
         "externalProcessMonitorOutput": false
     },
-    "surfaceOutput": {
-        "animationFrequency": -1,
-        "animationFrequencyOffset": 0,
-        "animationFrequencyTimeAverage": -1,
-        "animationFrequencyTimeAverageOffset": 0,
-        "outputFields": [],
-        "outputFormat": "paraview",
-        "startAverageIntegrationStep": -1,
-        "surfaces": {
-            "blk-1/Cylinder": {
-                "outputFields": [
-                    "primitiveVars",
-                    "Cp",
-                    "Cf",
-                    "yPlus"
-                ]
+    "surfaceOutput": [
+        {
+            "animationFrequency": -1,
+            "animationFrequencyOffset": 0,
+            "animationFrequencyTimeAverage": -1,
+            "animationFrequencyTimeAverageOffset": 0,
+            "name": "",
+            "outputFields": [],
+            "outputFormat": "paraview",
+            "startAverageIntegrationStep": -1,
+            "surfaces": {
+                "blk-1/Cylinder": {
+                    "outputFields": [
+                        "primitiveVars",
+                        "Cp",
+                        "Cf",
+                        "yPlus"
+                    ]
+                },
+                "blk-1/OuterWall": {
+                    "outputFields": [
+                        "primitiveVars",
+                        "Cp",
+                        "Cf",
+                        "yPlus"
+                    ]
+                }
             },
-            "blk-1/OuterWall": {
-                "outputFields": [
-                    "primitiveVars",
-                    "Cp",
-                    "Cf",
-                    "yPlus"
-                ]
-            }
-        },
-        "writeSingleFile": false
-    },
+            "writeSingleFile": false
+        }
+    ],
     "thermallyPerfectGasModel": {
         "temperatureRanges": [
             {

--- a/tests/simulation/translator/ref/Flow360_TurbFlatPlate137x97_BoxTrip.json
+++ b/tests/simulation/translator/ref/Flow360_TurbFlatPlate137x97_BoxTrip.json
@@ -72,23 +72,26 @@
     "runControl": {
         "externalProcessMonitorOutput": false
     },
-    "surfaceOutput": {
-        "animationFrequency": -1,
-        "animationFrequencyOffset": 0,
-        "animationFrequencyTimeAverage": -1,
-        "animationFrequencyTimeAverageOffset": 0,
-        "outputFields": [],
-        "outputFormat": "paraview",
-        "startAverageIntegrationStep": -1,
-        "surfaces": {
-            "6": {
-                "outputFields": [
-                    "Cf"
-                ]
-            }
-        },
-        "writeSingleFile": false
-    },
+    "surfaceOutput": [
+        {
+            "animationFrequency": -1,
+            "animationFrequencyOffset": 0,
+            "animationFrequencyTimeAverage": -1,
+            "animationFrequencyTimeAverageOffset": 0,
+            "name": "",
+            "outputFields": [],
+            "outputFormat": "paraview",
+            "startAverageIntegrationStep": -1,
+            "surfaces": {
+                "6": {
+                    "outputFields": [
+                        "Cf"
+                    ]
+                }
+            },
+            "writeSingleFile": false
+        }
+    ],
     "thermallyPerfectGasModel": {
         "temperatureRanges": [
             {

--- a/tests/simulation/translator/ref/Flow360_XV15HoverMRF.json
+++ b/tests/simulation/translator/ref/Flow360_XV15HoverMRF.json
@@ -54,26 +54,29 @@
     "runControl": {
         "externalProcessMonitorOutput": false
     },
-    "surfaceOutput": {
-        "animationFrequency": -1,
-        "animationFrequencyOffset": 0,
-        "animationFrequencyTimeAverage": -1,
-        "animationFrequencyTimeAverageOffset": 0,
-        "outputFields": [],
-        "outputFormat": "paraview",
-        "startAverageIntegrationStep": -1,
-        "surfaces": {
-            "innerRotating/blade": {
-                "outputFields": [
-                    "primitiveVars",
-                    "Cp",
-                    "Cf",
-                    "yPlus"
-                ]
-            }
-        },
-        "writeSingleFile": false
-    },
+    "surfaceOutput": [
+        {
+            "animationFrequency": -1,
+            "animationFrequencyOffset": 0,
+            "animationFrequencyTimeAverage": -1,
+            "animationFrequencyTimeAverageOffset": 0,
+            "name": "",
+            "outputFields": [],
+            "outputFormat": "paraview",
+            "startAverageIntegrationStep": -1,
+            "surfaces": {
+                "innerRotating/blade": {
+                    "outputFields": [
+                        "primitiveVars",
+                        "Cp",
+                        "Cf",
+                        "yPlus"
+                    ]
+                }
+            },
+            "writeSingleFile": false
+        }
+    ],
     "thermallyPerfectGasModel": {
         "temperatureRanges": [
             {

--- a/tests/simulation/translator/ref/Flow360_ghost_periodic.json
+++ b/tests/simulation/translator/ref/Flow360_ghost_periodic.json
@@ -74,26 +74,29 @@
     "runControl": {
         "externalProcessMonitorOutput": false
     },
-    "surfaceOutput": {
-        "animationFrequency": -1,
-        "animationFrequencyOffset": 0,
-        "animationFrequencyTimeAverage": -1,
-        "animationFrequencyTimeAverageOffset": 0,
-        "outputFields": [],
-        "outputFormat": "paraview",
-        "startAverageIntegrationStep": -1,
-        "surfaces": {
-            "body00001": {
-                "outputFields": [
-                    "Cf",
-                    "CfVec",
-                    "Cp",
-                    "yPlus"
-                ]
-            }
-        },
-        "writeSingleFile": false
-    },
+    "surfaceOutput": [
+        {
+            "animationFrequency": -1,
+            "animationFrequencyOffset": 0,
+            "animationFrequencyTimeAverage": -1,
+            "animationFrequencyTimeAverageOffset": 0,
+            "name": "",
+            "outputFields": [],
+            "outputFormat": "paraview",
+            "startAverageIntegrationStep": -1,
+            "surfaces": {
+                "body00001": {
+                    "outputFields": [
+                        "Cf",
+                        "CfVec",
+                        "Cp",
+                        "yPlus"
+                    ]
+                }
+            },
+            "writeSingleFile": false
+        }
+    ],
     "thermallyPerfectGasModel": {
         "temperatureRanges": [
             {

--- a/tests/simulation/translator/ref/Flow360_heatFluxCylinder.json
+++ b/tests/simulation/translator/ref/Flow360_heatFluxCylinder.json
@@ -82,26 +82,29 @@
     "runControl": {
         "externalProcessMonitorOutput": false
     },
-    "surfaceOutput": {
-        "animationFrequency": -1,
-        "animationFrequencyOffset": 0,
-        "animationFrequencyTimeAverage": -1,
-        "animationFrequencyTimeAverageOffset": 0,
-        "outputFields": [],
-        "outputFormat": "paraview",
-        "startAverageIntegrationStep": -1,
-        "surfaces": {
-            "fluid/wall": {
-                "outputFields": [
-                    "Cp",
-                    "primitiveVars",
-                    "T",
-                    "heatFlux"
-                ]
-            }
-        },
-        "writeSingleFile": false
-    },
+    "surfaceOutput": [
+        {
+            "animationFrequency": -1,
+            "animationFrequencyOffset": 0,
+            "animationFrequencyTimeAverage": -1,
+            "animationFrequencyTimeAverageOffset": 0,
+            "name": "",
+            "outputFields": [],
+            "outputFormat": "paraview",
+            "startAverageIntegrationStep": -1,
+            "surfaces": {
+                "fluid/wall": {
+                    "outputFields": [
+                        "Cp",
+                        "primitiveVars",
+                        "T",
+                        "heatFlux"
+                    ]
+                }
+            },
+            "writeSingleFile": false
+        }
+    ],
     "thermallyPerfectGasModel": {
         "temperatureRanges": [
             {

--- a/tests/simulation/translator/ref/Flow360_mirrored_surface_translation.json
+++ b/tests/simulation/translator/ref/Flow360_mirrored_surface_translation.json
@@ -143,98 +143,101 @@
     "runControl": {
         "externalProcessMonitorOutput": false
     },
-    "surfaceOutput": {
-        "animationFrequency": -1,
-        "animationFrequencyOffset": 0,
-        "animationFrequencyTimeAverage": -1,
-        "animationFrequencyTimeAverageOffset": 0,
-        "outputFields": [],
-        "outputFormat": "paraview",
-        "startAverageIntegrationStep": -1,
-        "surfaces": {
-            "farfield/BottomCap": {
-                "outputFields": [
-                    "Cf",
-                    "Cp",
-                    "primitiveVars",
-                    "yPlus"
-                ]
+    "surfaceOutput": [
+        {
+            "animationFrequency": -1,
+            "animationFrequencyOffset": 0,
+            "animationFrequencyTimeAverage": -1,
+            "animationFrequencyTimeAverageOffset": 0,
+            "name": "",
+            "outputFields": [],
+            "outputFormat": "paraview",
+            "startAverageIntegrationStep": -1,
+            "surfaces": {
+                "farfield/BottomCap": {
+                    "outputFields": [
+                        "Cf",
+                        "Cp",
+                        "primitiveVars",
+                        "yPlus"
+                    ]
+                },
+                "farfield/BottomCap_<mirror>": {
+                    "outputFields": [
+                        "Cf",
+                        "Cp",
+                        "primitiveVars",
+                        "yPlus"
+                    ]
+                },
+                "farfield/Curved": {
+                    "outputFields": [
+                        "Cf",
+                        "Cp",
+                        "primitiveVars",
+                        "yPlus"
+                    ]
+                },
+                "farfield/Curved_<mirror>": {
+                    "outputFields": [
+                        "Cf",
+                        "Cp",
+                        "primitiveVars",
+                        "yPlus"
+                    ]
+                },
+                "farfield/TopCap": {
+                    "outputFields": [
+                        "Cf",
+                        "Cp",
+                        "primitiveVars",
+                        "yPlus"
+                    ]
+                },
+                "farfield/TopCap_<mirror>": {
+                    "outputFields": [
+                        "Cf",
+                        "Cp",
+                        "primitiveVars",
+                        "yPlus"
+                    ]
+                },
+                "farfield/windTunnelCentralBelt": {
+                    "outputFields": [
+                        "Cf",
+                        "Cp",
+                        "primitiveVars",
+                        "yPlus"
+                    ]
+                },
+                "farfield/windTunnelFloor": {
+                    "outputFields": [
+                        "Cf",
+                        "Cp",
+                        "primitiveVars",
+                        "yPlus"
+                    ]
+                },
+                "farfield/windTunnelFrontWheelBelt": {
+                    "outputFields": [
+                        "Cf",
+                        "Cp",
+                        "primitiveVars",
+                        "yPlus"
+                    ]
+                },
+                "farfield/windTunnelRearWheelBelt": {
+                    "outputFields": [
+                        "Cf",
+                        "Cp",
+                        "primitiveVars",
+                        "yPlus"
+                    ]
+                }
             },
-            "farfield/BottomCap_<mirror>": {
-                "outputFields": [
-                    "Cf",
-                    "Cp",
-                    "primitiveVars",
-                    "yPlus"
-                ]
-            },
-            "farfield/Curved": {
-                "outputFields": [
-                    "Cf",
-                    "Cp",
-                    "primitiveVars",
-                    "yPlus"
-                ]
-            },
-            "farfield/Curved_<mirror>": {
-                "outputFields": [
-                    "Cf",
-                    "Cp",
-                    "primitiveVars",
-                    "yPlus"
-                ]
-            },
-            "farfield/TopCap": {
-                "outputFields": [
-                    "Cf",
-                    "Cp",
-                    "primitiveVars",
-                    "yPlus"
-                ]
-            },
-            "farfield/TopCap_<mirror>": {
-                "outputFields": [
-                    "Cf",
-                    "Cp",
-                    "primitiveVars",
-                    "yPlus"
-                ]
-            },
-            "farfield/windTunnelCentralBelt": {
-                "outputFields": [
-                    "Cf",
-                    "Cp",
-                    "primitiveVars",
-                    "yPlus"
-                ]
-            },
-            "farfield/windTunnelFloor": {
-                "outputFields": [
-                    "Cf",
-                    "Cp",
-                    "primitiveVars",
-                    "yPlus"
-                ]
-            },
-            "farfield/windTunnelFrontWheelBelt": {
-                "outputFields": [
-                    "Cf",
-                    "Cp",
-                    "primitiveVars",
-                    "yPlus"
-                ]
-            },
-            "farfield/windTunnelRearWheelBelt": {
-                "outputFields": [
-                    "Cf",
-                    "Cp",
-                    "primitiveVars",
-                    "yPlus"
-                ]
-            }
-        },
-        "writeSingleFile": false
-    },
+            "writeSingleFile": false
+        }
+    ],
     "thermallyPerfectGasModel": {
         "temperatureRanges": [
             {

--- a/tests/simulation/translator/ref/Flow360_om6Wing.json
+++ b/tests/simulation/translator/ref/Flow360_om6Wing.json
@@ -104,33 +104,36 @@
         },
         "startAverageIntegrationStep": -1
     },
-    "surfaceOutput": {
-        "animationFrequency": -1,
-        "animationFrequencyOffset": 0,
-        "animationFrequencyTimeAverage": -1,
-        "animationFrequencyTimeAverageOffset": 0,
-        "outputFields": [],
-        "outputFormat": "paraview",
-        "startAverageIntegrationStep": -1,
-        "surfaces": {
-            "1": {
-                "outputFields": [
-                    "Cp"
-                ]
+    "surfaceOutput": [
+        {
+            "animationFrequency": -1,
+            "animationFrequencyOffset": 0,
+            "animationFrequencyTimeAverage": -1,
+            "animationFrequencyTimeAverageOffset": 0,
+            "name": "",
+            "outputFields": [],
+            "outputFormat": "paraview",
+            "startAverageIntegrationStep": -1,
+            "surfaces": {
+                "1": {
+                    "outputFields": [
+                        "Cp"
+                    ]
+                },
+                "2": {
+                    "outputFields": [
+                        "Cp"
+                    ]
+                },
+                "3": {
+                    "outputFields": [
+                        "Cp"
+                    ]
+                }
             },
-            "2": {
-                "outputFields": [
-                    "Cp"
-                ]
-            },
-            "3": {
-                "outputFields": [
-                    "Cp"
-                ]
-            }
-        },
-        "writeSingleFile": false
-    },
+            "writeSingleFile": false
+        }
+    ],
     "thermallyPerfectGasModel": {
         "temperatureRanges": [
             {

--- a/tests/simulation/translator/ref/Flow360_om6Wing_SA_with_low_reynolds_correction.json
+++ b/tests/simulation/translator/ref/Flow360_om6Wing_SA_with_low_reynolds_correction.json
@@ -104,33 +104,36 @@
         },
         "startAverageIntegrationStep": -1
     },
-    "surfaceOutput": {
-        "animationFrequency": -1,
-        "animationFrequencyOffset": 0,
-        "animationFrequencyTimeAverage": -1,
-        "animationFrequencyTimeAverageOffset": 0,
-        "outputFields": [],
-        "outputFormat": "paraview",
-        "startAverageIntegrationStep": -1,
-        "surfaces": {
-            "1": {
-                "outputFields": [
-                    "Cp"
-                ]
+    "surfaceOutput": [
+        {
+            "animationFrequency": -1,
+            "animationFrequencyOffset": 0,
+            "animationFrequencyTimeAverage": -1,
+            "animationFrequencyTimeAverageOffset": 0,
+            "name": "",
+            "outputFields": [],
+            "outputFormat": "paraview",
+            "startAverageIntegrationStep": -1,
+            "surfaces": {
+                "1": {
+                    "outputFields": [
+                        "Cp"
+                    ]
+                },
+                "2": {
+                    "outputFields": [
+                        "Cp"
+                    ]
+                },
+                "3": {
+                    "outputFields": [
+                        "Cp"
+                    ]
+                }
             },
-            "2": {
-                "outputFields": [
-                    "Cp"
-                ]
-            },
-            "3": {
-                "outputFields": [
-                    "Cp"
-                ]
-            }
-        },
-        "writeSingleFile": false
-    },
+            "writeSingleFile": false
+        }
+    ],
     "thermallyPerfectGasModel": {
         "temperatureRanges": [
             {

--- a/tests/simulation/translator/ref/Flow360_om6Wing_debug_point.json
+++ b/tests/simulation/translator/ref/Flow360_om6Wing_debug_point.json
@@ -109,33 +109,36 @@
         },
         "startAverageIntegrationStep": -1
     },
-    "surfaceOutput": {
-        "animationFrequency": -1,
-        "animationFrequencyOffset": 0,
-        "animationFrequencyTimeAverage": -1,
-        "animationFrequencyTimeAverageOffset": 0,
-        "outputFields": [],
-        "outputFormat": "paraview",
-        "startAverageIntegrationStep": -1,
-        "surfaces": {
-            "1": {
-                "outputFields": [
-                    "Cp"
-                ]
+    "surfaceOutput": [
+        {
+            "animationFrequency": -1,
+            "animationFrequencyOffset": 0,
+            "animationFrequencyTimeAverage": -1,
+            "animationFrequencyTimeAverageOffset": 0,
+            "name": "",
+            "outputFields": [],
+            "outputFormat": "paraview",
+            "startAverageIntegrationStep": -1,
+            "surfaces": {
+                "1": {
+                    "outputFields": [
+                        "Cp"
+                    ]
+                },
+                "2": {
+                    "outputFields": [
+                        "Cp"
+                    ]
+                },
+                "3": {
+                    "outputFields": [
+                        "Cp"
+                    ]
+                }
             },
-            "2": {
-                "outputFields": [
-                    "Cp"
-                ]
-            },
-            "3": {
-                "outputFields": [
-                    "Cp"
-                ]
-            }
-        },
-        "writeSingleFile": false
-    },
+            "writeSingleFile": false
+        }
+    ],
     "thermallyPerfectGasModel": {
         "temperatureRanges": [
             {

--- a/tests/simulation/translator/ref/Flow360_om6Wing_debug_type.json
+++ b/tests/simulation/translator/ref/Flow360_om6Wing_debug_type.json
@@ -105,33 +105,36 @@
         },
         "startAverageIntegrationStep": -1
     },
-    "surfaceOutput": {
-        "animationFrequency": -1,
-        "animationFrequencyOffset": 0,
-        "animationFrequencyTimeAverage": -1,
-        "animationFrequencyTimeAverageOffset": 0,
-        "outputFields": [],
-        "outputFormat": "paraview",
-        "startAverageIntegrationStep": -1,
-        "surfaces": {
-            "1": {
-                "outputFields": [
-                    "Cp"
-                ]
+    "surfaceOutput": [
+        {
+            "animationFrequency": -1,
+            "animationFrequencyOffset": 0,
+            "animationFrequencyTimeAverage": -1,
+            "animationFrequencyTimeAverageOffset": 0,
+            "name": "",
+            "outputFields": [],
+            "outputFormat": "paraview",
+            "startAverageIntegrationStep": -1,
+            "surfaces": {
+                "1": {
+                    "outputFields": [
+                        "Cp"
+                    ]
+                },
+                "2": {
+                    "outputFields": [
+                        "Cp"
+                    ]
+                },
+                "3": {
+                    "outputFields": [
+                        "Cp"
+                    ]
+                }
             },
-            "2": {
-                "outputFields": [
-                    "Cp"
-                ]
-            },
-            "3": {
-                "outputFields": [
-                    "Cp"
-                ]
-            }
-        },
-        "writeSingleFile": false
-    },
+            "writeSingleFile": false
+        }
+    ],
     "thermallyPerfectGasModel": {
         "temperatureRanges": [
             {

--- a/tests/simulation/translator/ref/Flow360_om6wing_FS_with_turbulence_quantities.json
+++ b/tests/simulation/translator/ref/Flow360_om6wing_FS_with_turbulence_quantities.json
@@ -108,33 +108,36 @@
         },
         "startAverageIntegrationStep": -1
     },
-    "surfaceOutput": {
-        "animationFrequency": -1,
-        "animationFrequencyOffset": 0,
-        "animationFrequencyTimeAverage": -1,
-        "animationFrequencyTimeAverageOffset": 0,
-        "outputFields": [],
-        "outputFormat": "paraview",
-        "startAverageIntegrationStep": -1,
-        "surfaces": {
-            "1": {
-                "outputFields": [
-                    "Cp"
-                ]
+    "surfaceOutput": [
+        {
+            "animationFrequency": -1,
+            "animationFrequencyOffset": 0,
+            "animationFrequencyTimeAverage": -1,
+            "animationFrequencyTimeAverageOffset": 0,
+            "name": "",
+            "outputFields": [],
+            "outputFormat": "paraview",
+            "startAverageIntegrationStep": -1,
+            "surfaces": {
+                "1": {
+                    "outputFields": [
+                        "Cp"
+                    ]
+                },
+                "2": {
+                    "outputFields": [
+                        "Cp"
+                    ]
+                },
+                "3": {
+                    "outputFields": [
+                        "Cp"
+                    ]
+                }
             },
-            "2": {
-                "outputFields": [
-                    "Cp"
-                ]
-            },
-            "3": {
-                "outputFields": [
-                    "Cp"
-                ]
-            }
-        },
-        "writeSingleFile": false
-    },
+            "writeSingleFile": false
+        }
+    ],
     "thermallyPerfectGasModel": {
         "temperatureRanges": [
             {

--- a/tests/simulation/translator/ref/Flow360_om6wing_FS_with_vel.json
+++ b/tests/simulation/translator/ref/Flow360_om6wing_FS_with_vel.json
@@ -109,33 +109,36 @@
         },
         "startAverageIntegrationStep": -1
     },
-    "surfaceOutput": {
-        "animationFrequency": -1,
-        "animationFrequencyOffset": 0,
-        "animationFrequencyTimeAverage": -1,
-        "animationFrequencyTimeAverageOffset": 0,
-        "outputFields": [],
-        "outputFormat": "paraview",
-        "startAverageIntegrationStep": -1,
-        "surfaces": {
-            "1": {
-                "outputFields": [
-                    "Cp"
-                ]
+    "surfaceOutput": [
+        {
+            "animationFrequency": -1,
+            "animationFrequencyOffset": 0,
+            "animationFrequencyTimeAverage": -1,
+            "animationFrequencyTimeAverageOffset": 0,
+            "name": "",
+            "outputFields": [],
+            "outputFormat": "paraview",
+            "startAverageIntegrationStep": -1,
+            "surfaces": {
+                "1": {
+                    "outputFields": [
+                        "Cp"
+                    ]
+                },
+                "2": {
+                    "outputFields": [
+                        "Cp"
+                    ]
+                },
+                "3": {
+                    "outputFields": [
+                        "Cp"
+                    ]
+                }
             },
-            "2": {
-                "outputFields": [
-                    "Cp"
-                ]
-            },
-            "3": {
-                "outputFields": [
-                    "Cp"
-                ]
-            }
-        },
-        "writeSingleFile": false
-    },
+            "writeSingleFile": false
+        }
+    ],
     "thermallyPerfectGasModel": {
         "temperatureRanges": [
             {

--- a/tests/simulation/translator/ref/Flow360_om6wing_FS_with_vel_expression.json
+++ b/tests/simulation/translator/ref/Flow360_om6wing_FS_with_vel_expression.json
@@ -109,33 +109,36 @@
         },
         "startAverageIntegrationStep": -1
     },
-    "surfaceOutput": {
-        "animationFrequency": -1,
-        "animationFrequencyOffset": 0,
-        "animationFrequencyTimeAverage": -1,
-        "animationFrequencyTimeAverageOffset": 0,
-        "outputFields": [],
-        "outputFormat": "paraview",
-        "startAverageIntegrationStep": -1,
-        "surfaces": {
-            "1": {
-                "outputFields": [
-                    "Cp"
-                ]
+    "surfaceOutput": [
+        {
+            "animationFrequency": -1,
+            "animationFrequencyOffset": 0,
+            "animationFrequencyTimeAverage": -1,
+            "animationFrequencyTimeAverageOffset": 0,
+            "name": "",
+            "outputFields": [],
+            "outputFormat": "paraview",
+            "startAverageIntegrationStep": -1,
+            "surfaces": {
+                "1": {
+                    "outputFields": [
+                        "Cp"
+                    ]
+                },
+                "2": {
+                    "outputFields": [
+                        "Cp"
+                    ]
+                },
+                "3": {
+                    "outputFields": [
+                        "Cp"
+                    ]
+                }
             },
-            "2": {
-                "outputFields": [
-                    "Cp"
-                ]
-            },
-            "3": {
-                "outputFields": [
-                    "Cp"
-                ]
-            }
-        },
-        "writeSingleFile": false
-    },
+            "writeSingleFile": false
+        }
+    ],
     "thermallyPerfectGasModel": {
         "temperatureRanges": [
             {

--- a/tests/simulation/translator/ref/Flow360_om6wing_SA_with_modified_C_w2.json
+++ b/tests/simulation/translator/ref/Flow360_om6wing_SA_with_modified_C_w2.json
@@ -104,33 +104,36 @@
         },
         "startAverageIntegrationStep": -1
     },
-    "surfaceOutput": {
-        "animationFrequency": -1,
-        "animationFrequencyOffset": 0,
-        "animationFrequencyTimeAverage": -1,
-        "animationFrequencyTimeAverageOffset": 0,
-        "outputFields": [],
-        "outputFormat": "paraview",
-        "startAverageIntegrationStep": -1,
-        "surfaces": {
-            "1": {
-                "outputFields": [
-                    "Cp"
-                ]
+    "surfaceOutput": [
+        {
+            "animationFrequency": -1,
+            "animationFrequencyOffset": 0,
+            "animationFrequencyTimeAverage": -1,
+            "animationFrequencyTimeAverageOffset": 0,
+            "name": "",
+            "outputFields": [],
+            "outputFormat": "paraview",
+            "startAverageIntegrationStep": -1,
+            "surfaces": {
+                "1": {
+                    "outputFields": [
+                        "Cp"
+                    ]
+                },
+                "2": {
+                    "outputFields": [
+                        "Cp"
+                    ]
+                },
+                "3": {
+                    "outputFields": [
+                        "Cp"
+                    ]
+                }
             },
-            "2": {
-                "outputFields": [
-                    "Cp"
-                ]
-            },
-            "3": {
-                "outputFields": [
-                    "Cp"
-                ]
-            }
-        },
-        "writeSingleFile": false
-    },
+            "writeSingleFile": false
+        }
+    ],
     "thermallyPerfectGasModel": {
         "temperatureRanges": [
             {

--- a/tests/simulation/translator/ref/Flow360_om6wing_SST_with_modified_C_sigma_omega1.json
+++ b/tests/simulation/translator/ref/Flow360_om6wing_SST_with_modified_C_sigma_omega1.json
@@ -104,33 +104,36 @@
         },
         "startAverageIntegrationStep": -1
     },
-    "surfaceOutput": {
-        "animationFrequency": -1,
-        "animationFrequencyOffset": 0,
-        "animationFrequencyTimeAverage": -1,
-        "animationFrequencyTimeAverageOffset": 0,
-        "outputFields": [],
-        "outputFormat": "paraview",
-        "startAverageIntegrationStep": -1,
-        "surfaces": {
-            "1": {
-                "outputFields": [
-                    "Cp"
-                ]
+    "surfaceOutput": [
+        {
+            "animationFrequency": -1,
+            "animationFrequencyOffset": 0,
+            "animationFrequencyTimeAverage": -1,
+            "animationFrequencyTimeAverageOffset": 0,
+            "name": "",
+            "outputFields": [],
+            "outputFormat": "paraview",
+            "startAverageIntegrationStep": -1,
+            "surfaces": {
+                "1": {
+                    "outputFields": [
+                        "Cp"
+                    ]
+                },
+                "2": {
+                    "outputFields": [
+                        "Cp"
+                    ]
+                },
+                "3": {
+                    "outputFields": [
+                        "Cp"
+                    ]
+                }
             },
-            "2": {
-                "outputFields": [
-                    "Cp"
-                ]
-            },
-            "3": {
-                "outputFields": [
-                    "Cp"
-                ]
-            }
-        },
-        "writeSingleFile": false
-    },
+            "writeSingleFile": false
+        }
+    ],
     "thermallyPerfectGasModel": {
         "temperatureRanges": [
             {

--- a/tests/simulation/translator/ref/Flow360_om6wing_render.json
+++ b/tests/simulation/translator/ref/Flow360_om6wing_render.json
@@ -327,33 +327,36 @@
         },
         "startAverageIntegrationStep": -1
     },
-    "surfaceOutput": {
-        "animationFrequency": -1,
-        "animationFrequencyOffset": 0,
-        "animationFrequencyTimeAverage": -1,
-        "animationFrequencyTimeAverageOffset": 0,
-        "outputFields": [],
-        "outputFormat": "paraview",
-        "startAverageIntegrationStep": -1,
-        "surfaces": {
-            "1": {
-                "outputFields": [
-                    "Cp"
-                ]
+    "surfaceOutput": [
+        {
+            "animationFrequency": -1,
+            "animationFrequencyOffset": 0,
+            "animationFrequencyTimeAverage": -1,
+            "animationFrequencyTimeAverageOffset": 0,
+            "name": "",
+            "outputFields": [],
+            "outputFormat": "paraview",
+            "startAverageIntegrationStep": -1,
+            "surfaces": {
+                "1": {
+                    "outputFields": [
+                        "Cp"
+                    ]
+                },
+                "2": {
+                    "outputFields": [
+                        "Cp"
+                    ]
+                },
+                "3": {
+                    "outputFields": [
+                        "Cp"
+                    ]
+                }
             },
-            "2": {
-                "outputFields": [
-                    "Cp"
-                ]
-            },
-            "3": {
-                "outputFields": [
-                    "Cp"
-                ]
-            }
-        },
-        "writeSingleFile": false
-    },
+            "writeSingleFile": false
+        }
+    ],
     "thermallyPerfectGasModel": {
         "temperatureRanges": [
             {

--- a/tests/simulation/translator/ref/Flow360_om6wing_stopping_criterion_and_moving_statistic.json
+++ b/tests/simulation/translator/ref/Flow360_om6wing_stopping_criterion_and_moving_statistic.json
@@ -184,33 +184,36 @@
         },
         "startAverageIntegrationStep": -1
     },
-    "surfaceOutput": {
-        "animationFrequency": -1,
-        "animationFrequencyOffset": 0,
-        "animationFrequencyTimeAverage": -1,
-        "animationFrequencyTimeAverageOffset": 0,
-        "outputFields": [],
-        "outputFormat": "paraview",
-        "startAverageIntegrationStep": -1,
-        "surfaces": {
-            "1": {
-                "outputFields": [
-                    "Cp"
-                ]
+    "surfaceOutput": [
+        {
+            "animationFrequency": -1,
+            "animationFrequencyOffset": 0,
+            "animationFrequencyTimeAverage": -1,
+            "animationFrequencyTimeAverageOffset": 0,
+            "name": "",
+            "outputFields": [],
+            "outputFormat": "paraview",
+            "startAverageIntegrationStep": -1,
+            "surfaces": {
+                "1": {
+                    "outputFields": [
+                        "Cp"
+                    ]
+                },
+                "2": {
+                    "outputFields": [
+                        "Cp"
+                    ]
+                },
+                "3": {
+                    "outputFields": [
+                        "Cp"
+                    ]
+                }
             },
-            "2": {
-                "outputFields": [
-                    "Cp"
-                ]
-            },
-            "3": {
-                "outputFields": [
-                    "Cp"
-                ]
-            }
-        },
-        "writeSingleFile": false
-    },
+            "writeSingleFile": false
+        }
+    ],
     "thermallyPerfectGasModel": {
         "temperatureRanges": [
             {

--- a/tests/simulation/translator/ref/Flow360_om6wing_streamlines.json
+++ b/tests/simulation/translator/ref/Flow360_om6wing_streamlines.json
@@ -160,33 +160,36 @@
             "velocity_SI"
         ]
     },
-    "surfaceOutput": {
-        "animationFrequency": -1,
-        "animationFrequencyOffset": 0,
-        "animationFrequencyTimeAverage": -1,
-        "animationFrequencyTimeAverageOffset": 0,
-        "outputFields": [],
-        "outputFormat": "paraview",
-        "startAverageIntegrationStep": -1,
-        "surfaces": {
-            "1": {
-                "outputFields": [
-                    "Cp"
-                ]
+    "surfaceOutput": [
+        {
+            "animationFrequency": -1,
+            "animationFrequencyOffset": 0,
+            "animationFrequencyTimeAverage": -1,
+            "animationFrequencyTimeAverageOffset": 0,
+            "name": "",
+            "outputFields": [],
+            "outputFormat": "paraview",
+            "startAverageIntegrationStep": -1,
+            "surfaces": {
+                "1": {
+                    "outputFields": [
+                        "Cp"
+                    ]
+                },
+                "2": {
+                    "outputFields": [
+                        "Cp"
+                    ]
+                },
+                "3": {
+                    "outputFields": [
+                        "Cp"
+                    ]
+                }
             },
-            "2": {
-                "outputFields": [
-                    "Cp"
-                ]
-            },
-            "3": {
-                "outputFields": [
-                    "Cp"
-                ]
-            }
-        },
-        "writeSingleFile": false
-    },
+            "writeSingleFile": false
+        }
+    ],
     "thermallyPerfectGasModel": {
         "temperatureRanges": [
             {

--- a/tests/simulation/translator/ref/Flow360_om6wing_wall_model.json
+++ b/tests/simulation/translator/ref/Flow360_om6wing_wall_model.json
@@ -71,33 +71,36 @@
     "runControl": {
         "externalProcessMonitorOutput": false
     },
-    "surfaceOutput": {
-        "animationFrequency": -1,
-        "animationFrequencyOffset": 0,
-        "animationFrequencyTimeAverage": -1,
-        "animationFrequencyTimeAverageOffset": 0,
-        "outputFields": [],
-        "outputFormat": "paraview",
-        "startAverageIntegrationStep": -1,
-        "surfaces": {
-            "1": {
-                "outputFields": [
-                    "nuHat"
-                ]
+    "surfaceOutput": [
+        {
+            "animationFrequency": -1,
+            "animationFrequencyOffset": 0,
+            "animationFrequencyTimeAverage": -1,
+            "animationFrequencyTimeAverageOffset": 0,
+            "name": "",
+            "outputFields": [],
+            "outputFormat": "paraview",
+            "startAverageIntegrationStep": -1,
+            "surfaces": {
+                "1": {
+                    "outputFields": [
+                        "nuHat"
+                    ]
+                },
+                "2": {
+                    "outputFields": [
+                        "nuHat"
+                    ]
+                },
+                "3": {
+                    "outputFields": [
+                        "nuHat"
+                    ]
+                }
             },
-            "2": {
-                "outputFields": [
-                    "nuHat"
-                ]
-            },
-            "3": {
-                "outputFields": [
-                    "nuHat"
-                ]
-            }
-        },
-        "writeSingleFile": false
-    },
+            "writeSingleFile": false
+        }
+    ],
     "thermallyPerfectGasModel": {
         "temperatureRanges": [
             {

--- a/tests/simulation/translator/ref/Flow360_plateASI.json
+++ b/tests/simulation/translator/ref/Flow360_plateASI.json
@@ -73,23 +73,26 @@
     "runControl": {
         "externalProcessMonitorOutput": false
     },
-    "surfaceOutput": {
-        "animationFrequency": -1,
-        "animationFrequencyOffset": 0,
-        "animationFrequencyTimeAverage": -1,
-        "animationFrequencyTimeAverageOffset": 0,
-        "outputFields": [],
-        "outputFormat": "paraview",
-        "startAverageIntegrationStep": -1,
-        "surfaces": {
-            "plateBlock/noSlipWall": {
-                "outputFields": [
-                    "Cp"
-                ]
-            }
-        },
-        "writeSingleFile": false
-    },
+    "surfaceOutput": [
+        {
+            "animationFrequency": -1,
+            "animationFrequencyOffset": 0,
+            "animationFrequencyTimeAverage": -1,
+            "animationFrequencyTimeAverageOffset": 0,
+            "name": "",
+            "outputFields": [],
+            "outputFormat": "paraview",
+            "startAverageIntegrationStep": -1,
+            "surfaces": {
+                "plateBlock/noSlipWall": {
+                    "outputFields": [
+                        "Cp"
+                    ]
+                }
+            },
+            "writeSingleFile": false
+        }
+    ],
     "thermallyPerfectGasModel": {
         "temperatureRanges": [
             {

--- a/tests/simulation/translator/ref/Flow360_porous_jump.json
+++ b/tests/simulation/translator/ref/Flow360_porous_jump.json
@@ -79,73 +79,76 @@
     "runControl": {
         "externalProcessMonitorOutput": false
     },
-    "surfaceOutput": {
-        "animationFrequency": -1,
-        "animationFrequencyOffset": 0,
-        "animationFrequencyTimeAverage": -1,
-        "animationFrequencyTimeAverageOffset": 0,
-        "outputFields": [],
-        "outputFormat": "paraview",
-        "startAverageIntegrationStep": -1,
-        "surfaces": {
-            "blk-1/outflow": {
-                "outputFields": [
-                    "Cf",
-                    "CfVec",
-                    "Cp",
-                    "Mach",
-                    "primitiveVars",
-                    "wallDistance",
-                    "yPlus"
-                ]
+    "surfaceOutput": [
+        {
+            "animationFrequency": -1,
+            "animationFrequencyOffset": 0,
+            "animationFrequencyTimeAverage": -1,
+            "animationFrequencyTimeAverageOffset": 0,
+            "name": "",
+            "outputFields": [],
+            "outputFormat": "paraview",
+            "startAverageIntegrationStep": -1,
+            "surfaces": {
+                "blk-1/outflow": {
+                    "outputFields": [
+                        "Cf",
+                        "CfVec",
+                        "Cp",
+                        "Mach",
+                        "primitiveVars",
+                        "wallDistance",
+                        "yPlus"
+                    ]
+                },
+                "blk-1/slip": {
+                    "outputFields": [
+                        "Cf",
+                        "CfVec",
+                        "Cp",
+                        "Mach",
+                        "primitiveVars",
+                        "wallDistance",
+                        "yPlus"
+                    ]
+                },
+                "blk-2/slip": {
+                    "outputFields": [
+                        "Cf",
+                        "CfVec",
+                        "Cp",
+                        "Mach",
+                        "primitiveVars",
+                        "wallDistance",
+                        "yPlus"
+                    ]
+                },
+                "blk-3/inflow": {
+                    "outputFields": [
+                        "Cf",
+                        "CfVec",
+                        "Cp",
+                        "Mach",
+                        "primitiveVars",
+                        "wallDistance",
+                        "yPlus"
+                    ]
+                },
+                "blk-3/slip": {
+                    "outputFields": [
+                        "Cf",
+                        "CfVec",
+                        "Cp",
+                        "Mach",
+                        "primitiveVars",
+                        "wallDistance",
+                        "yPlus"
+                    ]
+                }
             },
-            "blk-1/slip": {
-                "outputFields": [
-                    "Cf",
-                    "CfVec",
-                    "Cp",
-                    "Mach",
-                    "primitiveVars",
-                    "wallDistance",
-                    "yPlus"
-                ]
-            },
-            "blk-2/slip": {
-                "outputFields": [
-                    "Cf",
-                    "CfVec",
-                    "Cp",
-                    "Mach",
-                    "primitiveVars",
-                    "wallDistance",
-                    "yPlus"
-                ]
-            },
-            "blk-3/inflow": {
-                "outputFields": [
-                    "Cf",
-                    "CfVec",
-                    "Cp",
-                    "Mach",
-                    "primitiveVars",
-                    "wallDistance",
-                    "yPlus"
-                ]
-            },
-            "blk-3/slip": {
-                "outputFields": [
-                    "Cf",
-                    "CfVec",
-                    "Cp",
-                    "Mach",
-                    "primitiveVars",
-                    "wallDistance",
-                    "yPlus"
-                ]
-            }
-        },
-        "writeSingleFile": false
-    },
+            "writeSingleFile": false
+        }
+    ],
     "thermallyPerfectGasModel": {
         "temperatureRanges": [
             {

--- a/tests/simulation/translator/ref/Flow360_porous_media_box.json
+++ b/tests/simulation/translator/ref/Flow360_porous_media_box.json
@@ -105,73 +105,76 @@
         "externalProcessMonitorOutput": true,
         "monitorProcessorHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
     },
-    "surfaceOutput": {
-        "animationFrequency": -1,
-        "animationFrequencyOffset": 0,
-        "animationFrequencyTimeAverage": -1,
-        "animationFrequencyTimeAverageOffset": 0,
-        "outputFields": [],
-        "outputFormat": "paraview",
-        "startAverageIntegrationStep": -1,
-        "surfaces": {
-            "blk-1/xblocks": {
-                "outputFields": [
-                    "Cp",
-                    "Cf",
-                    "CfVec",
-                    "primitiveVars",
-                    "yPlus",
-                    "Mach",
-                    "wallDistance"
-                ]
+    "surfaceOutput": [
+        {
+            "animationFrequency": -1,
+            "animationFrequencyOffset": 0,
+            "animationFrequencyTimeAverage": -1,
+            "animationFrequencyTimeAverageOffset": 0,
+            "name": "",
+            "outputFields": [],
+            "outputFormat": "paraview",
+            "startAverageIntegrationStep": -1,
+            "surfaces": {
+                "blk-1/xblocks": {
+                    "outputFields": [
+                        "Cp",
+                        "Cf",
+                        "CfVec",
+                        "primitiveVars",
+                        "yPlus",
+                        "Mach",
+                        "wallDistance"
+                    ]
+                },
+                "blk-1/xblocks2": {
+                    "outputFields": [
+                        "Cp",
+                        "Cf",
+                        "CfVec",
+                        "primitiveVars",
+                        "yPlus",
+                        "Mach",
+                        "wallDistance"
+                    ]
+                },
+                "blk-1/yblocks": {
+                    "outputFields": [
+                        "Cp",
+                        "Cf",
+                        "CfVec",
+                        "primitiveVars",
+                        "yPlus",
+                        "Mach",
+                        "wallDistance"
+                    ]
+                },
+                "blk-1/yblocks2": {
+                    "outputFields": [
+                        "Cp",
+                        "Cf",
+                        "CfVec",
+                        "primitiveVars",
+                        "yPlus",
+                        "Mach",
+                        "wallDistance"
+                    ]
+                },
+                "blk-1/zblocks": {
+                    "outputFields": [
+                        "Cp",
+                        "Cf",
+                        "CfVec",
+                        "primitiveVars",
+                        "yPlus",
+                        "Mach",
+                        "wallDistance"
+                    ]
+                }
             },
-            "blk-1/xblocks2": {
-                "outputFields": [
-                    "Cp",
-                    "Cf",
-                    "CfVec",
-                    "primitiveVars",
-                    "yPlus",
-                    "Mach",
-                    "wallDistance"
-                ]
-            },
-            "blk-1/yblocks": {
-                "outputFields": [
-                    "Cp",
-                    "Cf",
-                    "CfVec",
-                    "primitiveVars",
-                    "yPlus",
-                    "Mach",
-                    "wallDistance"
-                ]
-            },
-            "blk-1/yblocks2": {
-                "outputFields": [
-                    "Cp",
-                    "Cf",
-                    "CfVec",
-                    "primitiveVars",
-                    "yPlus",
-                    "Mach",
-                    "wallDistance"
-                ]
-            },
-            "blk-1/zblocks": {
-                "outputFields": [
-                    "Cp",
-                    "Cf",
-                    "CfVec",
-                    "primitiveVars",
-                    "yPlus",
-                    "Mach",
-                    "wallDistance"
-                ]
-            }
-        },
-        "writeSingleFile": false
-    },
+            "writeSingleFile": false
+        }
+    ],
     "thermallyPerfectGasModel": {
         "temperatureRanges": [
             {

--- a/tests/simulation/translator/ref/Flow360_porous_media_volume_zone.json
+++ b/tests/simulation/translator/ref/Flow360_porous_media_volume_zone.json
@@ -96,73 +96,76 @@
         "externalProcessMonitorOutput": true,
         "monitorProcessorHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
     },
-    "surfaceOutput": {
-        "animationFrequency": -1,
-        "animationFrequencyOffset": 0,
-        "animationFrequencyTimeAverage": -1,
-        "animationFrequencyTimeAverageOffset": 0,
-        "outputFields": [],
-        "outputFormat": "paraview",
-        "startAverageIntegrationStep": -1,
-        "surfaces": {
-            "blk-1/outflow": {
-                "outputFields": [
-                    "Cp",
-                    "Cf",
-                    "CfVec",
-                    "primitiveVars",
-                    "yPlus",
-                    "Mach",
-                    "wallDistance"
-                ]
+    "surfaceOutput": [
+        {
+            "animationFrequency": -1,
+            "animationFrequencyOffset": 0,
+            "animationFrequencyTimeAverage": -1,
+            "animationFrequencyTimeAverageOffset": 0,
+            "name": "",
+            "outputFields": [],
+            "outputFormat": "paraview",
+            "startAverageIntegrationStep": -1,
+            "surfaces": {
+                "blk-1/outflow": {
+                    "outputFields": [
+                        "Cp",
+                        "Cf",
+                        "CfVec",
+                        "primitiveVars",
+                        "yPlus",
+                        "Mach",
+                        "wallDistance"
+                    ]
+                },
+                "blk-1/slip": {
+                    "outputFields": [
+                        "Cp",
+                        "Cf",
+                        "CfVec",
+                        "primitiveVars",
+                        "yPlus",
+                        "Mach",
+                        "wallDistance"
+                    ]
+                },
+                "blk-2/slip": {
+                    "outputFields": [
+                        "Cp",
+                        "Cf",
+                        "CfVec",
+                        "primitiveVars",
+                        "yPlus",
+                        "Mach",
+                        "wallDistance"
+                    ]
+                },
+                "blk-3/inflow": {
+                    "outputFields": [
+                        "Cp",
+                        "Cf",
+                        "CfVec",
+                        "primitiveVars",
+                        "yPlus",
+                        "Mach",
+                        "wallDistance"
+                    ]
+                },
+                "blk-3/slip": {
+                    "outputFields": [
+                        "Cp",
+                        "Cf",
+                        "CfVec",
+                        "primitiveVars",
+                        "yPlus",
+                        "Mach",
+                        "wallDistance"
+                    ]
+                }
             },
-            "blk-1/slip": {
-                "outputFields": [
-                    "Cp",
-                    "Cf",
-                    "CfVec",
-                    "primitiveVars",
-                    "yPlus",
-                    "Mach",
-                    "wallDistance"
-                ]
-            },
-            "blk-2/slip": {
-                "outputFields": [
-                    "Cp",
-                    "Cf",
-                    "CfVec",
-                    "primitiveVars",
-                    "yPlus",
-                    "Mach",
-                    "wallDistance"
-                ]
-            },
-            "blk-3/inflow": {
-                "outputFields": [
-                    "Cp",
-                    "Cf",
-                    "CfVec",
-                    "primitiveVars",
-                    "yPlus",
-                    "Mach",
-                    "wallDistance"
-                ]
-            },
-            "blk-3/slip": {
-                "outputFields": [
-                    "Cp",
-                    "Cf",
-                    "CfVec",
-                    "primitiveVars",
-                    "yPlus",
-                    "Mach",
-                    "wallDistance"
-                ]
-            }
-        },
-        "writeSingleFile": false
-    },
+            "writeSingleFile": false
+        }
+    ],
     "thermallyPerfectGasModel": {
         "temperatureRanges": [
             {

--- a/tests/simulation/translator/ref/Flow360_symmetryBC.json
+++ b/tests/simulation/translator/ref/Flow360_symmetryBC.json
@@ -56,26 +56,29 @@
     "runControl": {
         "externalProcessMonitorOutput": false
     },
-    "surfaceOutput": {
-        "animationFrequency": -1,
-        "animationFrequencyOffset": 0,
-        "animationFrequencyTimeAverage": -1,
-        "animationFrequencyTimeAverageOffset": 0,
-        "outputFields": [],
-        "outputFormat": "paraview",
-        "startAverageIntegrationStep": -1,
-        "surfaces": {
-            "fluid/wall": {
-                "outputFields": [
-                    "primitiveVars",
-                    "Cp",
-                    "Cf",
-                    "yPlus"
-                ]
-            }
-        },
-        "writeSingleFile": false
-    },
+    "surfaceOutput": [
+        {
+            "animationFrequency": -1,
+            "animationFrequencyOffset": 0,
+            "animationFrequencyTimeAverage": -1,
+            "animationFrequencyTimeAverageOffset": 0,
+            "name": "",
+            "outputFields": [],
+            "outputFormat": "paraview",
+            "startAverageIntegrationStep": -1,
+            "surfaces": {
+                "fluid/wall": {
+                    "outputFields": [
+                        "primitiveVars",
+                        "Cp",
+                        "Cf",
+                        "yPlus"
+                    ]
+                }
+            },
+            "writeSingleFile": false
+        }
+    ],
     "thermallyPerfectGasModel": {
         "temperatureRanges": [
             {

--- a/tests/simulation/translator/ref/Flow360_user_variable.json
+++ b/tests/simulation/translator/ref/Flow360_user_variable.json
@@ -132,26 +132,29 @@
         "externalProcessMonitorOutput": true,
         "monitorProcessorHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
     },
-    "surfaceOutput": {
-        "animationFrequency": -1,
-        "animationFrequencyOffset": 0,
-        "animationFrequencyTimeAverage": -1,
-        "animationFrequencyTimeAverageOffset": 0,
-        "outputFields": [],
-        "outputFormat": "paraview",
-        "startAverageIntegrationStep": -1,
-        "surfaces": {
-            "fluid/body": {
-                "outputFields": [
-                    "cos_deg_res",
-                    "exp_res",
-                    "sin_float_res",
-                    "tan_rad_res"
-                ]
-            }
-        },
-        "writeSingleFile": false
-    },
+    "surfaceOutput": [
+        {
+            "animationFrequency": -1,
+            "animationFrequencyOffset": 0,
+            "animationFrequencyTimeAverage": -1,
+            "animationFrequencyTimeAverageOffset": 0,
+            "name": "surface_output",
+            "outputFields": [],
+            "outputFormat": "paraview",
+            "startAverageIntegrationStep": -1,
+            "surfaces": {
+                "fluid/body": {
+                    "outputFields": [
+                        "cos_deg_res",
+                        "exp_res",
+                        "sin_float_res",
+                        "tan_rad_res"
+                    ]
+                }
+            },
+            "writeSingleFile": false
+        }
+    ],
     "timeStepping": {
         "CFL": {
             "convergenceLimitingFactor": 1.0,

--- a/tests/simulation/translator/ref/Flow360_windtunnel.json
+++ b/tests/simulation/translator/ref/Flow360_windtunnel.json
@@ -99,50 +99,53 @@
     "runControl": {
         "externalProcessMonitorOutput": false
     },
-    "surfaceOutput": {
-        "animationFrequency": -1,
-        "animationFrequencyOffset": 0,
-        "animationFrequencyTimeAverage": -1,
-        "animationFrequencyTimeAverageOffset": 0,
-        "outputFields": [],
-        "outputFormat": "paraview",
-        "startAverageIntegrationStep": -1,
-        "surfaces": {
-            "windTunnelCentralBelt": {
-                "outputFields": [
-                    "Cf",
-                    "Cp",
-                    "primitiveVars",
-                    "yPlus"
-                ]
+    "surfaceOutput": [
+        {
+            "animationFrequency": -1,
+            "animationFrequencyOffset": 0,
+            "animationFrequencyTimeAverage": -1,
+            "animationFrequencyTimeAverageOffset": 0,
+            "name": "",
+            "outputFields": [],
+            "outputFormat": "paraview",
+            "startAverageIntegrationStep": -1,
+            "surfaces": {
+                "windTunnelCentralBelt": {
+                    "outputFields": [
+                        "Cf",
+                        "Cp",
+                        "primitiveVars",
+                        "yPlus"
+                    ]
+                },
+                "windTunnelFloor": {
+                    "outputFields": [
+                        "Cf",
+                        "Cp",
+                        "primitiveVars",
+                        "yPlus"
+                    ]
+                },
+                "windTunnelFrontWheelBelt": {
+                    "outputFields": [
+                        "Cf",
+                        "Cp",
+                        "primitiveVars",
+                        "yPlus"
+                    ]
+                },
+                "windTunnelRearWheelBelt": {
+                    "outputFields": [
+                        "Cf",
+                        "Cp",
+                        "primitiveVars",
+                        "yPlus"
+                    ]
+                }
             },
-            "windTunnelFloor": {
-                "outputFields": [
-                    "Cf",
-                    "Cp",
-                    "primitiveVars",
-                    "yPlus"
-                ]
-            },
-            "windTunnelFrontWheelBelt": {
-                "outputFields": [
-                    "Cf",
-                    "Cp",
-                    "primitiveVars",
-                    "yPlus"
-                ]
-            },
-            "windTunnelRearWheelBelt": {
-                "outputFields": [
-                    "Cf",
-                    "Cp",
-                    "primitiveVars",
-                    "yPlus"
-                ]
-            }
-        },
-        "writeSingleFile": false
-    },
+            "writeSingleFile": false
+        }
+    ],
     "thermallyPerfectGasModel": {
         "temperatureRanges": [
             {

--- a/tests/simulation/translator/ref/Flow360_xv15_bet_disk_nested_rotation.json
+++ b/tests/simulation/translator/ref/Flow360_xv15_bet_disk_nested_rotation.json
@@ -459,26 +459,29 @@
         "externalProcessMonitorOutput": true,
         "monitorProcessorHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
     },
-    "surfaceOutput": {
-        "animationFrequency": -1,
-        "animationFrequencyOffset": 0,
-        "animationFrequencyTimeAverage": -1,
-        "animationFrequencyTimeAverageOffset": 0,
-        "outputFields": [],
-        "outputFormat": "paraview,tecplot",
-        "startAverageIntegrationStep": -1,
-        "surfaces": {
-            "1": {
-                "outputFields": [
-                    "primitiveVars",
-                    "Cp",
-                    "Cf",
-                    "CfVec"
-                ]
-            }
-        },
-        "writeSingleFile": false
-    },
+    "surfaceOutput": [
+        {
+            "animationFrequency": -1,
+            "animationFrequencyOffset": 0,
+            "animationFrequencyTimeAverage": -1,
+            "animationFrequencyTimeAverageOffset": 0,
+            "name": "",
+            "outputFields": [],
+            "outputFormat": "paraview,tecplot",
+            "startAverageIntegrationStep": -1,
+            "surfaces": {
+                "1": {
+                    "outputFields": [
+                        "primitiveVars",
+                        "Cp",
+                        "Cf",
+                        "CfVec"
+                    ]
+                }
+            },
+            "writeSingleFile": false
+        }
+    ],
     "thermallyPerfectGasModel": {
         "temperatureRanges": [
             {

--- a/tests/simulation/translator/ref/Flow360_xv15_bet_disk_steady_airplane.json
+++ b/tests/simulation/translator/ref/Flow360_xv15_bet_disk_steady_airplane.json
@@ -454,26 +454,29 @@
         "externalProcessMonitorOutput": true,
         "monitorProcessorHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
     },
-    "surfaceOutput": {
-        "animationFrequency": -1,
-        "animationFrequencyOffset": 0,
-        "animationFrequencyTimeAverage": -1,
-        "animationFrequencyTimeAverageOffset": 0,
-        "outputFields": [],
-        "outputFormat": "paraview,tecplot",
-        "startAverageIntegrationStep": -1,
-        "surfaces": {
-            "1": {
-                "outputFields": [
-                    "primitiveVars",
-                    "Cp",
-                    "Cf",
-                    "CfVec"
-                ]
-            }
-        },
-        "writeSingleFile": false
-    },
+    "surfaceOutput": [
+        {
+            "animationFrequency": -1,
+            "animationFrequencyOffset": 0,
+            "animationFrequencyTimeAverage": -1,
+            "animationFrequencyTimeAverageOffset": 0,
+            "name": "",
+            "outputFields": [],
+            "outputFormat": "paraview,tecplot",
+            "startAverageIntegrationStep": -1,
+            "surfaces": {
+                "1": {
+                    "outputFields": [
+                        "primitiveVars",
+                        "Cp",
+                        "Cf",
+                        "CfVec"
+                    ]
+                }
+            },
+            "writeSingleFile": false
+        }
+    ],
     "thermallyPerfectGasModel": {
         "temperatureRanges": [
             {

--- a/tests/simulation/translator/ref/Flow360_xv15_bet_disk_steady_hover.json
+++ b/tests/simulation/translator/ref/Flow360_xv15_bet_disk_steady_hover.json
@@ -454,26 +454,29 @@
         "externalProcessMonitorOutput": true,
         "monitorProcessorHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
     },
-    "surfaceOutput": {
-        "animationFrequency": -1,
-        "animationFrequencyOffset": 0,
-        "animationFrequencyTimeAverage": -1,
-        "animationFrequencyTimeAverageOffset": 0,
-        "outputFields": [],
-        "outputFormat": "paraview,tecplot",
-        "startAverageIntegrationStep": -1,
-        "surfaces": {
-            "1": {
-                "outputFields": [
-                    "primitiveVars",
-                    "Cp",
-                    "Cf",
-                    "CfVec"
-                ]
-            }
-        },
-        "writeSingleFile": false
-    },
+    "surfaceOutput": [
+        {
+            "animationFrequency": -1,
+            "animationFrequencyOffset": 0,
+            "animationFrequencyTimeAverage": -1,
+            "animationFrequencyTimeAverageOffset": 0,
+            "name": "",
+            "outputFields": [],
+            "outputFormat": "paraview,tecplot",
+            "startAverageIntegrationStep": -1,
+            "surfaces": {
+                "1": {
+                    "outputFields": [
+                        "primitiveVars",
+                        "Cp",
+                        "Cf",
+                        "CfVec"
+                    ]
+                }
+            },
+            "writeSingleFile": false
+        }
+    ],
     "thermallyPerfectGasModel": {
         "temperatureRanges": [
             {

--- a/tests/simulation/translator/ref/Flow360_xv15_bet_disk_unsteady_hover.json
+++ b/tests/simulation/translator/ref/Flow360_xv15_bet_disk_unsteady_hover.json
@@ -459,26 +459,29 @@
         "externalProcessMonitorOutput": true,
         "monitorProcessorHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
     },
-    "surfaceOutput": {
-        "animationFrequency": -1,
-        "animationFrequencyOffset": 0,
-        "animationFrequencyTimeAverage": -1,
-        "animationFrequencyTimeAverageOffset": 0,
-        "outputFields": [],
-        "outputFormat": "paraview,tecplot",
-        "startAverageIntegrationStep": -1,
-        "surfaces": {
-            "1": {
-                "outputFields": [
-                    "primitiveVars",
-                    "Cp",
-                    "Cf",
-                    "CfVec"
-                ]
-            }
-        },
-        "writeSingleFile": false
-    },
+    "surfaceOutput": [
+        {
+            "animationFrequency": -1,
+            "animationFrequencyOffset": 0,
+            "animationFrequencyTimeAverage": -1,
+            "animationFrequencyTimeAverageOffset": 0,
+            "name": "",
+            "outputFields": [],
+            "outputFormat": "paraview,tecplot",
+            "startAverageIntegrationStep": -1,
+            "surfaces": {
+                "1": {
+                    "outputFields": [
+                        "primitiveVars",
+                        "Cp",
+                        "Cf",
+                        "CfVec"
+                    ]
+                }
+            },
+            "writeSingleFile": false
+        }
+    ],
     "thermallyPerfectGasModel": {
         "temperatureRanges": [
             {

--- a/tests/simulation/translator/ref/Flow360_xv15_bet_disk_unsteady_hover_UDD.json
+++ b/tests/simulation/translator/ref/Flow360_xv15_bet_disk_unsteady_hover_UDD.json
@@ -459,26 +459,29 @@
         "externalProcessMonitorOutput": true,
         "monitorProcessorHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
     },
-    "surfaceOutput": {
-        "animationFrequency": -1,
-        "animationFrequencyOffset": 0,
-        "animationFrequencyTimeAverage": -1,
-        "animationFrequencyTimeAverageOffset": 0,
-        "outputFields": [],
-        "outputFormat": "paraview,tecplot",
-        "startAverageIntegrationStep": -1,
-        "surfaces": {
-            "1": {
-                "outputFields": [
-                    "primitiveVars",
-                    "Cp",
-                    "Cf",
-                    "CfVec"
-                ]
-            }
-        },
-        "writeSingleFile": false
-    },
+    "surfaceOutput": [
+        {
+            "animationFrequency": -1,
+            "animationFrequencyOffset": 0,
+            "animationFrequencyTimeAverage": -1,
+            "animationFrequencyTimeAverageOffset": 0,
+            "name": "",
+            "outputFields": [],
+            "outputFormat": "paraview,tecplot",
+            "startAverageIntegrationStep": -1,
+            "surfaces": {
+                "1": {
+                    "outputFields": [
+                        "primitiveVars",
+                        "Cp",
+                        "Cf",
+                        "CfVec"
+                    ]
+                }
+            },
+            "writeSingleFile": false
+        }
+    ],
     "thermallyPerfectGasModel": {
         "temperatureRanges": [
             {

--- a/tests/simulation/translator/test_output_translation.py
+++ b/tests/simulation/translator/test_output_translation.py
@@ -217,40 +217,56 @@ def surface_output_config(vel_in_km_per_hr):
                 output_format="tecplot",
             ),
         ],
-        {
-            "animationFrequency": 123,
-            "animationFrequencyOffset": 321,
-            "animationFrequencyTimeAverage": -1,
-            "animationFrequencyTimeAverageOffset": 0,
-            "outputFields": [],
-            "outputFormat": "tecplot",
-            "startAverageIntegrationStep": -1,
-            "surfaces": {
-                "surface1": {"outputFields": ["Cp", "velocity_in_km_per_hr"]},
-                "surface11": {
-                    "outputFields": [
-                        "T",
-                        "velocity",
-                        "velocity_in_km_per_hr",
-                        "velocity_magnitude",
-                        "vorticity",
-                        "vorticityMagnitude",
-                    ]
+        [
+            {
+                "animationFrequency": 123,
+                "animationFrequencyOffset": 321,
+                "animationFrequencyTimeAverage": -1,
+                "animationFrequencyTimeAverageOffset": 0,
+                "outputFields": [],
+                "outputFormat": "tecplot",
+                "startAverageIntegrationStep": -1,
+                "surfaces": {
+                    "surface1": {"outputFields": ["Cp", "velocity_in_km_per_hr"]},
+                    "surface2": {"outputFields": ["Cp", "velocity_in_km_per_hr"]},
                 },
-                "surface2": {"outputFields": ["Cp", "velocity_in_km_per_hr"]},
-                "surface22": {
-                    "outputFields": [
-                        "T",
-                        "velocity",
-                        "velocity_in_km_per_hr",
-                        "velocity_magnitude",
-                        "vorticity",
-                        "vorticityMagnitude",
-                    ]
-                },
+                "writeSingleFile": False,
+                "name": "",
             },
-            "writeSingleFile": False,
-        },
+            {
+                "animationFrequency": 123,
+                "animationFrequencyOffset": 321,
+                "animationFrequencyTimeAverage": -1,
+                "animationFrequencyTimeAverageOffset": 0,
+                "outputFields": [],
+                "outputFormat": "tecplot",
+                "startAverageIntegrationStep": -1,
+                "surfaces": {
+                    "surface11": {
+                        "outputFields": [
+                            "T",
+                            "velocity",
+                            "velocity_in_km_per_hr",
+                            "velocity_magnitude",
+                            "vorticity",
+                            "vorticityMagnitude",
+                        ]
+                    },
+                    "surface22": {
+                        "outputFields": [
+                            "T",
+                            "velocity",
+                            "velocity_in_km_per_hr",
+                            "velocity_magnitude",
+                            "vorticity",
+                            "vorticityMagnitude",
+                        ]
+                    },
+                },
+                "writeSingleFile": False,
+                "name": "",
+            },
+        ],
     )
 
 
@@ -275,14 +291,17 @@ def test_surface_output(
     surface_output_config,
     avg_surface_output_config,
 ):
-    ##:: surfaceOutput
+    ##:: surfaceOutput (multiple instances -> array)
     with SI_unit_system:
         param = SimulationParams(outputs=surface_output_config[0])
     translated = {"boundaries": {}}
     translated = translate_output(param, translated)
-    assert compare_values(surface_output_config[1], translated["surfaceOutput"])
+    assert isinstance(translated["surfaceOutput"], list)
+    assert len(translated["surfaceOutput"]) == 2
+    assert compare_values(surface_output_config[1][0], translated["surfaceOutput"][0])
+    assert compare_values(surface_output_config[1][1], translated["surfaceOutput"][1])
 
-    ##:: timeAverageSurfaceOutput and surfaceOutput
+    ##:: timeAverageSurfaceOutput and surfaceOutput (both as arrays)
     with SI_unit_system:
         param = SimulationParams(
             time_stepping=Unsteady(step_size=0.1 * u.s, steps=10),
@@ -290,64 +309,164 @@ def test_surface_output(
         )
     translated = {"boundaries": {}}
     translated = translate_output(param, translated)
-    ref = {
-        "surfaceOutput": {
-            "animationFrequency": 123,
-            "animationFrequencyOffset": 321,
-            "animationFrequencyTimeAverage": -1,
-            "animationFrequencyTimeAverageOffset": 0,
-            "outputFields": [],
-            "outputFormat": "tecplot",
-            "startAverageIntegrationStep": -1,
-            "surfaces": {
-                "surface1": {"outputFields": ["Cp", "velocity_in_km_per_hr"]},
-                "surface11": {
-                    "outputFields": [
-                        "T",
-                        "velocity",
-                        "velocity_in_km_per_hr",
-                        "velocity_magnitude",
-                        "vorticity",
-                        "vorticityMagnitude",
-                    ]
-                },
-                "surface2": {"outputFields": ["Cp", "velocity_in_km_per_hr"]},
-                "surface22": {
-                    "outputFields": [
-                        "T",
-                        "velocity",
-                        "velocity_in_km_per_hr",
-                        "velocity_magnitude",
-                        "vorticity",
-                        "vorticityMagnitude",
-                    ]
-                },
-            },
-            "writeSingleFile": False,
+
+    assert isinstance(translated["surfaceOutput"], list)
+    assert len(translated["surfaceOutput"]) == 2
+    assert compare_values(surface_output_config[1][0], translated["surfaceOutput"][0])
+    assert compare_values(surface_output_config[1][1], translated["surfaceOutput"][1])
+
+    assert isinstance(translated["timeAverageSurfaceOutput"], list)
+    assert len(translated["timeAverageSurfaceOutput"]) == 2
+    ref_avg_0 = {
+        "animationFrequency": -1,
+        "animationFrequencyOffset": 0,
+        "animationFrequencyTimeAverage": 111,
+        "animationFrequencyTimeAverageOffset": 222,
+        "outputFields": [],
+        "outputFormat": "paraview",
+        "startAverageIntegrationStep": -1,
+        "surfaces": {
+            "surface1": {"outputFields": ["Cf", "velocity_in_km_per_hr"]},
+            "surface2": {"outputFields": ["Cf", "velocity_in_km_per_hr"]},
         },
-        "timeAverageSurfaceOutput": {
-            "animationFrequency": -1,
-            "animationFrequencyOffset": 0,
-            "animationFrequencyTimeAverage": 111,
-            "animationFrequencyTimeAverageOffset": 222,
-            "outputFields": [],
-            "outputFormat": "paraview",
-            "startAverageIntegrationStep": -1,
-            "surfaces": {
-                "surface1": {"outputFields": ["Cf", "velocity_in_km_per_hr"]},
-                "surface3": {
-                    "outputFields": [
-                        "primitiveVars",
-                        "velocity_in_km_per_hr",
-                    ]
-                },
-                "surface2": {"outputFields": ["Cf", "velocity_in_km_per_hr"]},
-            },
-            "writeSingleFile": False,
-        },
+        "writeSingleFile": False,
+        "name": "",
     }
-    assert compare_values(ref["surfaceOutput"], translated["surfaceOutput"])
-    assert compare_values(ref["timeAverageSurfaceOutput"], translated["timeAverageSurfaceOutput"])
+    ref_avg_1 = {
+        "animationFrequency": -1,
+        "animationFrequencyOffset": 0,
+        "animationFrequencyTimeAverage": -1,
+        "animationFrequencyTimeAverageOffset": 0,
+        "outputFields": [],
+        "outputFormat": "paraview",
+        "startAverageIntegrationStep": -1,
+        "surfaces": {
+            "surface3": {
+                "outputFields": [
+                    "primitiveVars",
+                    "velocity_in_km_per_hr",
+                ]
+            },
+        },
+        "writeSingleFile": False,
+        "name": "",
+    }
+    assert compare_values(ref_avg_0, translated["timeAverageSurfaceOutput"][0])
+    assert compare_values(ref_avg_1, translated["timeAverageSurfaceOutput"][1])
+
+
+def test_multiple_surface_outputs_same_surface_different_freq():
+    """Test the primary use case: same surface with different frequencies and formats."""
+    with SI_unit_system:
+        param = SimulationParams(
+            outputs=[
+                SurfaceOutput(
+                    name="propeller_coarse",
+                    entities=[Surface(name="propeller")],
+                    output_fields=["Cp"],
+                    output_format="tecplot",
+                    frequency=100,
+                    frequency_offset=0,
+                ),
+                SurfaceOutput(
+                    name="propeller_fine",
+                    entities=[Surface(name="propeller")],
+                    output_fields=["Cp", "primitiveVars"],
+                    output_format="paraview",
+                    frequency=10,
+                    frequency_offset=5,
+                ),
+            ],
+        )
+    translated = {"boundaries": {}}
+    translated = translate_output(param, translated)
+
+    assert isinstance(translated["surfaceOutput"], list)
+    assert len(translated["surfaceOutput"]) == 2
+
+    coarse = translated["surfaceOutput"][0]
+    fine = translated["surfaceOutput"][1]
+
+    assert coarse["name"] == "propeller_coarse"
+    assert coarse["animationFrequency"] == 100
+    assert coarse["outputFormat"] == "tecplot"
+    assert "propeller" in coarse["surfaces"]
+
+    assert fine["name"] == "propeller_fine"
+    assert fine["animationFrequency"] == 10
+    assert fine["animationFrequencyOffset"] == 5
+    assert fine["outputFormat"] == "paraview"
+    assert "propeller" in fine["surfaces"]
+    assert set(fine["surfaces"]["propeller"]["outputFields"]) == {"Cp", "primitiveVars"}
+
+
+def test_multiple_surface_outputs_sorted_by_name():
+    """Translated surface outputs are sorted by name so user reordering doesn't cause diffs."""
+    with SI_unit_system:
+        param = SimulationParams(
+            outputs=[
+                SurfaceOutput(
+                    name="z_last",
+                    entities=[Surface(name="wing")],
+                    output_fields=["Cp"],
+                    frequency=10,
+                ),
+                SurfaceOutput(
+                    name="a_first",
+                    entities=[Surface(name="wing")],
+                    output_fields=["Cp"],
+                    frequency=100,
+                ),
+            ],
+        )
+    translated = {"boundaries": {}}
+    translated = translate_output(param, translated)
+
+    names = [c["name"] for c in translated["surfaceOutput"]]
+    assert names == ["a_first", "z_last"]
+
+
+def test_single_surface_output_emits_array():
+    """Even a single SurfaceOutput should produce an array (solver handles both formats)."""
+    with SI_unit_system:
+        param = SimulationParams(
+            outputs=[
+                SurfaceOutput(
+                    entities=[Surface(name="wing")],
+                    output_fields=["Cp"],
+                    output_format="paraview",
+                ),
+            ],
+        )
+    translated = {"boundaries": {}}
+    translated = translate_output(param, translated)
+
+    assert isinstance(translated["surfaceOutput"], list)
+    assert len(translated["surfaceOutput"]) == 1
+    assert translated["surfaceOutput"][0]["name"] == ""
+    assert "wing" in translated["surfaceOutput"][0]["surfaces"]
+
+
+def test_single_time_average_surface_output_emits_array():
+    """A single TimeAverageSurfaceOutput should also produce an array."""
+    with SI_unit_system:
+        param = SimulationParams(
+            time_stepping=Unsteady(step_size=0.1 * u.s, steps=10),
+            outputs=[
+                TimeAverageSurfaceOutput(
+                    entities=[Surface(name="wing")],
+                    output_fields=["Cp"],
+                    output_format="paraview",
+                ),
+            ],
+        )
+    translated = {"boundaries": {}}
+    translated = translate_output(param, translated)
+
+    assert isinstance(translated["timeAverageSurfaceOutput"], list)
+    assert len(translated["timeAverageSurfaceOutput"]) == 1
+    assert translated["timeAverageSurfaceOutput"][0]["name"] == ""
+    assert "wing" in translated["timeAverageSurfaceOutput"][0]["surfaces"]
 
 
 @pytest.fixture()
@@ -1707,7 +1826,7 @@ def test_dimensioned_output_fields_translation(vel_in_km_per_hr):
     ]
 
     assert set(solver_json["volumeOutput"]["outputFields"]) == set(expected_fields_v)
-    assert set(solver_json["surfaceOutput"]["surfaces"]["surface11"]["outputFields"]) == set(
+    assert set(solver_json["surfaceOutput"][0]["surfaces"]["surface11"]["outputFields"]) == set(
         expected_fields_s
     )
 

--- a/tests/simulation/translator/test_output_translation.py
+++ b/tests/simulation/translator/test_output_translation.py
@@ -447,6 +447,69 @@ def test_single_surface_output_emits_array():
     assert "wing" in translated["surfaceOutput"][0]["surfaces"]
 
 
+def test_default_named_outputs_no_suffix():
+    """Multiple default-named outputs on disjoint surfaces get no suffix (backward compat)."""
+    with SI_unit_system:
+        param = SimulationParams(
+            outputs=[
+                SurfaceOutput(
+                    entities=[Surface(name="wing")],
+                    output_fields=["Cp"],
+                    frequency=10,
+                ),
+                SurfaceOutput(
+                    entities=[Surface(name="tail")],
+                    output_fields=["Cp"],
+                    frequency=100,
+                ),
+                SurfaceOutput(
+                    entities=[Surface(name="body")],
+                    output_fields=["Cp"],
+                    frequency=50,
+                ),
+            ],
+        )
+    translated = {"boundaries": {}}
+    translated = translate_output(param, translated)
+
+    assert len(translated["surfaceOutput"]) == 3
+    names = [c["name"] for c in translated["surfaceOutput"]]
+    assert names == ["", "", ""]
+
+
+def test_mixed_default_and_custom_named_outputs():
+    """Default-named outputs sort before custom-named; defaults get no suffix,
+    customs get _<name> suffix."""
+    with SI_unit_system:
+        param = SimulationParams(
+            outputs=[
+                SurfaceOutput(
+                    name="custom_b",
+                    entities=[Surface(name="wing")],
+                    output_fields=["Cp"],
+                    frequency=10,
+                ),
+                SurfaceOutput(
+                    entities=[Surface(name="tail")],
+                    output_fields=["Cp"],
+                    frequency=100,
+                ),
+                SurfaceOutput(
+                    name="custom_a",
+                    entities=[Surface(name="body")],
+                    output_fields=["Cp"],
+                    frequency=50,
+                ),
+            ],
+        )
+    translated = {"boundaries": {}}
+    translated = translate_output(param, translated)
+
+    assert len(translated["surfaceOutput"]) == 3
+    names = [c["name"] for c in translated["surfaceOutput"]]
+    assert names == ["", "custom_a", "custom_b"]
+
+
 def test_single_time_average_surface_output_emits_array():
     """A single TimeAverageSurfaceOutput should also produce an array."""
     with SI_unit_system:


### PR DESCRIPTION
### Scenario matrix

| # | Outputs | Surfaces | Names | `writeSingleFile` | Result |
|---|---|---|---|---|---|
| 1 | 1 | `wing` | default | false | ✅ `surface_wing` |
| 2 | 1 | `wing, tail` | default | false | ✅ `surface_wing`, `surface_tail` |
| 3 | 1 | `wing, tail` | default | true | ✅ single file: `surfaces` |
| 4 | 2 | `wing` (both) | `coarse`, `fine` | false | ✅ `surface_wing_coarse`, `surface_wing_fine` |
| 5 | 2 | `wing` (both) | `coarse`, `fine` | true | ✅ single files: `surfaces_coarse`, `surfaces_fine` |
| 6 | 2 | `wing`, `tail` | default, default | false | ✅ `surface_wing`, `surface_tail` |
| 7 | 2 | `wing`, `tail` | default, default | true | ❌ **Rule 2**: both default-named with `writeSingleFile` — same empty suffix |
| 8 | 2 | `wing`, `tail` | `a`, `b` | false | ✅ `surface_wing_a`, `surface_tail_b` |
| 9 | 2 | `wing`, `tail` | `a`, `b` | true | ✅ single files: `surfaces_a`, `surfaces_b` |
| 10 | 2 | `wing` (both) | default, default | any | ❌ **Rule 1**: same surface, default names — need unique names |
| 11 | 2 | `wing` (both) | `same`, `same` | any | ❌ **Rule 1**: same surface, duplicate names — need unique names |
| 12 | 2 | `wing`, `tail` | `same`, `same` | false | ✅ `surface_wing_same`, `surface_tail_same` (surface disambiguates) |
| 13 | 2 | `wing`, `tail` | `same`, `same` | true | ❌ **Rule 2**: `writeSingleFile` duplicate suffix — need unique names |
| 14 | 2 | `wing`, `tail` | default, `"0"` | true | ✅ suffixes `""` and `_0` are distinct |
| 15 | 2 | `wing`, `tail` | `shared` (wsf=T), `shared` (wsf=F) | mixed | ✅ only one contributes to single-file map — no collision |
| 16 | 3 | `wing`, `tail`, `body` | `a`, `b`, `c` | true | ✅ single files: `surfaces_a`, `surfaces_b`, `surfaces_c` |
| 17 | 2 | `wing`, `tail` | default, `custom` | false | ✅ `surface_wing`, `surface_tail_custom` |
| V1 | 1 | `wing` | _(legacy, no `name` key)_ | false | ✅ `surface_wing` (solver wraps legacy object in a singleton array) |

### Validation rules

- **Rule 1 — Shared-surface uniqueness.** When multiple instances of the same output type (`SurfaceOutput` or `TimeAverageSurfaceOutput`) reference the same surface, every sharing instance must have a unique, non-default `name`. *(Catches #10, #11.)*
- **Rule 2 — `writeSingleFile` suffix uniqueness.** Among instances of the same output type with `write_single_file=True`, no two may resolve to the same filename suffix. Default-named outputs get no suffix; custom-named outputs get `_<name>`. *(Catches #7, #13.)*

### Backward compatibility preserved

- Single `SurfaceOutput` with one or more surfaces produces identical filenames to master. *(#1, #2, #3)*
- Multiple default-named outputs on disjoint surfaces produce identical filenames to master — no index-based suffixes are added. *(#6, #17)*
- Mixed `writeSingleFile=True/False` with the same name on disjoint surfaces works: only `writeSingleFile=True` instances contribute to the single-file collision check. *(#15)*
- Legacy single-object JSON (no `name` key) continues to work; the solver wraps it in a singleton array. *(V1)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the solver JSON schema for `surfaceOutput`/`timeAverageSurfaceOutput` from a single object to an array of per-instance configs, which can break downstream consumers expecting the legacy shape.
> 
> **Overview**
> **Surface output translation now supports multiple independent `SurfaceOutput`/`TimeAverageSurfaceOutput` instances.** The translator emits `surfaceOutput` and `timeAverageSurfaceOutput` as *lists* of per-instance solver config dicts (instead of a single merged object), allowing the same surface to be output with different frequencies/formats.
> 
> Each emitted surface-output config now includes a normalized `name` (default name becomes empty string), uses the instance’s `writeSingleFile`, and the resulting list is sorted by `name` for stable diffs. Tests and reference solver JSON fixtures are updated accordingly (including integration metadata assertions) to index into `surfaceOutput[0]` and validate ordering/behavior for multiple outputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 161acba0d0c3595adf841f70762a6477729a8865. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->