### PR TITLE
schema(): Split draft context managers from schema state

### DIFF
--- a/flow360/component/simulation/draft_context/coordinate_system_manager.py
+++ b/flow360/component/simulation/draft_context/coordinate_system_manager.py
@@ -24,8 +24,6 @@ from flow360.log import log
 # pylint: disable=protected-access,unused-import
 
 
-
-
 __all__ = [
     "CoordinateSystemAssignmentGroup",
     "CoordinateSystemEntityRef",

--- a/flow360/component/simulation/draft_context/coordinate_system_manager.py
+++ b/flow360/component/simulation/draft_context/coordinate_system_manager.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-import collections
-from typing import Dict, List, Optional, Tuple, Union
+from typing import List, Optional, Union
 
-import numpy as np
+from flow360_schema.framework.entity.coordinate_system_state import (
+    CoordinateSystemState,
+)
 from flow360_schema.models.asset_cache import (
     CoordinateSystemAssignmentGroup,
     CoordinateSystemEntityRef,
@@ -13,15 +14,25 @@ from flow360_schema.models.asset_cache import (
     CoordinateSystemStatus,
 )
 
-from flow360.component.simulation.entity_operation import (
-    CoordinateSystem,
-    _compose_transformation_matrices,
-)
+from flow360.component.simulation.entity_operation import CoordinateSystem
 from flow360.component.simulation.framework.entity_base import EntityBase
 from flow360.component.simulation.framework.entity_registry import EntityRegistry
 from flow360.component.simulation.utils import is_exact_instance
-from flow360.exceptions import Flow360RuntimeError
+from flow360.exceptions import Flow360ValueError
 from flow360.log import log
+
+# pylint: disable=protected-access,unused-import
+
+
+
+
+__all__ = [
+    "CoordinateSystemAssignmentGroup",
+    "CoordinateSystemEntityRef",
+    "CoordinateSystemManager",
+    "CoordinateSystemParent",
+    "CoordinateSystemStatus",
+]
 
 
 class CoordinateSystemManager:
@@ -40,39 +51,47 @@ class CoordinateSystemManager:
     asset cache.
     """
 
-    __slots__ = (
-        "_coordinate_systems",
-        "_coordinate_system_parents",
-        "_entity_key_to_coordinate_system_id",
-    )
+    # Keep the manager as a thin client-facing facade. We intentionally use composition
+    # instead of inheriting from CoordinateSystemState so the client does not implicitly
+    # expose every schema-core helper as part of its API surface.
+    __slots__ = ("_state",)
 
-    def __init__(self) -> None:
-        self._coordinate_systems: list[CoordinateSystem] = []
-        self._coordinate_system_parents: dict[str, Optional[str]] = {}
-        self._entity_key_to_coordinate_system_id: dict[Tuple[str, str], str] = {}
+    def __init__(self, *, state: Optional[CoordinateSystemState] = None) -> None:
+        self._state = CoordinateSystemState() if state is None else state
 
     @property
-    def _known_ids(self) -> set[str]:
-        """Return set of registered coordinate system IDs for O(1) lookups."""
-        return {cs.private_attribute_id for cs in self._coordinate_systems}
+    def _coordinate_systems(self) -> list[CoordinateSystem]:
+        """Read-only compatibility surface for existing tests and draft internals."""
+        return self._state._coordinate_systems
 
-    def _contains(self, coordinate_system: CoordinateSystem) -> bool:
-        return coordinate_system.private_attribute_id in self._known_ids
+    @property
+    def _coordinate_system_parents(self) -> dict[str, Optional[str]]:
+        """Read-only compatibility surface for existing tests and draft internals."""
+        return self._state._coordinate_system_parents
 
-    def _register_coordinate_system(
-        self, *, coordinate_system: CoordinateSystem, parent_id: Optional[str]
-    ) -> None:
-        """Internal helper to register a coordinate system without graph validation."""
-        if self._contains(coordinate_system):
-            return  # Already registered, skip
-        if any(existing.name == coordinate_system.name for existing in self._coordinate_systems):
-            raise Flow360RuntimeError(
-                f"Coordinate system name '{coordinate_system.name}' already registered."
-            )
-        self._coordinate_systems.append(coordinate_system)
-        self._coordinate_system_parents[coordinate_system.private_attribute_id] = parent_id
+    @property
+    def _entity_key_to_coordinate_system_id(self) -> dict[tuple[str, str], str]:
+        """Read-only compatibility surface for existing tests and draft internals."""
+        return self._state._entity_key_to_coordinate_system_id
 
-    # region Registration and hierarchy -------------------------------------------------
+    def _get_coordinate_system_by_id(self, coordinate_system_id: str) -> Optional[CoordinateSystem]:
+        return self._state._get_coordinate_system_by_id(coordinate_system_id)
+
+    def _get_coordinate_system_matrix(self, *, coordinate_system: CoordinateSystem):
+        return self._state._get_coordinate_system_matrix(coordinate_system=coordinate_system)
+
+    def _get_coordinate_system_for_entity(self, *, entity: EntityBase):
+        return self._state._get_coordinate_system_for_entity(entity=entity)
+
+    def _get_matrix_for_entity(self, *, entity: EntityBase):
+        return self._state._get_matrix_for_entity(entity=entity)
+
+    def _get_matrix_for_entity_key(self, *, entity_type: str, entity_id: str):
+        return self._state._get_matrix_for_entity_key(entity_type=entity_type, entity_id=entity_id)
+
+    def _to_status(self) -> CoordinateSystemStatus:
+        return self._state._to_status()
+
     def add(
         self, coordinate_system: CoordinateSystem, *, parent: Optional[CoordinateSystem] = None
     ) -> CoordinateSystem:
@@ -94,32 +113,31 @@ class CoordinateSystemManager:
 
         Raises
         ------
-        Flow360RuntimeError
+        Flow360ValueError
             If `coordinate_system` is not an exact `CoordinateSystem` instance, if the id or
             name is already registered, or if the resulting parent graph is invalid (e.g. cycle).
         """
         if not is_exact_instance(coordinate_system, CoordinateSystem):
-            raise Flow360RuntimeError(
+            raise Flow360ValueError(
                 f"coordinate_system must be a CoordinateSystem. Received: {type(coordinate_system).__name__}."
             )
         cs = coordinate_system
 
-        # Auto-register parent as root if not already registered
         if parent is not None:
-            self._register_coordinate_system(coordinate_system=parent, parent_id=None)
+            self._state._register_coordinate_system(coordinate_system=parent, parent_id=None)
 
-        if self._contains(cs):
-            raise Flow360RuntimeError(
+        if self._state._contains(cs):
+            raise Flow360ValueError(
                 f"Coordinate system id '{cs.private_attribute_id}' already registered."
             )
-        if any(existing.name == cs.name for existing in self._coordinate_systems):
-            raise Flow360RuntimeError(f"Coordinate system name '{cs.name}' already registered.")
+        if any(existing.name == cs.name for existing in self._state._coordinate_systems):
+            raise Flow360ValueError(f"Coordinate system name '{cs.name}' already registered.")
 
-        self._coordinate_systems.append(cs)
-        self._coordinate_system_parents[cs.private_attribute_id] = (
+        self._state._coordinate_systems.append(cs)
+        self._state._coordinate_system_parents[cs.private_attribute_id] = (
             parent.private_attribute_id if parent is not None else None
         )
-        self._validate_coordinate_system_graph()
+        self._state._validate_coordinate_system_graph()
         return cs
 
     def update_parent(
@@ -138,24 +156,26 @@ class CoordinateSystemManager:
 
         Raises
         ------
-        Flow360RuntimeError
+        Flow360ValueError
             If `coordinate_system` is not registered, or if updating the parent would make the
             parent graph invalid (e.g. introduce a cycle). In that case, the change is rolled back.
         """
-        if not self._contains(coordinate_system):
-            raise Flow360RuntimeError("Coordinate system must be part of the draft to be updated.")
-        # Auto-register parent as root if not already registered
-        if parent is not None:
-            self._register_coordinate_system(coordinate_system=parent, parent_id=None)
+        if not self._state._contains(coordinate_system):
+            raise Flow360ValueError("Coordinate system must be part of the draft to be updated.")
 
-        cs_id = coordinate_system.private_attribute_id
-        original_parent = self._coordinate_system_parents.get(cs_id)
-        self._coordinate_system_parents[cs_id] = parent.private_attribute_id if parent else None
+        if parent is not None:
+            self._state._register_coordinate_system(coordinate_system=parent, parent_id=None)
+
+        coordinate_system_id = coordinate_system.private_attribute_id
+        original_parent = self._state._coordinate_system_parents.get(coordinate_system_id)
+        self._state._coordinate_system_parents[coordinate_system_id] = (
+            parent.private_attribute_id if parent else None
+        )
 
         try:
-            self._validate_coordinate_system_graph()
-        except Exception:
-            self._coordinate_system_parents[cs_id] = original_parent
+            self._state._validate_coordinate_system_graph()
+        except Flow360ValueError:
+            self._state._coordinate_system_parents[coordinate_system_id] = original_parent
             raise
 
     def remove(self, coordinate_system: CoordinateSystem) -> None:
@@ -171,143 +191,41 @@ class CoordinateSystemManager:
 
         Raises
         ------
-        Flow360RuntimeError
+        Flow360ValueError
             If the coordinate system is not registered, or if other registered coordinate systems
             depend on it (i.e. it is a parent).
         """
-        if not self._contains(coordinate_system):
-            raise Flow360RuntimeError("Coordinate system is not registered in this draft.")
+        if not self._state._contains(coordinate_system):
+            raise Flow360ValueError("Coordinate system is not registered in this draft.")
 
-        cs_id = coordinate_system.private_attribute_id
+        coordinate_system_id = coordinate_system.private_attribute_id
         dependents = [
             child_id
-            for child_id, parent_id in self._coordinate_system_parents.items()
-            if parent_id == cs_id
+            for child_id, parent_id in self._state._coordinate_system_parents.items()
+            if parent_id == coordinate_system_id
         ]
         if dependents:
             names = ", ".join(
-                cs.name for cs in self._coordinate_systems if cs.private_attribute_id in dependents
+                coordinate_system.name
+                for coordinate_system in self._state._coordinate_systems
+                if coordinate_system.private_attribute_id in dependents
             )
-            raise Flow360RuntimeError(
+            raise Flow360ValueError(
                 f"Cannot remove coordinate system '{coordinate_system.name}' because dependents exist: {names}"
             )
 
-        self._coordinate_systems = [
-            cs
-            for cs in self._coordinate_systems
-            if cs.private_attribute_id != coordinate_system.private_attribute_id
+        self._state._coordinate_systems = [
+            existing
+            for existing in self._state._coordinate_systems
+            if existing.private_attribute_id != coordinate_system.private_attribute_id
         ]
-        self._coordinate_system_parents.pop(cs_id, None)
-        # Drop assignments referencing this coordinate system.
-        self._entity_key_to_coordinate_system_id = {
+        self._state._coordinate_system_parents.pop(coordinate_system_id, None)
+        self._state._entity_key_to_coordinate_system_id = {
             entity_id: assigned_id
-            for entity_id, assigned_id in self._entity_key_to_coordinate_system_id.items()
-            if assigned_id != cs_id
+            for entity_id, assigned_id in self._state._entity_key_to_coordinate_system_id.items()
+            if assigned_id != coordinate_system_id
         }
 
-    # endregion ------------------------------------------------------------------------------------
-
-    def _validate_coordinate_system_graph(self) -> None:
-        """Validate parent references exist and detect cycles using Kahn's algorithm."""
-        id_to_cs: Dict[str, CoordinateSystem] = {}
-        for cs in self._coordinate_systems:
-            if cs.private_attribute_id in id_to_cs:
-                raise Flow360RuntimeError(
-                    f"Duplicate coordinate system id '{cs.private_attribute_id}' detected."
-                )
-            if cs.name in (existing.name for existing in id_to_cs.values()):
-                raise Flow360RuntimeError(f"Coordinate system name '{cs.name}' already registered.")
-            id_to_cs[cs.private_attribute_id] = cs
-
-        # Validate all parent references exist
-        for cs_id, cs in id_to_cs.items():
-            parent_id = self._coordinate_system_parents.get(cs_id)
-            if parent_id is not None and parent_id not in id_to_cs:
-                raise Flow360RuntimeError(
-                    f"Parent coordinate system '{parent_id}' not found for '{cs.name}'."
-                )
-
-        # Kahn's algorithm for cycle detection
-        in_degree = {cs_id: 0 for cs_id in id_to_cs}
-        for cs_id in id_to_cs:
-            parent_id = self._coordinate_system_parents.get(cs_id)
-            if parent_id is not None:
-                in_degree[cs_id] += 1
-
-        queue = collections.deque([cs_id for cs_id, degree in in_degree.items() if degree == 0])
-        processed = 0
-
-        while queue:
-            current = queue.popleft()
-            processed += 1
-            for cs_id, parent_id in self._coordinate_system_parents.items():
-                if parent_id == current:
-                    in_degree[cs_id] -= 1
-                    if in_degree[cs_id] == 0:
-                        queue.append(cs_id)
-
-        if processed != len(id_to_cs):
-            cycle_nodes = [cs_id for cs_id, degree in in_degree.items() if degree > 0]
-            raise Flow360RuntimeError(
-                f"Cycle detected in coordinate system inheritance among: {sorted(cycle_nodes)}"
-            )
-
-    def _get_coordinate_system_matrix(self, *, coordinate_system: CoordinateSystem) -> np.ndarray:
-        """Return the composed matrix for a registered coordinate system (parents applied)."""
-        if not self._contains(coordinate_system):
-            raise Flow360RuntimeError("Coordinate system must be registered to compute its matrix.")
-
-        cs_id = coordinate_system.private_attribute_id
-        combined_matrix = coordinate_system._get_local_matrix()  # pylint:disable=protected-access
-
-        # Graph is validated, parent guaranteed to exist and no cycles
-        parent_id = self._coordinate_system_parents.get(cs_id)
-        while parent_id is not None:
-            parent = self._get_coordinate_system_by_id(parent_id)
-            combined_matrix = _compose_transformation_matrices(
-                parent=parent._get_local_matrix(),  # pylint:disable=protected-access
-                child=combined_matrix,
-            )
-            parent_id = self._coordinate_system_parents.get(parent_id)
-
-        return combined_matrix
-
-    # --------------------------------------------------------------------
-    def get_by_name(self, name: str) -> CoordinateSystem:
-        """
-        Retrieve a registered coordinate system by name.
-
-        Parameters
-        ----------
-        name : str
-            Coordinate system name.
-
-        Returns
-        -------
-        CoordinateSystem
-            The matching coordinate system.
-
-        Raises
-        ------
-        Flow360RuntimeError
-            If no coordinate system with the given name exists in this draft.
-        """
-        for cs in self._coordinate_systems:
-            if cs.name == name:
-                return cs
-        raise Flow360RuntimeError(f"Coordinate system '{name}' not found in the draft.")
-
-    def _get_coordinate_system_by_id(self, cs_id: str) -> Optional[CoordinateSystem]:
-        for cs in self._coordinate_systems:
-            if cs.private_attribute_id == cs_id:
-                return cs
-        return None
-
-    @staticmethod
-    def _entity_key(entity: EntityBase) -> tuple[str, Optional[str]]:
-        return (entity.private_attribute_entity_type_name, entity.private_attribute_id)
-
-    # Assignment ----------------------------------------------------------------
     def assign(
         self,
         *,
@@ -327,7 +245,7 @@ class CoordinateSystemManager:
 
         Raises
         ------
-        Flow360RuntimeError
+        Flow360ValueError
             If `coordinate_system` is not an exact `CoordinateSystem` instance or if any item
             in `entities` is not an entity instance.
 
@@ -337,11 +255,10 @@ class CoordinateSystemManager:
         overwritten and a warning is logged.
         """
         if not is_exact_instance(coordinate_system, CoordinateSystem):
-            raise Flow360RuntimeError(
+            raise Flow360ValueError(
                 f"`coordinate_system` must be a CoordinateSystem. Received: {type(coordinate_system).__name__}."
             )
 
-        # Normalize to list for uniform validation.
         if isinstance(entities, list):
             normalized_entities = entities
         else:
@@ -349,20 +266,20 @@ class CoordinateSystemManager:
 
         for entity in normalized_entities:
             if not isinstance(entity, EntityBase):
-                raise Flow360RuntimeError(
+                raise Flow360ValueError(
                     f"Only entities can be assigned a coordinate system. Received: {type(entity).__name__}."
                 )
             if entity.private_attribute_id is None:
-                raise Flow360RuntimeError(
+                raise Flow360ValueError(
                     f"Entity '{entity.name}' ({type(entity).__name__}) is not supported "
                     f"for coordinate system assignment."
                 )
 
-        self._register_coordinate_system(coordinate_system=coordinate_system, parent_id=None)
+        self._state._register_coordinate_system(coordinate_system=coordinate_system, parent_id=None)
 
         for entity in normalized_entities:
-            entity_key = self._entity_key(entity)
-            previous = self._entity_key_to_coordinate_system_id.get(entity_key)
+            entity_key = self._state._entity_key(entity)
+            previous = self._state._entity_key_to_coordinate_system_id.get(entity_key)
             if previous is not None and previous != coordinate_system.private_attribute_id:
                 log.warning(
                     "Entity '%s' already had a coordinate system '%s'; overwriting to '%s'.",
@@ -370,7 +287,7 @@ class CoordinateSystemManager:
                     previous,
                     coordinate_system.private_attribute_id,
                 )
-            self._entity_key_to_coordinate_system_id[entity_key] = (
+            self._state._entity_key_to_coordinate_system_id[entity_key] = (
                 coordinate_system.private_attribute_id
             )
 
@@ -383,72 +300,28 @@ class CoordinateSystemManager:
         entity : EntityBase
             The entity whose coordinate system assignment should be cleared.
         """
-        self._entity_key_to_coordinate_system_id.pop(self._entity_key(entity), None)
+        self._state._entity_key_to_coordinate_system_id.pop(self._state._entity_key(entity), None)
 
-    def _get_coordinate_system_for_entity(
-        self, *, entity: EntityBase
-    ) -> Optional[CoordinateSystem]:
-        """Return the coordinate system assigned to the entity, if any."""
-        cs_id = self._entity_key_to_coordinate_system_id.get(self._entity_key(entity))
-        if cs_id is None:
-            return None
-        cs = self._get_coordinate_system_by_id(cs_id)
-        if cs is None:
-            raise Flow360RuntimeError(
-                f"Coordinate system id '{cs_id}' assigned to entity '{entity.name}' is not registered."
-            )
-        return cs
+    def get_by_name(self, name: str) -> CoordinateSystem:
+        """
+        Retrieve a registered coordinate system by name.
 
-    def _get_matrix_for_entity(self, *, entity: EntityBase) -> Optional[np.ndarray]:
-        """Return the composed 3x4 transformation matrix for an entity, if assigned."""
-        cs = self._get_coordinate_system_for_entity(entity=entity)
-        if cs is None:
-            return None
-        return self._get_coordinate_system_matrix(coordinate_system=cs)
-
-    def _get_matrix_for_entity_key(
-        self, *, entity_type: str, entity_id: str
-    ) -> Optional[np.ndarray]:
-        """Return the composed 3x4 matrix for an entity reference, if assigned."""
-        cs_id = self._entity_key_to_coordinate_system_id.get((entity_type, entity_id))
-        if cs_id is None:
-            return None
-        cs = self._get_coordinate_system_by_id(cs_id)
-        if cs is None:
-            raise Flow360RuntimeError(
-                f"Coordinate system id '{cs_id}' assigned to entity '{entity_type}:{entity_id}' is not registered."
-            )
-        return self._get_coordinate_system_matrix(coordinate_system=cs)
-
-    # Serialization ----------------------------------------------------------------
-    def _to_status(self) -> CoordinateSystemStatus:
-        """Build a serializable status snapshot.
+        Parameters
+        ----------
+        name : str
+            Coordinate system name.
 
         Returns
         -------
-        CoordinateSystemStatus
-            The serialized status.
+        CoordinateSystem
+            The matching coordinate system.
+
+        Raises
+        ------
+        Flow360ValueError
+            If no coordinate system with the given name exists in this draft.
         """
-        parents = [
-            CoordinateSystemParent(coordinate_system_id=cs_id, parent_id=parent_id)
-            for cs_id, parent_id in self._coordinate_system_parents.items()
-        ]
-
-        grouped: Dict[str, List[CoordinateSystemEntityRef]] = {}
-        for (entity_type, entity_id), cs_id in self._entity_key_to_coordinate_system_id.items():
-            grouped.setdefault(cs_id, []).append(
-                CoordinateSystemEntityRef(entity_type=entity_type, entity_id=entity_id)
-            )
-
-        assignments = [
-            CoordinateSystemAssignmentGroup(coordinate_system_id=cs_id, entities=entities)
-            for cs_id, entities in grouped.items()
-        ]
-        return CoordinateSystemStatus(
-            coordinate_systems=self._coordinate_systems,
-            parents=parents,
-            assignments=assignments,
-        )
+        return self._state.get_by_name(name)
 
     @classmethod
     def _from_status(
@@ -457,7 +330,8 @@ class CoordinateSystemManager:
         status: Optional[CoordinateSystemStatus],
         entity_registry: Optional[EntityRegistry] = None,
     ) -> CoordinateSystemManager:
-        """Restore manager from a status snapshot.
+        """
+        Restore manager from a status snapshot.
 
         Parameters
         ----------
@@ -470,59 +344,9 @@ class CoordinateSystemManager:
         CoordinateSystemManager
             The restored manager.
         """
-        mgr = cls()
-        if status is None:
-            return mgr
-
-        # Build set of IDs for validation of parent/assignment references.
-        existing_ids: set[str] = set()
-        for cs in status.coordinate_systems:
-            mgr._coordinate_systems.append(cs)
-            existing_ids.add(cs.private_attribute_id)
-
-        for parent in status.parents:
-            if parent.coordinate_system_id not in existing_ids:
-                raise Flow360RuntimeError(
-                    f"Parent record references unknown coordinate system '{parent.coordinate_system_id}'."
-                )
-            if parent.parent_id is not None and parent.parent_id not in existing_ids:
-                raise Flow360RuntimeError(
-                    f"Parent coordinate system '{parent.parent_id}' not found for '{parent.coordinate_system_id}'."
-                )
-            mgr._coordinate_system_parents[parent.coordinate_system_id] = parent.parent_id
-
-        seen_entity_keys: set[Tuple[str, str]] = set()
-        for assignment in status.assignments:
-            if assignment.coordinate_system_id not in existing_ids:
-                raise Flow360RuntimeError(
-                    f"Assignment references unknown coordinate system '{assignment.coordinate_system_id}'."
-                )
-            for entity in assignment.entities:
-                key = (entity.entity_type, entity.entity_id)
-                # Sanitize invalid assignments due to entity not being in scope anymore.
-                if (
-                    entity_registry  # Fast lane: entity_registry None indicates that no validation is needed
-                    and (
-                        entity_registry.find_by_type_name_and_id(
-                            entity_type=entity.entity_type, entity_id=entity.entity_id
-                        )
-                        is None
-                    )
-                ):
-                    log.warning(
-                        "Entity '%s:%s' assigned to coordinate system '%s' is not in the draft registry; "
-                        "skipping this coordinate system assignment.",
-                        entity.entity_type,
-                        entity.entity_id,
-                        assignment.coordinate_system_id,
-                    )
-                    continue
-                if key in seen_entity_keys:
-                    raise Flow360RuntimeError(
-                        f"Duplicate entity assignment for entity '{entity.entity_type}:{entity.entity_id}'."
-                    )
-                seen_entity_keys.add(key)
-                mgr._entity_key_to_coordinate_system_id[key] = assignment.coordinate_system_id
-
-        mgr._validate_coordinate_system_graph()
-        return mgr
+        return cls(
+            state=CoordinateSystemState._from_status(
+                status=status,
+                entity_registry=entity_registry,
+            )
+        )

--- a/flow360/component/simulation/draft_context/coordinate_system_manager.py
+++ b/flow360/component/simulation/draft_context/coordinate_system_manager.py
@@ -172,7 +172,7 @@ class CoordinateSystemManager:
 
         try:
             self._state._validate_coordinate_system_graph()
-        except Flow360ValueError:
+        except Exception:
             self._state._coordinate_system_parents[coordinate_system_id] = original_parent
             raise
 
@@ -204,9 +204,9 @@ class CoordinateSystemManager:
         ]
         if dependents:
             names = ", ".join(
-                coordinate_system.name
-                for coordinate_system in self._state._coordinate_systems
-                if coordinate_system.private_attribute_id in dependents
+                existing.name
+                for existing in self._state._coordinate_systems
+                if existing.private_attribute_id in dependents
             )
             raise Flow360ValueError(
                 f"Cannot remove coordinate system '{coordinate_system.name}' because dependents exist: {names}"

--- a/flow360/component/simulation/draft_context/mirror.py
+++ b/flow360/component/simulation/draft_context/mirror.py
@@ -24,7 +24,6 @@ from flow360.exceptions import Flow360ValueError
 # pylint: disable=protected-access
 
 
-
 __all__ = [
     "MIRROR_SUFFIX",
     "MirrorManager",

--- a/flow360/component/simulation/draft_context/mirror.py
+++ b/flow360/component/simulation/draft_context/mirror.py
@@ -1,9 +1,14 @@
 """Mirror plane, mirrored entities and helpers."""
 
-from typing import Dict, List, Optional, Tuple, Union
+from __future__ import annotations
 
+from flow360_schema.framework.entity.mirror_state import (
+    MIRROR_SUFFIX,
+    MirrorState,
+    _derive_mirrored_entities_from_actions,
+)
 from flow360_schema.models.asset_cache import MirrorStatus
-from flow360_schema.models.entities import MirrorPlane
+from flow360_schema.models.entities.geometry_entities import MirrorPlane
 
 from flow360.component.simulation.framework.entity_registry import (
     EntityRegistry,
@@ -13,238 +18,20 @@ from flow360.component.simulation.primitives import (
     GeometryBodyGroup,
     MirroredGeometryBodyGroup,
     MirroredSurface,
-    Surface,
 )
-from flow360.component.simulation.utils import is_exact_instance
-from flow360.exceptions import Flow360RuntimeError
-from flow360.log import log
+from flow360.exceptions import Flow360ValueError
 
-MIRROR_SUFFIX = "_<mirror>"
-
-# region -----------------------------Internal Functions Below-------------------------------------
+# pylint: disable=protected-access
 
 
-def _build_mirrored_geometry_groups(
-    *,
-    body_group_id_to_mirror_id: Dict[str, str],
-    body_groups_by_id: Dict[str, GeometryBodyGroup],
-    mirror_planes_by_id: Dict[str, MirrorPlane],
-) -> List[MirroredGeometryBodyGroup]:
-    """Create mirrored geometry body groups for valid mirror actions."""
 
-    mirrored_groups: List[MirroredGeometryBodyGroup] = []
-
-    for body_group_id, mirror_plane_id in body_group_id_to_mirror_id.items():
-        body_group = body_groups_by_id.get(body_group_id)
-        if body_group is None:
-            log.warning(
-                "Mirror action references unknown GeometryBodyGroup id '%s'; skipping.",
-                body_group_id,
-            )
-            continue
-
-        mirror_plane = mirror_planes_by_id.get(mirror_plane_id)
-        if mirror_plane is None:
-            log.warning(
-                "Mirror action references unknown MirrorPlane id '%s'; skipping.",
-                mirror_plane_id,
-            )
-            continue
-
-        mirrored_groups.append(
-            MirroredGeometryBodyGroup(
-                name=f"{body_group.name}{MIRROR_SUFFIX}",
-                geometry_body_group_id=body_group_id,
-                mirror_plane_id=mirror_plane_id,
-            )
-        )
-
-    return mirrored_groups
-
-
-def _build_mirrored_surfaces(
-    *,
-    body_group_id_to_mirror_id: Dict[str, str],
-    face_group_to_body_group: Optional[Dict[str, str]],
-    surfaces: List[Surface],
-    mirror_planes_by_id: Dict[str, MirrorPlane],
-) -> List[MirroredSurface]:
-    """Create mirrored surfaces for the requested body groups."""
-
-    if not body_group_id_to_mirror_id or face_group_to_body_group is None:
-        return []
-
-    surfaces_by_name: Dict[str, Surface] = {surface.name: surface for surface in surfaces}
-    requested_body_group_ids = set(body_group_id_to_mirror_id.keys())
-    mirrored_surfaces: List[MirroredSurface] = []
-
-    for surface_name, owning_body_group_id in face_group_to_body_group.items():
-        if owning_body_group_id not in requested_body_group_ids:
-            continue
-
-        surface = surfaces_by_name.get(surface_name)
-        if surface is None:
-            log.warning(
-                "Surface '%s' referenced in GeometryEntityInfo was not found in draft registry; "
-                "skipping mirroring for this surface.",
-                surface_name,
-            )
-            continue
-
-        mirror_plane_id = body_group_id_to_mirror_id.get(owning_body_group_id)
-        mirror_plane = mirror_planes_by_id.get(mirror_plane_id)
-        if mirror_plane is None:
-            log.warning(
-                "Mirror action references unknown MirrorPlane id '%s' for body group '%s'; "
-                "skipping mirroring for surface '%s'.",
-                mirror_plane_id,
-                owning_body_group_id,
-                surface_name,
-            )
-            continue
-
-        mirrored_surface = MirroredSurface(
-            name=f"{surface.name}{MIRROR_SUFFIX}",
-            surface_id=surface.private_attribute_id,
-            mirror_plane_id=mirror_plane_id,
-        )
-        # Draft-only bookkeeping: record which body group generated this mirrored surface.
-        mirrored_surface._geometry_body_group_id = (  # pylint: disable=protected-access
-            owning_body_group_id
-        )
-        mirrored_surfaces.append(mirrored_surface)
-
-    return mirrored_surfaces
-
-
-def _derive_mirrored_entities_from_actions(
-    *,
-    body_group_id_to_mirror_id: Dict[str, str],
-    face_group_to_body_group: Optional[Dict[str, str]],
-    entity_registry: EntityRegistry,
-    mirror_planes: List[MirrorPlane],
-) -> Tuple[List[MirroredGeometryBodyGroup], List[MirroredSurface]]:
-    """
-    Derive mirrored entities (MirroredGeometryBodyGroup + MirroredSurface)
-    based on the given ``body_group_id_to_mirror_id`` mapping.
-
-    The ``body_group_id_to_mirror_id`` schema is::
-
-        {geometry_body_group_id: mirror_plane_id}
-
-    Parameters
-    ----------
-    body_group_id_to_mirror_id : Dict[str, str]
-        Mapping from geometry body group ID to mirror plane ID.
-    face_group_to_body_group : Optional[Dict[str, str]]
-        Mapping from surface name to owning body group ID. If None, no surfaces will be mirrored.
-    entity_registry : EntityRegistry
-        Entity registry containing body groups and surfaces.
-    mirror_planes : List[MirrorPlane]
-        List of all mirror planes.
-
-    Returns
-    -------
-    Tuple[List[MirroredGeometryBodyGroup], List[MirroredSurface]]
-        Mirrored body groups and surfaces.
-
-    This helper is intended to be reusable both from within the draft context
-    (for incremental updates) and before submission (for generating the full list
-    of mirrored entities from the stored mirror status).
-    """
-
-    if not body_group_id_to_mirror_id:
-        return [], []
-
-    # Extract body groups and surfaces from the entity registry.
-    body_groups = entity_registry.view(  # pylint: disable=protected-access
-        GeometryBodyGroup
-    )._entities
-    surfaces = entity_registry.view(Surface)._entities  # pylint: disable=protected-access
-
-    # Lookup tables for body groups and mirror planes.
-    body_groups_by_id: Dict[str, GeometryBodyGroup] = {
-        body_group.private_attribute_id: body_group for body_group in body_groups
-    }
-    mirror_planes_by_id: Dict[str, MirrorPlane] = {
-        plane.private_attribute_id: plane for plane in mirror_planes
-    }
-
-    mirrored_geometry_groups = _build_mirrored_geometry_groups(
-        body_group_id_to_mirror_id=body_group_id_to_mirror_id,
-        body_groups_by_id=body_groups_by_id,
-        mirror_planes_by_id=mirror_planes_by_id,
-    )
-    mirrored_surfaces = _build_mirrored_surfaces(
-        body_group_id_to_mirror_id=body_group_id_to_mirror_id,
-        face_group_to_body_group=face_group_to_body_group,
-        surfaces=surfaces,
-        mirror_planes_by_id=mirror_planes_by_id,
-    )
-
-    return mirrored_geometry_groups, mirrored_surfaces
-
-
-def _extract_body_group_id_to_mirror_id_from_status(
-    *,
-    mirror_status: Optional[MirrorStatus],
-    valid_body_group_ids: Optional[set[str]],
-) -> Dict[str, str]:
-    """
-    Deserialize mirror actions from a :class:`MirrorStatus` instance.
-
-    Parameters
-    ----------
-    mirror_status : MirrorStatus
-        The mirror status to deserialize.
-    valid_body_group_ids : Optional[set[str]]
-        Set of valid body group IDs. If provided, any mirror actions referencing
-        body groups not in this set will be skipped.
-
-    Returns
-    -------
-    Dict[str, str]
-        - ``body_group_id_to_mirror_id``: mapping from geometry body group ID to mirror plane ID.
-    """
-
-    if mirror_status is None:
-        # No mirror feature used in the asset.
-        log.debug("Mirror status not provided; no mirroring actions to restore.")
-        return {}
-
-    mirror_planes_by_id: Dict[str, MirrorPlane] = {
-        plane.private_attribute_id: plane for plane in mirror_status.mirror_planes
-    }
-
-    body_group_id_to_mirror_id: Dict[str, str] = {}
-    for mirrored_group in mirror_status.mirrored_geometry_body_groups:
-        body_group_id = mirrored_group.geometry_body_group_id
-        mirror_plane_id = mirrored_group.mirror_plane_id
-
-        if valid_body_group_ids is not None and body_group_id not in valid_body_group_ids:
-            # Skip body groups that no longer exist.
-            log.debug(
-                "Ignoring mirroring of GeometryBodyGroup (ID:'%s') because it no longer exists.",
-                body_group_id,
-            )
-            continue
-
-        if mirror_plane_id not in mirror_planes_by_id:
-            # Skip if the referenced mirror plane is no longer present.
-            log.debug(
-                "Ignoring mirroring of GeometryBodyGroup (ID:'%s') because the referenced"
-                " mirror plane (ID:'%s') no longer exists.",
-                body_group_id,
-                mirror_plane_id,
-            )
-            continue
-
-        body_group_id_to_mirror_id[body_group_id] = mirror_plane_id
-
-    return body_group_id_to_mirror_id
-
-
-# endregion -------------------------------------------------------------------------------------
+__all__ = [
+    "MIRROR_SUFFIX",
+    "MirrorManager",
+    "MirrorPlane",
+    "MirrorStatus",
+    "_derive_mirrored_entities_from_actions",
+]
 
 
 class MirrorManager:
@@ -265,32 +52,29 @@ class MirrorManager:
     is disabled and mirror operations will raise.
     """
 
-    __slots__ = (
-        # MirrorManager owns the single mirror status instance. This is always validate and up to date.
-        "_mirror_status",
-        "_body_group_id_to_mirror_id",
-        "_face_group_to_body_group",
-        "_entity_registry",  # A link to the full picture.
-    )
-    _mirror_status: MirrorStatus
-    _body_group_id_to_mirror_id: Dict[str, str]
-    _face_group_to_body_group: Optional[Dict[str, str]]
-    _entity_registry: EntityRegistry
+    # Keep the manager as a thin client-facing facade. We intentionally use composition
+    # instead of inheriting from MirrorState so the client does not implicitly expose
+    # every schema-core helper as part of its API surface.
+    __slots__ = ("_state",)
 
     def __init__(
         self,
         *,
-        face_group_to_body_group: Optional[Dict[str, str]],
-        entity_registry: EntityRegistry,
+        face_group_to_body_group: dict[str, str] | None = None,
+        entity_registry: EntityRegistry | None = None,
+        state: MirrorState | None = None,
     ) -> None:
-        self._body_group_id_to_mirror_id = {}
-        self._face_group_to_body_group = face_group_to_body_group
-        self._entity_registry = entity_registry
-        self._mirror_status = MirrorStatus(
-            mirror_planes=[], mirrored_geometry_body_groups=[], mirrored_surfaces=[]
-        )
+        if state is None:
+            if entity_registry is None:
+                raise Flow360ValueError(
+                    "[Internal] MirrorManager requires `entity_registry` when `state` is not provided."
+                )
+            state = MirrorState(
+                face_group_to_body_group=face_group_to_body_group,
+                entity_registry=entity_registry,
+            )
+        self._state = state
 
-    # region Public API -------------------------------------------------
     @property
     def mirror_planes(self) -> EntityRegistryView:
         """
@@ -301,14 +85,29 @@ class MirrorManager:
         EntityRegistryView
             A registry view of `MirrorPlane` entities available in this draft.
         """
-        return self._entity_registry.view(MirrorPlane)
+        return self._state.mirror_planes
+
+    @property
+    def _mirror_status(self) -> MirrorStatus:
+        """Read-only compatibility surface for existing draft plumbing and tests."""
+        return self._state._mirror_status
+
+    @property
+    def _body_group_id_to_mirror_id(self) -> dict[str, str]:
+        """Read-only compatibility surface for existing draft plumbing and tests."""
+        return self._state._body_group_id_to_mirror_id
+
+    @property
+    def _mirror_planes(self) -> list[MirrorPlane]:
+        """Read-only compatibility surface for existing draft plumbing and tests."""
+        return self._state._mirror_planes
 
     def create_mirror_of(
         self,
         *,
-        entities: Union[List[GeometryBodyGroup], GeometryBodyGroup],
+        entities: list[GeometryBodyGroup] | GeometryBodyGroup,
         mirror_plane: MirrorPlane,
-    ) -> tuple[List[MirroredGeometryBodyGroup], List[MirroredSurface]]:
+    ) -> tuple[list[MirroredGeometryBodyGroup], list[MirroredSurface]]:
         """
         Create mirrored entities for one or more geometry body groups.
 
@@ -323,331 +122,48 @@ class MirrorManager:
 
         Parameters
         ----------
-        entities : Union[List[GeometryBodyGroup], GeometryBodyGroup]
+        entities : list[GeometryBodyGroup] | GeometryBodyGroup
             One or more geometry body groups to mirror.
         mirror_plane : MirrorPlane
             The mirror plane to use for mirroring.
 
         Returns
         -------
-        tuple[List[MirroredGeometryBodyGroup], List[MirroredSurface]]
+        tuple[list[MirroredGeometryBodyGroup], list[MirroredSurface]]
             Mirrored geometry body groups and surfaces.
-
-        Raises
-        ------
-        Flow360RuntimeError
-            If inputs are of incorrect types, if the mirror plane name conflicts with an existing
-            plane in the draft, or if mirroring is unavailable due to missing surface ownership
-            mapping.
-
-        Notes
-        -----
-        If a body group was previously mirrored, its existing derived mirrored entities are removed
-        and replaced with the latest mirror plane request (a warning is logged).
         """
-        normalized_entities = self._validate_and_normalize_create_inputs(
-            entities=entities, mirror_plane=mirror_plane
-        )
-        self._prepare_for_mirror_update(entities=normalized_entities)
-        self._ensure_mirror_plane_registered(mirror_plane=mirror_plane)
-        mirrored_geometry_groups, mirrored_surfaces = self._apply_actions_and_generate_entities(
-            entities=normalized_entities, mirror_plane=mirror_plane
-        )
-        return mirrored_geometry_groups, mirrored_surfaces
-
-    # region Internal helpers -------------------------------------------------
-    def _validate_and_normalize_create_inputs(
-        self,
-        *,
-        entities: Union[List[GeometryBodyGroup], GeometryBodyGroup],
-        mirror_plane: MirrorPlane,
-    ) -> List[GeometryBodyGroup]:
-        """Validate inputs for create_mirror_of and normalize entities to a list."""
-        if isinstance(entities, GeometryBodyGroup):
-            normalized_entities = [entities]
-        elif isinstance(entities, list):
-            normalized_entities = entities
-        else:
-            raise Flow360RuntimeError(
-                f"`entities` accepts a single entity or a list of entities. Received type: {type(entities).__name__}."
-            )
-
-        for entity in normalized_entities:
-            if not is_exact_instance(entity, GeometryBodyGroup):
-                raise Flow360RuntimeError(
-                    "Only GeometryBodyGroup entities are supported by `create()` currently. "
-                    f"Received: {type(entity).__name__}."
-                )
-            if entity.private_attribute_id is None:
-                raise Flow360RuntimeError(
-                    f"Entity '{entity.name}' ({type(entity).__name__}) is not supported "
-                    f"for mirror operations."
-                )
-
-        if not is_exact_instance(mirror_plane, MirrorPlane):
-            raise Flow360RuntimeError(
-                f"`mirror_plane` must be a MirrorPlane entity. Instead received: {type(mirror_plane).__name__}."
-            )
-
-        if self._face_group_to_body_group is None:
-            raise Flow360RuntimeError(
-                "Mirroring is not available because the surface-to-body-group mapping could not be derived. "
-                "This typically happens when face groupings span across multiple body groups."
-            )
-
-        return normalized_entities
-
-    def _prepare_for_mirror_update(self, *, entities: List[GeometryBodyGroup]) -> None:
-        """Warn on overwrites and remove previously-derived mirrored entities for these body groups."""
-        body_group_ids_to_update = set()
-        for body_group in entities:
-            body_group_id = body_group.private_attribute_id
-            body_group_ids_to_update.add(body_group_id)
-            if body_group_id in self._body_group_id_to_mirror_id:
-                log.warning(
-                    "GeometryBodyGroup `%s` was already mirrored; resetting to the latest mirror plane request.",
-                    body_group.name,
-                )
-
-        existing_mirrored_groups = [
-            mirrored_group
-            for mirrored_group in list(self._mirror_status.mirrored_geometry_body_groups)
-            if mirrored_group.geometry_body_group_id in body_group_ids_to_update
-        ]
-        for mirrored_group in existing_mirrored_groups:
-            self._remove(mirrored_group)
-
-    def _ensure_mirror_plane_registered(self, *, mirror_plane: MirrorPlane) -> None:
-        """Validate mirror plane name uniqueness and register the plane if needed."""
-        for existing_plane in self._mirror_planes:
-            if (
-                existing_plane.name == mirror_plane.name
-                and existing_plane.private_attribute_id != mirror_plane.private_attribute_id
-            ):
-                raise Flow360RuntimeError(
-                    f"Mirror plane name '{mirror_plane.name}' already exists in the draft."
-                )
-
-        if any(
-            plane.private_attribute_id == mirror_plane.private_attribute_id
-            for plane in self._mirror_planes
-        ):
-            return
-        self._add(mirror_plane)
-
-    def _apply_actions_and_generate_entities(
-        self,
-        *,
-        entities: List[GeometryBodyGroup],
-        mirror_plane: MirrorPlane,
-    ) -> Tuple[List[MirroredGeometryBodyGroup], List[MirroredSurface]]:
-        """Update actions for the given entities and generate/register derived mirrored entities."""
-        mirror_plane_id = mirror_plane.private_attribute_id
-        body_group_id_to_mirror_id_update: Dict[str, str] = {}
-        for body_group in entities:
-            body_group_id = body_group.private_attribute_id
-            body_group_id_to_mirror_id_update[body_group_id] = mirror_plane_id
-            self._body_group_id_to_mirror_id[body_group_id] = mirror_plane_id
-
-        mirrored_geometry_groups, mirrored_surfaces = _derive_mirrored_entities_from_actions(
-            body_group_id_to_mirror_id=body_group_id_to_mirror_id_update,
-            face_group_to_body_group=self._face_group_to_body_group,
-            entity_registry=self._entity_registry,
-            mirror_planes=self._mirror_status.mirror_planes,
+        return self._state.create_mirror_of(
+            entities=entities,
+            mirror_plane=mirror_plane,
         )
 
-        for mirrored_geometry_group in mirrored_geometry_groups:
-            self._add(mirrored_geometry_group)
-        for mirrored_surface in mirrored_surfaces:
-            self._add(mirrored_surface)
-
-        return mirrored_geometry_groups, mirrored_surfaces
-
-    # endregion --------------------------------------------------------------
-
-    def remove_mirror_of(
-        self, *, entities: Union[List[GeometryBodyGroup], GeometryBodyGroup]
-    ) -> None:
+    def remove_mirror_of(self, *, entities: list[GeometryBodyGroup] | GeometryBodyGroup) -> None:
         """
         Remove the mirror of the given entities.
 
         Parameters
         ----------
-        entities : Union[List[GeometryBodyGroup], GeometryBodyGroup]
+        entities : list[GeometryBodyGroup] | GeometryBodyGroup
             One or more geometry body groups to remove mirroring from.
-
-        Raises
-        ------
-        Flow360RuntimeError
-            If `entities` is not a `GeometryBodyGroup` or a list of `GeometryBodyGroup` instances.
         """
-        # 1. [Validation] Ensure `entities` are GeometryBodyGroup entities.
-        normalized_entities: List[GeometryBodyGroup]
-        if isinstance(entities, GeometryBodyGroup):
-            normalized_entities = [entities]
-        elif isinstance(entities, list):
-            normalized_entities = entities
-        else:
-            raise Flow360RuntimeError(
-                f"`entities` accepts a single entity or a list of entities. Received type: {type(entities).__name__}."
-            )
-
-        for entity in normalized_entities:
-            if not is_exact_instance(entity, GeometryBodyGroup):
-                raise Flow360RuntimeError(
-                    "Only GeometryBodyGroup entities are supported by `remove_mirror_of()`. "
-                    f"Received: {type(entity).__name__}."
-                )
-
-        # 2. Remove mirror assignments for the given entities.
-        for body_group in normalized_entities:
-            body_group_id = body_group.private_attribute_id
-            self._body_group_id_to_mirror_id.pop(body_group_id, None)
-            mirrored_groups_to_remove = [
-                mirrored_group
-                for mirrored_group in list(self._mirror_status.mirrored_geometry_body_groups)
-                if mirrored_group.geometry_body_group_id == body_group_id
-            ]
-            for mirrored_group in mirrored_groups_to_remove:
-                self._remove(mirrored_group)
-
-    # endregion ------------------------------------------------------------------------------------
-    @property
-    def _mirror_planes(self) -> List[MirrorPlane]:
-        """Return the list of mirror planes."""
-        return self._mirror_status.mirror_planes
-
-    @_mirror_planes.setter
-    def _mirror_planes(self, *args, **kwargs):
-        """Set the list of mirror planes."""
-        raise NotImplementedError(
-            "Mirror planes are managed by the mirror manager -> _mirror_status and cannot be assigned directly."
-        )
-
-    def _add(self, entity: Union[MirrorPlane, MirroredGeometryBodyGroup, MirroredSurface]) -> None:
-        """Add an entity to the mirror status."""
-        if self._entity_registry.contains(entity):
-            return
-
-        # pylint: disable=no-member
-        if is_exact_instance(entity, MirrorPlane):
-            self._mirror_status.mirror_planes.append(entity)
-            self._entity_registry.register(entity)
-        elif is_exact_instance(entity, MirroredGeometryBodyGroup):
-            self._mirror_status.mirrored_geometry_body_groups.append(entity)
-            self._entity_registry.register(entity)
-        elif is_exact_instance(entity, MirroredSurface):
-            self._mirror_status.mirrored_surfaces.append(entity)
-            self._entity_registry.register(entity)
-        else:
-            raise Flow360RuntimeError(
-                f"[Internal] Unsupported entity type: {type(entity).__name__}."
-            )
-
-    def _remove(self, entity: MirroredGeometryBodyGroup) -> None:
-        """Remove an MirroredGeometryBodyGroup from the mirror status."""
-        # pylint: disable=no-member
-
-        if entity in self._mirror_status.mirrored_geometry_body_groups:
-            self._mirror_status.mirrored_geometry_body_groups.remove(entity)
-        self._entity_registry.remove(entity)
-
-        # Now remove the mirrored surfaces that are associated with this body group.
-        body_group_id = entity.geometry_body_group_id
-
-        mirrored_surfaces_to_remove = [
-            mirrored_surface
-            for mirrored_surface in list(self._mirror_status.mirrored_surfaces)
-            if getattr(mirrored_surface, "_geometry_body_group_id", None) == body_group_id
-        ]
-        for mirrored_surface in mirrored_surfaces_to_remove:
-            if mirrored_surface in self._mirror_status.mirrored_surfaces:
-                self._mirror_status.mirrored_surfaces.remove(mirrored_surface)
-            self._entity_registry.remove(mirrored_surface)
-
-    @staticmethod
-    def _generate_mirror_status(
-        entity_registry, body_group_id_to_mirror_id, face_group_to_body_group, mirror_planes
-    ) -> MirrorStatus:
-        """Build a serializable status snapshot.
-
-        Parameters
-        ----------
-        entity_registry : EntityRegistry
-            The entity registry to validate entity references against.
-
-        Returns
-        -------
-        Optional[MirrorStatus]
-            The serialized mirror status, or None if no valid mirror actions exist.
-        """
-
-        # Build a set of existing GeometryBodyGroup IDs in the registry for validation.
-        existing_body_group_ids = set()
-        for entity in entity_registry.find_by_type(GeometryBodyGroup):
-            if is_exact_instance(entity, GeometryBodyGroup):
-                existing_body_group_ids.add(entity.private_attribute_id)
-
-        # Filter out actions that refer to body groups that no longer exist in the registry.
-        filtered_actions: Dict[str, str] = {}
-        for body_group_id, mirror_plane_id in body_group_id_to_mirror_id.items():
-            if body_group_id not in existing_body_group_ids:
-                log.warning(
-                    "GeometryBodyGroup '%s' assigned to mirror plane '%s' is not in the draft registry; "
-                    "skipping this mirror action.",
-                    body_group_id,
-                    mirror_plane_id,
-                )
-                continue
-            filtered_actions[body_group_id] = mirror_plane_id
-
-        if not filtered_actions:
-            # No valid mirror actions – nothing to serialize.
-            return MirrorStatus(
-                mirror_planes=[], mirrored_geometry_body_groups=[], mirrored_surfaces=[]
-            )
-
-        mirrored_geometry_groups, mirrored_surfaces = _derive_mirrored_entities_from_actions(
-            body_group_id_to_mirror_id=filtered_actions,
-            face_group_to_body_group=face_group_to_body_group,
-            entity_registry=entity_registry,
-            mirror_planes=mirror_planes,
-        )
-
-        # Only keep mirror planes that are actually referenced by the filtered actions.
-        mirror_planes_by_id: Dict[str, MirrorPlane] = {
-            plane.private_attribute_id: plane for plane in mirror_planes
-        }
-        used_plane_ids = {
-            mirror_plane_id
-            for mirror_plane_id in filtered_actions.values()
-            if mirror_plane_id in mirror_planes_by_id
-        }
-        mirror_planes_for_status: List[MirrorPlane] = [
-            plane for plane in mirror_planes if plane.private_attribute_id in used_plane_ids
-        ]
-
-        return MirrorStatus(
-            mirror_planes=mirror_planes_for_status,
-            mirrored_geometry_body_groups=mirrored_geometry_groups,
-            mirrored_surfaces=mirrored_surfaces,
-        )
+        self._state.remove_mirror_of(entities=entities)
 
     @classmethod
     def _from_status(
         cls,
         *,
-        status: Optional[MirrorStatus],
-        face_group_to_body_group: Optional[Dict[str, str]],
+        status: MirrorStatus | None,
+        face_group_to_body_group: dict[str, str] | None,
         entity_registry: EntityRegistry,
     ) -> "MirrorManager":
-        """Restore manager from a status snapshot.
+        """
+        Restore manager from a status snapshot.
 
         Parameters
         ----------
-        status : Optional[MirrorStatus]
+        status : MirrorStatus | None
             The mirror status to restore from.
-        face_group_to_body_group : Optional[Dict[str, str]]
+        face_group_to_body_group : dict[str, str] | None
             Mapping from surface name to owning body group ID.
         entity_registry : EntityRegistry
             Entity registry containing body groups and surfaces.
@@ -657,43 +173,10 @@ class MirrorManager:
         MirrorManager
             Restored mirror manager.
         """
-        mgr = cls(
-            face_group_to_body_group=face_group_to_body_group,
-            entity_registry=entity_registry,
+        return cls(
+            state=MirrorState._from_status(
+                status=status,
+                face_group_to_body_group=face_group_to_body_group,
+                entity_registry=entity_registry,
+            )
         )
-
-        body_groups = entity_registry.view(  # pylint: disable=protected-access
-            GeometryBodyGroup
-        )._entities
-        valid_body_group_ids = {body_group.private_attribute_id for body_group in body_groups}
-
-        body_group_id_to_mirror_id = _extract_body_group_id_to_mirror_id_from_status(
-            mirror_status=status,
-            valid_body_group_ids=valid_body_group_ids,
-        )
-
-        mgr._body_group_id_to_mirror_id = body_group_id_to_mirror_id
-
-        # Initialize with external mirror planes.
-        # These are not tightly coupled with the persistent entities therefore can be initialized separately.
-        mgr._mirror_status.mirror_planes = status.mirror_planes if status is not None else []
-
-        mgr._mirror_status = cls._generate_mirror_status(
-            entity_registry=entity_registry,
-            body_group_id_to_mirror_id=mgr._body_group_id_to_mirror_id,
-            face_group_to_body_group=mgr._face_group_to_body_group,
-            mirror_planes=mgr._mirror_status.mirror_planes,
-        )
-
-        # Register restored entities in the entity registry without mutating the same
-        # MirrorStatus lists while iterating.
-        for mirrored_group in list(mgr._mirror_status.mirrored_geometry_body_groups):
-            mgr._entity_registry.register(mirrored_group)
-        for mirrored_surface in list(mgr._mirror_status.mirrored_surfaces):
-            mgr._entity_registry.register(mirrored_surface)
-        for mirror_plane in list(mgr._mirror_status.mirror_planes):
-            mgr._entity_registry.register(mirror_plane)
-
-        return mgr
-
-    # endregion ------------------------------------------------------------------------------------

--- a/flow360/component/simulation/draft_context/mirror.py
+++ b/flow360/component/simulation/draft_context/mirror.py
@@ -145,7 +145,7 @@ class MirrorManager:
                 )
 
         return self._state.create_mirror_of(
-            entities=entities,
+            entities=normalized_entities,
             mirror_plane=mirror_plane,
         )
 

--- a/flow360/component/simulation/draft_context/mirror.py
+++ b/flow360/component/simulation/draft_context/mirror.py
@@ -132,7 +132,14 @@ class MirrorManager:
         tuple[list[MirroredGeometryBodyGroup], list[MirroredSurface]]
             Mirrored geometry body groups and surfaces.
         """
-        normalized_entities = [entities] if isinstance(entities, GeometryBodyGroup) else entities
+        if isinstance(entities, GeometryBodyGroup):
+            normalized_entities = [entities]
+        elif isinstance(entities, list):
+            normalized_entities = entities
+        else:
+            raise Flow360ValueError(
+                f"`entities` accepts a single entity or a list of entities. Received type: {type(entities).__name__}."
+            )
         for entity in normalized_entities:
             if not is_exact_instance(entity, GeometryBodyGroup):
                 raise Flow360ValueError(

--- a/flow360/component/simulation/draft_context/mirror.py
+++ b/flow360/component/simulation/draft_context/mirror.py
@@ -19,6 +19,7 @@ from flow360.component.simulation.primitives import (
     MirroredGeometryBodyGroup,
     MirroredSurface,
 )
+from flow360.component.simulation.utils import is_exact_instance
 from flow360.exceptions import Flow360ValueError
 
 # pylint: disable=protected-access
@@ -131,6 +132,18 @@ class MirrorManager:
         tuple[list[MirroredGeometryBodyGroup], list[MirroredSurface]]
             Mirrored geometry body groups and surfaces.
         """
+        normalized_entities = [entities] if isinstance(entities, GeometryBodyGroup) else entities
+        for entity in normalized_entities:
+            if not is_exact_instance(entity, GeometryBodyGroup):
+                raise Flow360ValueError(
+                    "Only GeometryBodyGroup entities are supported by `create()` currently. "
+                    f"Received: {type(entity).__name__}."
+                )
+            if entity.private_attribute_id is None:
+                raise Flow360ValueError(
+                    f"Entity '{entity.name}' ({type(entity).__name__}) is not supported for mirror operations."
+                )
+
         return self._state.create_mirror_of(
             entities=entities,
             mirror_plane=mirror_plane,
@@ -172,6 +185,12 @@ class MirrorManager:
         MirrorManager
             Restored mirror manager.
         """
+        if status is None or status.is_empty():
+            return cls(
+                face_group_to_body_group=face_group_to_body_group,
+                entity_registry=entity_registry,
+            )
+
         return cls(
             state=MirrorState._from_status(
                 status=status,

--- a/poetry.lock
+++ b/poetry.lock
@@ -1468,14 +1468,14 @@ files = [
 
 [[package]]
 name = "flow360-schema"
-version = "0.1.22"
+version = "0.1.24"
 description = "Pure Pydantic schemas for Flow360 - Single Source of Truth"
 optional = false
 python-versions = ">=3.10,<4.0"
 groups = ["main"]
 files = [
-    {file = "flow360_schema-0.1.22-py3-none-any.whl", hash = "sha256:b3f84e445a0aa9b973d682f9b0547f6b6e706dacb2bed12efe003c726ec645b5"},
-    {file = "flow360_schema-0.1.22.tar.gz", hash = "sha256:73d55b2cfc99c673612decb6f1de5f2b46b8d46a0cf55c32619550cccc858bde"},
+    {file = "flow360_schema-0.1.24-py3-none-any.whl", hash = "sha256:ce44c694d88ffb42316f262603b3b1c4ea02e46fd8416564c8fa649fc5b825ab"},
+    {file = "flow360_schema-0.1.24.tar.gz", hash = "sha256:d5ad3ecc5046976c9791d9530ec13d025298e906f73be26ed2f676f556c25e7f"},
 ]
 
 [package.dependencies]
@@ -6526,4 +6526,4 @@ docs = ["autodoc_pydantic", "cairosvg", "ipython", "jinja2", "jupyter", "myst-pa
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.14"
-content-hash = "e11c2aaf5aac714ffa242b26ef22404b4da6689ec4983198cf022ae989675068"
+content-hash = "3aaf995480733e28ca8f33d2197489f017c762d94cfa35c34cefe2a685608727"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ pydantic = ">=2.8,<2.12"
 # -- Local dev (editable install, schema changes take effect immediately):
 # flow360-schema = { path = "../flex/share/flow360-schema", develop = true }
 # -- CI / release (install from CodeArtifact, swap comments before pushing):
-flow360-schema = { version = "~0.1.18", source = "codeartifact" }
+flow360-schema = { version = "~0.1.24", source = "codeartifact" }
 pytest = "^7.1.2"
 click = "^8.1.3"
 toml = "^0.10.2"

--- a/tests/simulation/draft_context/test_coordinate_system_assignment.py
+++ b/tests/simulation/draft_context/test_coordinate_system_assignment.py
@@ -14,7 +14,7 @@ from flow360.component.simulation.draft_context.coordinate_system_manager import
 from flow360.component.simulation.entity_operation import CoordinateSystem
 from flow360.component.simulation.primitives import Edge, ImportedSurface
 from flow360.component.simulation.simulation_params import SimulationParams
-from flow360.exceptions import Flow360RuntimeError
+from flow360.exceptions import Flow360ValueError
 
 
 def _compose(parent: np.ndarray, child: np.ndarray) -> np.ndarray:
@@ -106,7 +106,7 @@ def test_assign_coordinate_system_rejects_cycle(mock_geometry):
         )
 
         with pytest.raises(
-            Flow360RuntimeError, match="Cycle detected in coordinate system inheritance"
+            Flow360ValueError, match="Cycle detected in coordinate system inheritance"
         ):
             draft.coordinate_systems.update_parent(coordinate_system=cs_root, parent=cs_child)
 
@@ -117,7 +117,7 @@ def test_assign_coordinate_system_rejects_duplicate_ids(mock_geometry):
             coordinate_system=CoordinateSystem(name="first", private_attribute_id="dup-id")
         )
         with pytest.raises(
-            Flow360RuntimeError,
+            Flow360ValueError,
             match="Coordinate system id 'dup-id' already registered.",
         ):
             draft.coordinate_systems.add(
@@ -129,7 +129,7 @@ def test_assign_coordinate_system_rejects_duplicate_names(mock_geometry):
     with create_draft(new_run_from=mock_geometry) as draft:
         draft.coordinate_systems.add(coordinate_system=CoordinateSystem(name="dup-name"))
         with pytest.raises(
-            Flow360RuntimeError,
+            Flow360ValueError,
             match="Coordinate system name 'dup-name' already registered.",
         ):
             draft.coordinate_systems.add(coordinate_system=CoordinateSystem(name="dup-name"))
@@ -142,7 +142,7 @@ def test_get_coordinate_system_by_name(mock_geometry):
         assert fetched.private_attribute_id == cs.private_attribute_id
 
         with pytest.raises(
-            Flow360RuntimeError,
+            Flow360ValueError,
             match="Coordinate system 'missing' not found in the draft.",
         ):
             draft.coordinate_systems.get_by_name("missing")
@@ -153,7 +153,7 @@ def test_update_parent_requires_registered_coordinate_system(mock_geometry):
     with create_draft(new_run_from=mock_geometry) as draft:
         cs = CoordinateSystem(name="standalone")
         with pytest.raises(
-            Flow360RuntimeError,
+            Flow360ValueError,
             match="Coordinate system must be part of the draft to be updated.",
         ):
             draft.coordinate_systems.update_parent(coordinate_system=cs, parent=None)
@@ -191,7 +191,7 @@ def test_remove_coordinate_system_errors(mock_geometry):
     with create_draft(new_run_from=mock_geometry) as draft:
         cs = CoordinateSystem(name="not-registered")
         with pytest.raises(
-            Flow360RuntimeError,
+            Flow360ValueError,
             match="Coordinate system is not registered in this draft.",
         ):
             draft.coordinate_systems.remove(coordinate_system=cs)
@@ -201,7 +201,7 @@ def test_remove_coordinate_system_errors(mock_geometry):
             coordinate_system=CoordinateSystem(name="child"), parent=parent
         )
         with pytest.raises(
-            Flow360RuntimeError,
+            Flow360ValueError,
             match="Cannot remove coordinate system 'parent' because dependents exist: child",
         ):
             draft.coordinate_systems.remove(coordinate_system=parent)
@@ -221,7 +221,7 @@ def test_assign_requires_registered_entity(mock_geometry):
         cs = draft.coordinate_systems.add(coordinate_system=CoordinateSystem(name="cs"))
         rogue_entity = CoordinateSystem(name="not-an-entity")  # wrong type
         with pytest.raises(
-            Flow360RuntimeError,
+            Flow360ValueError,
             match="Only entities can be assigned a coordinate system. Received: CoordinateSystem",
         ):
             draft.coordinate_systems.assign(entities=rogue_entity, coordinate_system=cs)
@@ -231,7 +231,7 @@ def test_get_coordinate_system_matrix_requires_registration(mock_geometry):
     with create_draft(new_run_from=mock_geometry) as draft:
         cs = CoordinateSystem(name="unregistered")
         with pytest.raises(
-            Flow360RuntimeError,
+            Flow360ValueError,
             match="Coordinate system must be registered to compute its matrix.",
         ):
             draft.coordinate_systems._get_coordinate_system_matrix(coordinate_system=cs)
@@ -272,7 +272,7 @@ def test_from_status_validation_errors(mock_geometry):
             ],
         )
         with pytest.raises(
-            Flow360RuntimeError,
+            Flow360ValueError,
             match="Parent record references unknown coordinate system 'missing'",
         ):
             CoordinateSystemManager._from_status(
@@ -294,7 +294,7 @@ def test_from_status_rejects_assignment_unknown_cs(mock_geometry):
             ],
         )
         with pytest.raises(
-            Flow360RuntimeError,
+            Flow360ValueError,
             match="Assignment references unknown coordinate system 'missing'",
         ):
             CoordinateSystemManager._from_status(
@@ -327,7 +327,7 @@ def test_from_status_rejects_duplicate_entity_assignment(mock_geometry):
             ],
         )
         with pytest.raises(
-            Flow360RuntimeError,
+            Flow360ValueError,
             match=f"Duplicate entity assignment for entity '{entity_type_name}:{entity_id}'",
         ):
             CoordinateSystemManager._from_status(
@@ -439,7 +439,7 @@ def test_assign_entity_without_id_raises(mock_geometry):
         entity_without_id = Edge(name="orphan_edge")
         assert entity_without_id.private_attribute_id is None
 
-        with pytest.raises(Flow360RuntimeError, match="is not supported for coordinate system"):
+        with pytest.raises(Flow360ValueError, match="is not supported for coordinate system"):
             draft.coordinate_systems.assign(entities=entity_without_id, coordinate_system=cs)
 
 

--- a/tests/simulation/draft_context/test_mirror_action.py
+++ b/tests/simulation/draft_context/test_mirror_action.py
@@ -326,6 +326,18 @@ def test_remove_mirror_of_rejects_invalid_input_type(mock_geometry):
             draft.mirror.remove_mirror_of(entities="invalid_string")
 
 
+def test_create_mirror_of_rejects_invalid_input_type(mock_geometry):
+    """Test that create_mirror_of rejects invalid input types."""
+    with create_draft(new_run_from=mock_geometry) as draft:
+        mirror_plane = MirrorPlane(name="mirror", normal=(1, 0, 0), center=(0, 0, 0) * u.m)
+
+        with pytest.raises(
+            Flow360ValueError,
+            match="`entities` accepts a single entity or a list of entities",
+        ):
+            draft.mirror.create_mirror_of(entities="invalid_string", mirror_plane=mirror_plane)
+
+
 def test_remove_mirror_of_rejects_invalid_entity_type(mock_geometry):
     """Test that remove_mirror_of rejects invalid entity types."""
     with create_draft(new_run_from=mock_geometry) as draft:

--- a/tests/simulation/draft_context/test_mirror_action.py
+++ b/tests/simulation/draft_context/test_mirror_action.py
@@ -18,7 +18,7 @@ from flow360.component.simulation.draft_context.mirror import (
 )
 from flow360.component.simulation.primitives import GeometryBodyGroup
 from flow360.component.simulation.simulation_params import SimulationParams
-from flow360.exceptions import Flow360RuntimeError
+from flow360.exceptions import Flow360ValueError
 
 
 def test_mirror_single_call_returns_expected_entities(mock_geometry):
@@ -277,7 +277,7 @@ def test_mirror_create_rejects_duplicate_plane_name(mock_geometry):
         )
 
         with pytest.raises(
-            Flow360RuntimeError,
+            Flow360ValueError,
             match="Mirror plane name 'mirror' already exists in the draft",
         ):
             draft.mirror.create_mirror_of(entities=body_groups[0], mirror_plane=mirror_plane2)
@@ -320,7 +320,7 @@ def test_remove_mirror_of_rejects_invalid_input_type(mock_geometry):
     with create_draft(new_run_from=mock_geometry) as draft:
         # Try to pass something that's neither a GeometryBodyGroup nor a list
         with pytest.raises(
-            Flow360RuntimeError,
+            Flow360ValueError,
             match="`entities` accepts a single entity or a list of entities",
         ):
             draft.mirror.remove_mirror_of(entities="invalid_string")
@@ -333,7 +333,7 @@ def test_remove_mirror_of_rejects_invalid_entity_type(mock_geometry):
         invalid_entity = MirrorPlane(name="invalid", normal=(1, 0, 0), center=(0, 0, 0) * u.m)
 
         with pytest.raises(
-            Flow360RuntimeError,
+            Flow360ValueError,
             match="Only GeometryBodyGroup entities are supported by `remove_mirror_of\\(\\)`",
         ):
             draft.mirror.remove_mirror_of(entities=[invalid_entity])
@@ -534,7 +534,7 @@ def test_mirror_create_raises_when_face_group_to_body_group_is_none(mock_geometr
         )
 
         with pytest.raises(
-            Flow360RuntimeError,
+            Flow360ValueError,
             match="Mirroring is not available because the surface-to-body-group mapping could not be derived",
         ):
             mirror_manager.create_mirror_of(entities=body_group, mirror_plane=mirror_plane)
@@ -796,5 +796,5 @@ def test_mirror_entity_without_id_raises(mock_geometry):
             center=(0, 0, 0) * u.m,
         )
 
-        with pytest.raises(Flow360RuntimeError, match="is not supported for mirror"):
+        with pytest.raises(Flow360ValueError, match="is not supported for mirror"):
             draft.mirror.create_mirror_of(entities=[entity_without_id], mirror_plane=mirror_plane)


### PR DESCRIPTION
## What changed
- refactor `CoordinateSystemManager` into a thin client facade over schema-side `CoordinateSystemState`
- refactor `MirrorManager` into a thin client facade over schema-side `MirrorState`
- keep user-facing draft APIs and docstrings on the client managers
- preserve the currently used internal compatibility surface needed by draft plumbing, translators, and tests
- normalize manager errors to `Flow360ValueError`
- update draft-context tests accordingly

## Why
The simulation schema migration was about to drag full client draft managers into schema. That would blur the package boundary and make the migration PR harder to review.

This PR isolates the client-facing manager layer from the reusable state/core layer first, so the later migration PR can stay focused on mostly 1:1 model movement.

## Impact
- client still owns the user-facing draft manager API
- schema owns the reusable coordinate-system and mirror state logic
- migration PRs no longer need to carry manager implementation churn together with model moves

## Validation
- `pytest tests/simulation/draft_context/test_coordinate_system_assignment.py`
- `pytest tests/simulation/validation/test_coordinate_system_constraints.py`
- `pytest tests/simulation/draft_context/test_mirror_action.py`
- `pytest tests/simulation/params/test_simulation_params.py::test_transformation_matrix`
- `pytest tests/simulation/translator/test_gai_coordinate_system_e2e.py`
- `pytest tests/simulation/translator/test_mirrored_entity_translation.py`
- `pytest tests/simulation/translator/test_surface_meshing_translator.py`

## Notes
Local `pyproject.toml` / `poetry.lock` path-dependency drift in the client worktree was intentionally left out of this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate refactor of draft-context coordinate system and mirror managers to delegate core behavior to schema-side state objects; regressions would impact entity transformations and mirrored-entity generation/serialization. Also bumps `flow360-schema` dependency, which can change runtime behavior beyond this repo.
> 
> **Overview**
> **Refactors draft-context managers to use schema state via composition.** `CoordinateSystemManager` now wraps `CoordinateSystemState` and delegates graph validation, matrix composition, status (de)serialization, and entity assignment helpers while preserving a small internal compatibility surface (`_coordinate_systems`, `_coordinate_system_parents`, `_entity_key_to_coordinate_system_id`).
> 
> **Mirroring logic is similarly moved behind `MirrorState`.** `MirrorManager` drops its local derived-entity/build/serialization helpers in favor of `MirrorState` (and schema-exported `_derive_mirrored_entities_from_actions`/`MIRROR_SUFFIX`), adjusts `MirrorPlane` import, and keeps compatibility accessors for draft plumbing.
> 
> **Behavioral/contract tweaks.** Manager-raised errors are normalized to `Flow360ValueError`, draft-context tests are updated accordingly (plus a new invalid-input test for `create_mirror_of`), and `flow360-schema` is bumped to `~0.1.24` in `pyproject.toml`/`poetry.lock`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a86d6d0f8e09857c537c11ed122291cab40577d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->