### PR TITLE
fix(): Improve PyPI approval release context

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -96,22 +96,40 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
+        ref: ${{ needs.validate-release-source.outputs.tag_commit_sha }}
         sparse-checkout: |
           .github/scripts
+          flow360/version.py
     - name: Collect and summarize tagged commit CI status
       uses: actions/github-script@v7
       env:
         RELEASE_BRANCH: ${{ needs.validate-release-source.outputs.release_branch }}
+        RELEASE_TAG: ${{ needs.validate-release-source.outputs.release_tag }}
         TAG_COMMIT_SHA: ${{ needs.validate-release-source.outputs.tag_commit_sha }}
       with:
         script: |
+          const fs = require("fs");
           const {
             listCheckRunsForRef,
             getDetailsUrl,
           } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/pypi_check_runs.js`);
           const { owner, repo } = context.repo;
           const branch = process.env.RELEASE_BRANCH;
+          const releaseTag = process.env.RELEASE_TAG;
+          const releaseVersion = releaseTag.replace(/^v/, "");
           const tagCommitSha = process.env.TAG_COMMIT_SHA;
+          const versionFilePath = "flow360/version.py";
+          const versionFileContents = fs.readFileSync(
+            `${process.env.GITHUB_WORKSPACE}/${versionFilePath}`,
+            "utf8"
+          );
+          const versionMatch = versionFileContents.match(/^__version__\s*=\s*["']([^"']+)["']/m);
+
+          if (!versionMatch) {
+            throw new Error(`Could not parse __version__ from ${versionFilePath}.`);
+          }
+
+          const packageVersion = versionMatch[1];
 
           const branchInfo = await github.rest.repos.getBranch({ owner, repo, branch });
           const branchHeadSha = branchInfo.data.commit.sha;
@@ -140,12 +158,15 @@ jobs:
           const serverUrl = process.env.GITHUB_SERVER_URL;
           const repoSlug = process.env.GITHUB_REPOSITORY;
           const runId = process.env.GITHUB_RUN_ID;
+          const versionFileUrl = `${serverUrl}/${repoSlug}/blob/${tagCommitSha}/${versionFilePath}`;
 
           const lines = [
             `## PyPI Publish Approval Context`,
             ``,
             `| Field | Value |`,
             `|-------|-------|`,
+            `| Release tag/version | \`${releaseTag}\` / \`${releaseVersion}\` |`,
+            `| flow360/version.py | [${versionFilePath}](${versionFileUrl}) -> \`__version__ = "${packageVersion}"\` |`,
             `| Tag commit SHA | \`${tagCommitSha}\` |`,
             `| Release branch | \`${branch}\` |`,
             `| Branch HEAD SHA | \`${branchHeadSha}\` |`,

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -99,7 +99,7 @@ jobs:
         ref: ${{ needs.validate-release-source.outputs.tag_commit_sha }}
         sparse-checkout: |
           .github/scripts
-          flow360/version.py
+          flow360
     - name: Collect and summarize tagged commit CI status
       uses: actions/github-script@v7
       env:


### PR DESCRIPTION
## What changed
- update the `collect-approval-context` job to checkout the tagged commit instead of the workflow ref
- add a `Release tag/version` row to the approval summary table
- add a `flow360/version.py` row that links to the version file at the tagged commit and shows the parsed `__version__`

## Why
In `workflow_dispatch`, the workflow ref can be the release branch HEAD rather than the tagged commit being approved. That makes the approval summary less trustworthy for manual release inspection. Checking out the tagged commit and showing both the requested release tag/version and the actual `flow360/version.py` value makes approval easier and safer.

## Impact
Approvers can verify the exact version metadata for the commit that will be published without leaving the approval summary.

## Validation
- inspected the workflow diff to confirm only `collect-approval-context` changed
- ran `git diff --check -- .github/workflows/pypi-publish.yml`
- ran a local `node` regex parse against `flow360/version.py` to verify the `__version__` extraction logic

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that improves the manual approval summary; main risk is a publish-blocking failure if `flow360/version.py` can’t be checked out or `__version__` can’t be parsed for a tag.
> 
> **Overview**
> Tightens the `collect-approval-context` step in `pypi-publish.yml` to **checkout the exact tagged commit SHA** (and include `flow360/` in sparse checkout) so approval data reflects what will actually be published.
> 
> Enhances the approval summary by adding the requested **release tag/version** and by reading `flow360/version.py` at the tag to parse and display `__version__` (with a direct link to the file at that commit).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a4bf03145d1e96f42b65aefb01f01d7cd364d8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->