### PR TITLE
[FXC-7076] Add validation to check empty list in force output's models field

### DIFF
--- a/flow360/component/simulation/outputs/outputs.py
+++ b/flow360/component/simulation/outputs/outputs.py
@@ -857,6 +857,7 @@ class ForceOutput(_OutputBase):
     )
     models: List[Union[ForceOutputModelType, str]] = pd.Field(
         description="List of surface/volume models (or model ids) whose force contribution will be calculated.",
+        min_length=1,
     )
     moving_statistic: Optional[MovingStatistic] = pd.Field(
         None, description="When specified, report moving statistics of the fields instead."

--- a/tests/simulation/params/test_validators_output.py
+++ b/tests/simulation/params/test_validators_output.py
@@ -1297,6 +1297,19 @@ def test_force_output_with_surface_and_volume_models(mock_validation_context):
             )
 
 
+def test_force_output_empty_models():
+    """Test that ForceOutput rejects empty models list."""
+    with pytest.raises(
+        pydantic.ValidationError,
+        match="models",
+    ):
+        fl.ForceOutput(
+            name="force_output",
+            models=[],
+            output_fields=["CL", "CD"],
+        )
+
+
 def test_force_output_duplicate_models():
     """Test that ForceOutput rejects duplicate models."""
     wall_1 = Wall(entities=Surface(name="fluid/wing"))


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low-risk validation tightening, but it is a small backward-incompatible change for any callers previously constructing `ForceOutput` with `models=[]`.
> 
> **Overview**
> `ForceOutput.models` is now validated to require at least one model (`min_length=1`), preventing creation of force outputs that reference no contributing surface/volume models.
> 
> Adds a unit test asserting a `pydantic.ValidationError` is raised when `models` is an empty list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5373920286e595070da428a5d6d41b2799121372. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->