### PR TITLE
feat(Inflow): add rotate_velocity_direction_with_mesh option

### DIFF
--- a/flow360/component/simulation/translator/solver_translator.py
+++ b/flow360/component/simulation/translator/solver_translator.py
@@ -1649,6 +1649,8 @@ def boundary_spec_translator(model: SurfaceModelTypes, op_acoustic_to_static_pre
         boundary["totalTemperatureRatio"] = model_dict["totalTemperature"]
         if model.velocity_direction is not None:
             boundary["velocityDirection"] = list(model_dict["velocityDirection"])
+            if not model.rotate_velocity_direction_with_mesh:
+                boundary["rotateVelocityDirectionWithMesh"] = False
         if isinstance(model.spec, TotalPressure):
             boundary["type"] = "SubsonicInflow"
             total_pressure_ratio = model_dict["spec"]["value"]

--- a/flow360/component/simulation/translator/solver_translator.py
+++ b/flow360/component/simulation/translator/solver_translator.py
@@ -1649,8 +1649,8 @@ def boundary_spec_translator(model: SurfaceModelTypes, op_acoustic_to_static_pre
         boundary["totalTemperatureRatio"] = model_dict["totalTemperature"]
         if model.velocity_direction is not None:
             boundary["velocityDirection"] = list(model_dict["velocityDirection"])
-            if not model.rotate_velocity_direction_with_mesh:
-                boundary["rotateVelocityDirectionWithMesh"] = False
+            if model.rotate_velocity_direction_with_mesh:
+                boundary["rotateVelocityDirectionWithMesh"] = True
         if isinstance(model.spec, TotalPressure):
             boundary["type"] = "SubsonicInflow"
             total_pressure_ratio = model_dict["spec"]["value"]

--- a/poetry.lock
+++ b/poetry.lock
@@ -1468,14 +1468,14 @@ files = [
 
 [[package]]
 name = "flow360-schema"
-version = "25.10.2b1"
+version = "25.10.3b1"
 description = "Pure Pydantic schemas for Flow360 - Single Source of Truth"
 optional = false
 python-versions = ">=3.10,<4.0"
 groups = ["main"]
 files = [
-    {file = "flow360_schema-25.10.2b1-py3-none-any.whl", hash = "sha256:52e0ffd6e5a4c20fb23155b68fc1eadeebcb1f4236bab20c4d1b83043649e34c"},
-    {file = "flow360_schema-25.10.2b1.tar.gz", hash = "sha256:4f9f5b94635dc60a4862d90e5465cadcad32ec0a0fb65541347a556b1ea36503"},
+    {file = "flow360_schema-25.10.3b1-py3-none-any.whl", hash = "sha256:eecb0aace7d1b940f2bfb36939f4a71dde4272e5ba1954b397ffcdd62b1075a1"},
+    {file = "flow360_schema-25.10.3b1.tar.gz", hash = "sha256:f8b0483f701ccdc07380baa566318f375fb9d76c64e7267c9808ceb74929cb5b"},
 ]
 
 [package.dependencies]
@@ -6526,4 +6526,4 @@ docs = ["autodoc_pydantic", "cairosvg", "ipython", "jinja2", "jupyter", "myst-pa
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.14"
-content-hash = "6c2dbbccc52682232b6182a17d80c78822b01557fc1620c5d3553e97c9e84147"
+content-hash = "b4aa1fa2749f81bfacef4364bc7e7f7a4a91dd2470f79113002236df012dda9f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ pydantic = ">=2.8,<2.12"
 # -- Local dev (editable install, schema changes take effect immediately):
 # flow360-schema = { path = "../../../../flex/share/flow360-schema", develop = true }
 # -- CI / release (install from CodeArtifact, swap comments before pushing):
-flow360-schema = { version = "= 25.10.2b1", source = "codeartifact" }
+flow360-schema = { version = "= 25.10.3b1", source = "codeartifact" }
 pytest = "^7.1.2"
 click = "^8.1.3"
 toml = "^0.10.2"

--- a/tests/simulation/translator/test_solver_translator.py
+++ b/tests/simulation/translator/test_solver_translator.py
@@ -944,7 +944,7 @@ def test_boundaries():
 
 
 def test_rotate_velocity_direction_with_mesh():
-    """Verify rotateVelocityDirectionWithMesh is emitted only when overridden to False."""
+    """Verify rotateVelocityDirectionWithMesh is emitted only when set to True."""
     operating_condition = AerospaceCondition(velocity_magnitude=10 * u.m / u.s)
     with SI_unit_system:
         param_default = SimulationParams(
@@ -962,7 +962,7 @@ def test_rotate_velocity_direction_with_mesh():
                 ),
             ],
         )
-        param_disabled = SimulationParams(
+        param_enabled = SimulationParams(
             operating_condition=operating_condition,
             models=[
                 Inflow(
@@ -974,7 +974,7 @@ def test_rotate_velocity_direction_with_mesh():
                         static_pressure=101325 * u.Pa,
                     ),
                     velocity_direction=(0, -1, 0),
-                    rotate_velocity_direction_with_mesh=False,
+                    rotate_velocity_direction_with_mesh=True,
                 ),
             ],
         )
@@ -983,9 +983,9 @@ def test_rotate_velocity_direction_with_mesh():
     bc_default = translated_default["boundaries"]["engine_face"]
     assert "rotateVelocityDirectionWithMesh" not in bc_default
 
-    translated_disabled = get_solver_json(param_disabled, mesh_unit=1 * u.m)
-    bc_disabled = translated_disabled["boundaries"]["engine_face"]
-    assert bc_disabled["rotateVelocityDirectionWithMesh"] is False
+    translated_enabled = get_solver_json(param_enabled, mesh_unit=1 * u.m)
+    bc_enabled = translated_enabled["boundaries"]["engine_face"]
+    assert bc_enabled["rotateVelocityDirectionWithMesh"] is True
 
 
 def test_liquid_simulation_translation():

--- a/tests/simulation/translator/test_solver_translator.py
+++ b/tests/simulation/translator/test_solver_translator.py
@@ -943,6 +943,51 @@ def test_boundaries():
     translate_and_compare(param, mesh_unit=1 * u.m, ref_json_file="Flow360_boundaries.json")
 
 
+def test_rotate_velocity_direction_with_mesh():
+    """Verify rotateVelocityDirectionWithMesh is emitted only when overridden to False."""
+    operating_condition = AerospaceCondition(velocity_magnitude=10 * u.m / u.s)
+    with SI_unit_system:
+        param_default = SimulationParams(
+            operating_condition=operating_condition,
+            models=[
+                Inflow(
+                    name="exhaust",
+                    total_temperature=750 * u.K,
+                    surfaces=Surface(name="engine_face"),
+                    spec=Supersonic(
+                        total_pressure=3e6 * u.Pa,
+                        static_pressure=101325 * u.Pa,
+                    ),
+                    velocity_direction=(0, -1, 0),
+                ),
+            ],
+        )
+        param_disabled = SimulationParams(
+            operating_condition=operating_condition,
+            models=[
+                Inflow(
+                    name="exhaust",
+                    total_temperature=750 * u.K,
+                    surfaces=Surface(name="engine_face"),
+                    spec=Supersonic(
+                        total_pressure=3e6 * u.Pa,
+                        static_pressure=101325 * u.Pa,
+                    ),
+                    velocity_direction=(0, -1, 0),
+                    rotate_velocity_direction_with_mesh=False,
+                ),
+            ],
+        )
+
+    translated_default = get_solver_json(param_default, mesh_unit=1 * u.m)
+    bc_default = translated_default["boundaries"]["engine_face"]
+    assert "rotateVelocityDirectionWithMesh" not in bc_default
+
+    translated_disabled = get_solver_json(param_disabled, mesh_unit=1 * u.m)
+    bc_disabled = translated_disabled["boundaries"]["engine_face"]
+    assert bc_disabled["rotateVelocityDirectionWithMesh"] is False
+
+
 def test_liquid_simulation_translation():
     with SI_unit_system:
         param = SimulationParams(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, opt-in translation change gated behind a new boolean flag plus a schema version bump; risk is mainly limited to compatibility with the updated schema/solver key.
> 
> **Overview**
> Adds support for an `Inflow.rotate_velocity_direction_with_mesh` option by conditionally emitting `rotateVelocityDirectionWithMesh: true` in the translated solver boundary JSON when a `velocity_direction` is provided.
> 
> Updates the `flow360-schema` dependency from `25.10.2b1` to `25.10.3b1` and adds a translator unit test asserting the new key is *absent by default* and *present only when enabled*.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c5a689ef80b69a3d42986b0c23c06869c01116a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->