### PR TITLE
Add beta geometry processor flag to Project.from_geometry

### DIFF
--- a/flow360/component/project.py
+++ b/flow360/component/project.py
@@ -1179,8 +1179,9 @@ class Project(pd.BaseModel):
         folder : Optional[Folder], optional
             Parent folder for the project. If None, creates in root.
         beta_geometry_processor : bool, optional
-            Route geometry processing through the beta Nextflow-based geometry
-            processor instead of the legacy geometry pipeline (default is False).
+            Use the beta geometry processor for project geometry preparation,
+            intended for downstream meshing workflows such as GAI and snappy
+            meshing (default is False).
 
         Returns
         -------

--- a/flow360/component/project.py
+++ b/flow360/component/project.py
@@ -931,6 +931,7 @@ class Project(pd.BaseModel):
         tags: List[str] = None,
         run_async: bool = False,
         folder: Optional[Folder] = None,
+        beta_geometry_processor: bool = False,
     ):
         """
         Initializes a project from a file.
@@ -969,7 +970,13 @@ class Project(pd.BaseModel):
 
         if isinstance(files, GeometryFiles):
             draft = Geometry.from_file(
-                files.file_names, name, solver_version, length_unit, tags, folder=folder
+                files.file_names,
+                name,
+                solver_version,
+                length_unit,
+                tags,
+                folder=folder,
+                use_nextflow_pipelines=beta_geometry_processor,
             )
         elif isinstance(files, SurfaceMeshFile):
             draft = SurfaceMeshV2.from_file(
@@ -1150,6 +1157,7 @@ class Project(pd.BaseModel):
         tags: List[str] = None,
         run_async: bool = False,
         folder: Optional[Folder] = None,
+        beta_geometry_processor: bool = False,
     ):
         """
         Initializes a project from local geometry files.
@@ -1170,6 +1178,9 @@ class Project(pd.BaseModel):
             Whether to create project asynchronously (default is False).
         folder : Optional[Folder], optional
             Parent folder for the project. If None, creates in root.
+        beta_geometry_processor : bool, optional
+            Route geometry processing through the beta Nextflow-based geometry
+            processor instead of the legacy geometry pipeline (default is False).
 
         Returns
         -------
@@ -1205,6 +1216,7 @@ class Project(pd.BaseModel):
             tags=tags,
             run_async=run_async,
             folder=folder,
+            beta_geometry_processor=beta_geometry_processor,
         )
 
     @classmethod

--- a/tests/simulation/test_project.py
+++ b/tests/simulation/test_project.py
@@ -95,7 +95,7 @@ def test_from_geometry_passes_beta_geometry_processor(monkeypatch):
     )
 
     assert project_id == "prj-test-project-id"
-    assert captured["file_names"] == [Cylinder3D.geometry]
+    assert captured["file_names"] == Cylinder3D.geometry
     assert captured["project_name"] == "beta-geo-project"
     assert captured["solver_version"] == "release-test"
     assert captured["length_unit"] == "cm"

--- a/tests/simulation/test_project.py
+++ b/tests/simulation/test_project.py
@@ -57,6 +57,50 @@ def test_from_cloud(mock_id, mock_response):
         project.get_case(asset_id=current_case_id)
 
 
+def test_from_geometry_passes_beta_geometry_processor(monkeypatch):
+    Cylinder3D.get_files()
+    captured = {}
+
+    class _MockDraft:
+        def submit(self, run_async=False):
+            assert run_async is True
+            return MagicMock(project_id="prj-test-project-id")
+
+    def _mock_from_file(
+        file_names,
+        project_name=None,
+        solver_version=None,
+        length_unit="m",
+        tags=None,
+        folder=None,
+        use_nextflow_pipelines=False,
+    ):
+        captured["file_names"] = file_names
+        captured["project_name"] = project_name
+        captured["solver_version"] = solver_version
+        captured["length_unit"] = length_unit
+        captured["use_nextflow_pipelines"] = use_nextflow_pipelines
+        return _MockDraft()
+
+    monkeypatch.setattr("flow360.component.project.Geometry.from_file", _mock_from_file)
+
+    project_id = fl.Project.from_geometry(
+        Cylinder3D.geometry,
+        name="beta-geo-project",
+        solver_version="release-test",
+        length_unit="cm",
+        run_async=True,
+        beta_geometry_processor=True,
+    )
+
+    assert project_id == "prj-test-project-id"
+    assert captured["file_names"] == [Cylinder3D.geometry]
+    assert captured["project_name"] == "beta-geo-project"
+    assert captured["solver_version"] == "release-test"
+    assert captured["length_unit"] == "cm"
+    assert captured["use_nextflow_pipelines"] is True
+
+
 def test_root_asset_entity_change_reflection(mock_id, mock_response):
     project = fl.Project.from_cloud(project_id="prj-41d2333b-85fd-4bed-ae13-15dcb6da519e")
     geo = project.geometry

--- a/tests/simulation/test_project.py
+++ b/tests/simulation/test_project.py
@@ -16,6 +16,7 @@ from flow360.component.simulation.primitives import ImportedSurface
 from flow360.component.simulation.services import ValidationCalledBy, validate_model
 from flow360.component.simulation.utils import model_attribute_unlock
 from flow360.component.volume_mesh import VolumeMeshV2
+from flow360.examples import Cylinder3D
 from flow360.exceptions import Flow360ConfigurationError, Flow360ValueError
 
 log.set_logging_level("DEBUG")


### PR DESCRIPTION
## Summary
- add the beta_geometry_processor argument to Project.from_geometry
- map it to Geometry.from_file(..., use_nextflow_pipelines=...) for geometry-root project creation
- add a focused regression test for the flag passthrough

## Testing
- python3 -m py_compile flow360/component/project.py tests/simulation/test_project.py
- full pytest target could not be run in this shell because the available Python environment does not have project dependencies installed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new opt-in flag that changes which geometry processing pipeline is used when creating geometry-root projects, which could alter downstream meshing behavior despite defaulting to off.
> 
> **Overview**
> Adds a `beta_geometry_processor` boolean to `Project.from_geometry()` (and plumbing in `_create_project_from_files`) to optionally route geometry-root project creation through `Geometry.from_file(..., use_nextflow_pipelines=True)`.
> 
> Includes a focused regression test that monkeypatches `Geometry.from_file` to assert the flag is passed through and that async submission still returns the project id.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec01d69e663e53747eec349970f8c4754dc579cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->