### PR TITLE
Avoid frozen sequence rewrites during translator transforms

### DIFF
--- a/flow360/component/simulation/translator/utils.py
+++ b/flow360/component/simulation/translator/utils.py
@@ -135,7 +135,9 @@ def _apply_transformations_to_model(
                 transformed_items[index] = transformed
 
             if transformed_items is not None:
-                new_value = transformed_items if isinstance(field_value, list) else tuple(transformed_items)
+                new_value = (
+                    transformed_items if isinstance(field_value, list) else tuple(transformed_items)
+                )
                 setattr(model, field_name, new_value)
 
         elif isinstance(field_value, Flow360BaseModel):

--- a/flow360/component/simulation/translator/utils.py
+++ b/flow360/component/simulation/translator/utils.py
@@ -125,9 +125,18 @@ def _apply_transformations_to_model(
                 setattr(model, field_name, new_entity_list)
 
         elif isinstance(field_value, (list, tuple)):
-            new_items = [_transform_sequence_item(item, manager) for item in field_value]
-            new_value = new_items if isinstance(field_value, list) else tuple(new_items)
-            setattr(model, field_name, new_value)
+            transformed_items = None
+            for index, item in enumerate(field_value):
+                transformed = _transform_sequence_item(item, manager)
+                if transformed is item:
+                    continue
+                if transformed_items is None:
+                    transformed_items = list(field_value)
+                transformed_items[index] = transformed
+
+            if transformed_items is not None:
+                new_value = transformed_items if isinstance(field_value, list) else tuple(transformed_items)
+                setattr(model, field_name, new_value)
 
         elif isinstance(field_value, Flow360BaseModel):
             _apply_transformations_to_model(field_value, manager)

--- a/poetry.lock
+++ b/poetry.lock
@@ -1473,10 +1473,8 @@ description = "Pure Pydantic schemas for Flow360 - Single Source of Truth"
 optional = false
 python-versions = ">=3.10,<4.0"
 groups = ["main"]
-files = [
-    {file = "flow360_schema-0.1.25-py3-none-any.whl", hash = "sha256:4c9897a4f1b53df16615a0a4a0e69960cfd94d479acb3fe00f17d6b9be6d668b"},
-    {file = "flow360_schema-0.1.25.tar.gz", hash = "sha256:81c1518f09559748fec8c4cf6715c52f3fa81a4d7008021faeb662b39a88a925"},
-]
+files = []
+develop = true
 
 [package.dependencies]
 pydantic = ">=2.8,<3.0"
@@ -1484,9 +1482,8 @@ unyt = ">=2.9.0"
 wcmatch = ">=10,<11"
 
 [package.source]
-type = "legacy"
-url = "https://flexcompute-625554095313.d.codeartifact.us-east-1.amazonaws.com/pypi/pypi-releases/simple"
-reference = "codeartifact"
+type = "directory"
+url = "../../../../flex/share/flow360-schema"
 
 [[package]]
 name = "fonttools"
@@ -6526,4 +6523,4 @@ docs = ["autodoc_pydantic", "cairosvg", "ipython", "jinja2", "jupyter", "myst-pa
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.14"
-content-hash = "3aaf995480733e28ca8f33d2197489f017c762d94cfa35c34cefe2a685608727"
+content-hash = "0fad35a82e08e3a426b59802fb4f175f4908fd2785197aeca5647de00b870f30"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1468,13 +1468,15 @@ files = [
 
 [[package]]
 name = "flow360-schema"
-version = "0.1.25"
+version = "0.1.26"
 description = "Pure Pydantic schemas for Flow360 - Single Source of Truth"
 optional = false
 python-versions = ">=3.10,<4.0"
 groups = ["main"]
-files = []
-develop = true
+files = [
+    {file = "flow360_schema-0.1.26-py3-none-any.whl", hash = "sha256:393848512d87798f8a85614492feb9cb2e8b39b57e27a31e62243427865cd317"},
+    {file = "flow360_schema-0.1.26.tar.gz", hash = "sha256:5edd47bdce8f6f329969a028af2c333cc0b88af250b0331bb54b8f1992519964"},
+]
 
 [package.dependencies]
 pydantic = ">=2.8,<3.0"
@@ -1482,8 +1484,9 @@ unyt = ">=2.9.0"
 wcmatch = ">=10,<11"
 
 [package.source]
-type = "directory"
-url = "../../../../flex/share/flow360-schema"
+type = "legacy"
+url = "https://flexcompute-625554095313.d.codeartifact.us-east-1.amazonaws.com/pypi/pypi-releases/simple"
+reference = "codeartifact"
 
 [[package]]
 name = "fonttools"
@@ -6523,4 +6526,4 @@ docs = ["autodoc_pydantic", "cairosvg", "ipython", "jinja2", "jupyter", "myst-pa
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.14"
-content-hash = "0fad35a82e08e3a426b59802fb4f175f4908fd2785197aeca5647de00b870f30"
+content-hash = "3aaf995480733e28ca8f33d2197489f017c762d94cfa35c34cefe2a685608727"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,9 +14,9 @@ priority = "explicit"
 python = ">=3.10,<3.14"
 pydantic = ">=2.8,<2.12"
 # -- Local dev (editable install, schema changes take effect immediately):
-flow360-schema = { path = "../../../../flex/share/flow360-schema", develop = true }
+# flow360-schema = { path = "../../../../flex/share/flow360-schema", develop = true }
 # -- CI / release (install from CodeArtifact, swap comments before pushing):
-# flow360-schema = { version = "~0.1.24", source = "codeartifact" }
+flow360-schema = { version = "~0.1.24", source = "codeartifact" }
 pytest = "^7.1.2"
 click = "^8.1.3"
 toml = "^0.10.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,9 +14,9 @@ priority = "explicit"
 python = ">=3.10,<3.14"
 pydantic = ">=2.8,<2.12"
 # -- Local dev (editable install, schema changes take effect immediately):
-# flow360-schema = { path = "../flex/share/flow360-schema", develop = true }
+flow360-schema = { path = "../../../../flex/share/flow360-schema", develop = true }
 # -- CI / release (install from CodeArtifact, swap comments before pushing):
-flow360-schema = { version = "~0.1.24", source = "codeartifact" }
+# flow360-schema = { version = "~0.1.24", source = "codeartifact" }
 pytest = "^7.1.2"
 click = "^8.1.3"
 toml = "^0.10.2"

--- a/tests/simulation/translator/test_translation_utils.py
+++ b/tests/simulation/translator/test_translation_utils.py
@@ -1,0 +1,87 @@
+import flow360.component.simulation.units as u
+from flow360.component.simulation.draft_context.coordinate_system_manager import (
+    CoordinateSystemAssignmentGroup,
+    CoordinateSystemEntityRef,
+    CoordinateSystemStatus,
+)
+from flow360.component.simulation.entity_operation import CoordinateSystem
+from flow360.component.simulation.framework.param_utils import AssetCache
+from flow360.component.simulation.models.volume_models import (
+    BETDisk,
+    BETDiskChord,
+    BETDiskSectionalPolar,
+    BETDiskTwist,
+)
+from flow360.component.simulation.primitives import Cylinder
+from flow360.component.simulation.simulation_params import SimulationParams
+from flow360.component.simulation.translator.utils import (
+    apply_coordinate_system_transformations,
+)
+from flow360.component.simulation.unit_system import SI_unit_system
+
+
+def test_apply_coordinate_system_transformations_skips_frozen_non_entity_sequences():
+    with SI_unit_system:
+        cylinder = Cylinder(
+            name="bet_disk",
+            center=(0, 0, 0) * u.m,
+            axis=(0, 0, 1),
+            height=1 * u.m,
+            outer_radius=1 * u.m,
+        )
+        bet_disk = BETDisk(
+            entities=cylinder,
+            rotation_direction_rule="leftHand",
+            number_of_blades=3,
+            omega=100 * u.rpm,
+            chord_ref=1 * u.m,
+            n_loading_nodes=20,
+            mach_numbers=[0],
+            reynolds_numbers=[1000000],
+            twists=[BETDiskTwist(radius=0 * u.m, twist=0 * u.deg)],
+            chords=[BETDiskChord(radius=0 * u.m, chord=1 * u.m)],
+            alphas=[-2, 0, 2] * u.deg,
+            sectional_radiuses=[0.25, 0.5] * u.m,
+            sectional_polars=[
+                BETDiskSectionalPolar(
+                    lift_coeffs=[[[0.1, 0.2, 0.3]]],
+                    drag_coeffs=[[[0.01, 0.02, 0.03]]],
+                ),
+                BETDiskSectionalPolar(
+                    lift_coeffs=[[[0.15, 0.25, 0.35]]],
+                    drag_coeffs=[[[0.015, 0.025, 0.035]]],
+                ),
+            ],
+        )
+        coordinate_system = CoordinateSystem(name="cs", translation=(1, 2, 3) * u.m)
+        coordinate_system_status = CoordinateSystemStatus(
+            coordinate_systems=[coordinate_system],
+            parents=[],
+            assignments=[
+                CoordinateSystemAssignmentGroup(
+                    coordinate_system_id=coordinate_system.private_attribute_id,
+                    entities=[
+                        CoordinateSystemEntityRef(
+                            entity_type="Cylinder",
+                            entity_id=cylinder.private_attribute_id,
+                        )
+                    ],
+                )
+            ],
+        )
+        params = SimulationParams(
+            models=[bet_disk],
+            private_attribute_asset_cache=AssetCache(
+                coordinate_system_status=coordinate_system_status,
+            ),
+        )
+
+    apply_coordinate_system_transformations(params)
+
+    transformed_bet_disk = params.models[0]
+    transformed_cylinder = transformed_bet_disk.entities.stored_entities[0]
+
+    assert all(transformed_cylinder.center == [1, 2, 3] * u.m)
+    assert transformed_bet_disk.mach_numbers == [0]
+    assert transformed_bet_disk.twists[0].radius == 0 * u.m
+    assert transformed_bet_disk.chords[0].chord == 1 * u.m


### PR DESCRIPTION
## What changed
- updated translator coordinate-system transformation traversal to only rewrite `list` and `tuple` fields when an item actually changes
- added a regression test covering a `BETDisk` model that mixes transformable entities with frozen non-entity sequences

## Why
When the translator walked frozen models, it always rebuilt and reassigned sequence fields even if nothing inside those sequences changed. That can fail on frozen non-entity fields while applying otherwise valid coordinate-system transformations.

## Root cause
`_apply_transformations_to_model()` treated every `list` and `tuple` as modified after traversal, even when `_transform_sequence_item()` returned each original item unchanged.

## Impact
- coordinate-system transformations still update entity-bearing fields
- untouched frozen numeric or model sequences are left alone
- merge resolution for this conflict stays in the client translator layer instead of leaking runtime logic into schema

## Validation
- `/disk2/ben/SchemaMigration/compute/src/Flow360Core/Flow360/.venv/bin/python -m py_compile flow360/component/simulation/translator/utils.py tests/simulation/translator/test_translation_utils.py`
- `PYTEST_CACHE_DIR=./tests/.pytest_cache /disk2/ben/SchemaMigration/compute/src/Flow360Core/Flow360/.venv/bin/python -m pytest -c tests/pytest.ini -q tests/simulation/translator/test_translation_utils.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches recursive coordinate-system transformation traversal; a bug here could skip or misapply entity transforms, but change is narrowly scoped and covered by a new regression test.
> 
> **Overview**
> **Prevents unnecessary rewrites of sequence fields during coordinate-system transforms.** `apply_coordinate_system_transformations()` now only reassigns `list`/`tuple` fields when at least one element is actually transformed, avoiding failures when walking frozen models with non-entity numeric/model sequences.
> 
> Adds a regression test using a `BETDisk` containing both transformable entities and frozen non-entity sequences to verify entity translation occurs while untouched sequences remain unchanged. Also updates the locked `flow360-schema` dependency to `0.1.26` (and adjusts the commented local-dev path in `pyproject.toml`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb7db38591b10119d8f77a2fb3282824ad91c3cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->