### PR TITLE
fix: narrow Wall velocity validation errors

### DIFF
--- a/flow360/component/simulation/models/surface_models.py
+++ b/flow360/component/simulation/models/surface_models.py
@@ -308,7 +308,9 @@ class WallRotation(Flow360BaseModel):
     # pylint: disable=no-member
     center: LengthType.Point = pd.Field(description="The center of rotation")
     axis: Axis = pd.Field(description="The axis of rotation.")
-    angular_velocity: AngularVelocityType = pd.Field("The value of the angular velocity.")
+    angular_velocity: AngularVelocityType = pd.Field(
+        description="The value of the angular velocity."
+    )
     type_name: Literal["WallRotation"] = pd.Field("WallRotation", frozen=True)
     private_attribute_circle_mode: Optional[dict] = pd.Field(None)
 
@@ -321,6 +323,7 @@ class WallRotation(Flow360BaseModel):
 WallVelocityModelTypes = Annotated[
     Union[SlaterPorousBleed, WallRotation], pd.Field(discriminator="type_name")
 ]
+WALL_VELOCITY_MODEL_ADAPTER = pd.TypeAdapter(WallVelocityModelTypes)
 
 
 class WallFunction(Flow360BaseModel):
@@ -474,6 +477,15 @@ class Wall(BoundaryBase):
                 "Use `use_wall_function=None` instead of `False`."
             )
             return None
+        return value
+
+    @pd.field_validator("velocity", mode="before")
+    @classmethod
+    def _normalize_velocity(cls, value):
+        # Sadly we cannot add a discriminator to `velocity` directly because the alternative
+        # branch is `VelocityVectorType`, which compiles to a tuple schema instead of a model variant.
+        if isinstance(value, dict) and value.get("type_name") is not None:
+            return WALL_VELOCITY_MODEL_ADAPTER.validate_python(value)
         return value
 
     @pd.model_validator(mode="after")

--- a/tests/simulation/params/test_rotation.py
+++ b/tests/simulation/params/test_rotation.py
@@ -1,4 +1,5 @@
 import pytest
+from pydantic import ValidationError
 
 from flow360 import u
 from flow360.component.simulation.models.surface_models import Wall, WallRotation
@@ -46,6 +47,37 @@ def test_wall_angular_velocity():
         surfaces=[my_wall_surface],
         velocity=WallRotation(axis=(0, 0, 1), center=(1, 2, 3) * u.m, angular_velocity=100 * u.rpm),
         use_wall_function=True,
+    )
+
+
+def test_wall_rotation_missing_angular_velocity_reports_required_field():
+    with pytest.raises(ValidationError) as exc_info:
+        Wall.model_validate(
+            {
+                "name": "Wheel Front",
+                "type": "Wall",
+                "entities": {"stored_entities": []},
+                "velocity": {
+                    "axis": [0, -1, 0],
+                    "center": {"value": [0, 0, 0], "units": "m"},
+                    "type_name": "WallRotation",
+                },
+            }
+        )
+
+    errors = exc_info.value.errors()
+    angular_velocity_errors = [
+        error for error in errors if error["loc"][-1] == "angular_velocity"
+    ]
+    assert len(angular_velocity_errors) == 1
+    assert angular_velocity_errors[0]["msg"] == "Field required"
+    assert all(
+        not any(
+            isinstance(segment, str)
+            and ("tuple[" in segment or "function-plain[" in segment)
+            for segment in error["loc"]
+        )
+        for error in errors
     )
 
 

--- a/tests/simulation/params/test_rotation.py
+++ b/tests/simulation/params/test_rotation.py
@@ -66,15 +66,12 @@ def test_wall_rotation_missing_angular_velocity_reports_required_field():
         )
 
     errors = exc_info.value.errors()
-    angular_velocity_errors = [
-        error for error in errors if error["loc"][-1] == "angular_velocity"
-    ]
+    angular_velocity_errors = [error for error in errors if error["loc"][-1] == "angular_velocity"]
     assert len(angular_velocity_errors) == 1
     assert angular_velocity_errors[0]["msg"] == "Field required"
     assert all(
         not any(
-            isinstance(segment, str)
-            and ("tuple[" in segment or "function-plain[" in segment)
+            isinstance(segment, str) and ("tuple[" in segment or "function-plain[" in segment)
             for segment in error["loc"]
         )
         for error in errors


### PR DESCRIPTION
## Summary
- fix `WallRotation.angular_velocity` so its field metadata is treated as a description instead of a default value
- route `Wall.velocity` dict inputs through the tagged wall-velocity models before the tuple branch is attempted
- add a regression test for missing `WallRotation.angular_velocity`

## Why
Missing `WallRotation.angular_velocity` currently produces noisy validation output:
- the field description string is parsed as a unit expression because it was accidentally used as the default value
- `Wall.velocity` is a union with `VelocityVectorType`, so dict inputs also leak tuple/validator branch errors that are irrelevant once `type_name` already points to `WallRotation`

## Validation
- `python -m py_compile flow360/component/simulation/models/surface_models.py tests/simulation/params/test_rotation.py`
- `HOME=/tmp MPLCONFIGDIR=/tmp/matplotlib /disk2/ben/SchemaMigration/Flow360/.venv/bin/python3 -m pytest -c tests/pytest.ini -rA tests/simulation/params/test_rotation.py -k 'wall_angular_velocity or missing_angular_velocity'`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Pydantic validation for `Wall.velocity` unions, which can subtly change which branch is selected and the resulting error messages. Functional behavior should be unchanged for valid inputs, but invalid inputs will now fail differently and need test coverage (added here).
> 
> **Overview**
> Improves `WallRotation` and `Wall` validation to produce cleaner, more relevant errors when parsing wall velocity inputs.
> 
> Fixes `WallRotation.angular_velocity` field metadata so the description is no longer treated as a default value, and adds a `Wall.velocity` pre-validator that routes dict inputs with `type_name` through a `TypeAdapter` for the tagged wall-velocity models (avoiding noisy tuple-branch errors from `VelocityVectorType`). Adds a regression test asserting a missing `angular_velocity` reports a single `Field required` error without irrelevant union/tuple noise.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27628c60fea9bcf2fc3aaf5c018faadcca7ba074. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->