### PR TITLE
fix(): Fix coordinate transformation writes to frozen BETDisk fields

### DIFF
--- a/flow360/component/simulation/translator/utils.py
+++ b/flow360/component/simulation/translator/utils.py
@@ -123,9 +123,19 @@ def _apply_transformations_to_model(
                 setattr(model, field_name, new_entity_list)
 
         elif isinstance(field_value, (list, tuple)):
-            new_items = [_transform_sequence_item(item, manager) for item in field_value]
-            new_value = new_items if isinstance(field_value, list) else tuple(new_items)
-            setattr(model, field_name, new_value)
+            transformed_items = None
+            for index, item in enumerate(field_value):
+                transformed = _transform_sequence_item(item, manager)
+                if transformed is not item:
+                    if transformed_items is None:
+                        transformed_items = list(field_value)
+                    transformed_items[index] = transformed
+
+            if transformed_items is not None:
+                new_value = (
+                    transformed_items if isinstance(field_value, list) else tuple(transformed_items)
+                )
+                setattr(model, field_name, new_value)
 
         elif isinstance(field_value, Flow360BaseModel):
             _apply_transformations_to_model(field_value, manager)

--- a/tests/simulation/translator/test_translation_utils.py
+++ b/tests/simulation/translator/test_translation_utils.py
@@ -1,0 +1,87 @@
+import flow360.component.simulation.units as u
+from flow360.component.simulation.draft_context.coordinate_system_manager import (
+    CoordinateSystemAssignmentGroup,
+    CoordinateSystemEntityRef,
+    CoordinateSystemStatus,
+)
+from flow360.component.simulation.entity_operation import CoordinateSystem
+from flow360.component.simulation.framework.param_utils import AssetCache
+from flow360.component.simulation.models.volume_models import (
+    BETDisk,
+    BETDiskChord,
+    BETDiskSectionalPolar,
+    BETDiskTwist,
+)
+from flow360.component.simulation.primitives import Cylinder
+from flow360.component.simulation.simulation_params import SimulationParams
+from flow360.component.simulation.translator.utils import (
+    apply_coordinate_system_transformations,
+)
+from flow360.component.simulation.unit_system import SI_unit_system
+
+
+def test_apply_coordinate_system_transformations_skips_frozen_non_entity_sequences():
+    with SI_unit_system:
+        cylinder = Cylinder(
+            name="bet_disk",
+            center=(0, 0, 0) * u.m,
+            axis=(0, 0, 1),
+            height=1 * u.m,
+            outer_radius=1 * u.m,
+        )
+        bet_disk = BETDisk(
+            entities=cylinder,
+            rotation_direction_rule="leftHand",
+            number_of_blades=3,
+            omega=100 * u.rpm,
+            chord_ref=1 * u.m,
+            n_loading_nodes=20,
+            mach_numbers=[0],
+            reynolds_numbers=[1000000],
+            twists=[BETDiskTwist(radius=0 * u.m, twist=0 * u.deg)],
+            chords=[BETDiskChord(radius=0 * u.m, chord=1 * u.m)],
+            alphas=[-2, 0, 2] * u.deg,
+            sectional_radiuses=[0.25, 0.5] * u.m,
+            sectional_polars=[
+                BETDiskSectionalPolar(
+                    lift_coeffs=[[[0.1, 0.2, 0.3]]],
+                    drag_coeffs=[[[0.01, 0.02, 0.03]]],
+                ),
+                BETDiskSectionalPolar(
+                    lift_coeffs=[[[0.15, 0.25, 0.35]]],
+                    drag_coeffs=[[[0.015, 0.025, 0.035]]],
+                ),
+            ],
+        )
+        coordinate_system = CoordinateSystem(name="cs", translation=(1, 2, 3) * u.m)
+        coordinate_system_status = CoordinateSystemStatus(
+            coordinate_systems=[coordinate_system],
+            parents=[],
+            assignments=[
+                CoordinateSystemAssignmentGroup(
+                    coordinate_system_id=coordinate_system.private_attribute_id,
+                    entities=[
+                        CoordinateSystemEntityRef(
+                            entity_type="Cylinder",
+                            entity_id=cylinder.private_attribute_id,
+                        )
+                    ],
+                )
+            ],
+        )
+        params = SimulationParams(
+            models=[bet_disk],
+            private_attribute_asset_cache=AssetCache(
+                coordinate_system_status=coordinate_system_status,
+            ),
+        )
+
+    apply_coordinate_system_transformations(params)
+
+    transformed_bet_disk = params.models[0]
+    transformed_cylinder = transformed_bet_disk.entities.stored_entities[0]
+
+    assert all(transformed_cylinder.center == [1, 2, 3] * u.m)
+    assert transformed_bet_disk.mach_numbers == [0]
+    assert transformed_bet_disk.twists[0].radius == 0 * u.m
+    assert transformed_bet_disk.chords[0].chord == 1 * u.m


### PR DESCRIPTION
## Summary

Fix coordinate-system translation so it no longer rewrites frozen `list` / `tuple` fields when traversing nested simulation models.

## Root Cause

`_apply_transformations_to_model()` rebuilt and reassigned every sequence field unconditionally:

- scalar sequences like `BETDisk.mach_numbers` were reconstructed even though no transformation applied
- frozen `list[Flow360BaseModel]` fields such as `twists`, `chords`, and `sectional_polars` also hit the same outer `setattr`

That caused translation to fail with errors like `Cannot modify immutable/frozen fields: mach_numbers`.

## What Changed

- kept `_transform_sequence_item()` behavior unchanged
- updated the sequence branch in `_apply_transformations_to_model()` to only rebuild and reassign the outer sequence when an item is actually replaced
- continued to recurse into nested `Flow360BaseModel` items in place without rewriting the outer container
- added a regression test covering a minimal `BETDisk + CoordinateSystemStatus` setup

## Validation

Passed locally:

- `python3 -m py_compile flow360/component/simulation/translator/utils.py tests/simulation/translator/test_translation_utils.py`
- direct import and execution of `test_apply_coordinate_system_transformations_skips_frozen_non_entity_sequences()`

Local environment blocker:

- `python3 -m pytest tests/simulation/translator/test_translation_utils.py -q`
- fails before test collection because the local `pytest_asyncio` plugin is incompatible with the installed `pytest` version (`ImportError: cannot import name 'FixtureDef' from 'pytest'`)

## Follow-up

The same issue exists on `release-candidate/25.9` and should be forward-ported in a separate follow-up PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes recursive coordinate-system transformation traversal to stop reassigning `list`/`tuple` fields unless an element is actually replaced, which could affect how nested models are mutated during translation. Risk is moderate because it touches shared preprocessing logic, but the behavioral change is narrowly scoped and covered by a regression test.
> 
> **Overview**
> Fixes coordinate-system preprocessing so `_apply_transformations_to_model()` no longer rebuilds and `setattr`s every `list`/`tuple` field unconditionally; it now only reassigns the outer sequence when at least one element was transformed.
> 
> Adds a regression test using a minimal `BETDisk` setup to verify entity coordinate translation occurs while frozen/non-entity sequences (e.g. `mach_numbers`, `twists`, `chords`) are not rewritten.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67bb07c32450fb04e6c28e674b31628509a8450e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->