### PR TITLE
chore(deps): pin flow360-schema to 25.10.1b1

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1468,14 +1468,14 @@ files = [
 
 [[package]]
 name = "flow360-schema"
-version = "0.1.26"
+version = "25.10.1b1"
 description = "Pure Pydantic schemas for Flow360 - Single Source of Truth"
 optional = false
 python-versions = ">=3.10,<4.0"
 groups = ["main"]
 files = [
-    {file = "flow360_schema-0.1.26-py3-none-any.whl", hash = "sha256:393848512d87798f8a85614492feb9cb2e8b39b57e27a31e62243427865cd317"},
-    {file = "flow360_schema-0.1.26.tar.gz", hash = "sha256:5edd47bdce8f6f329969a028af2c333cc0b88af250b0331bb54b8f1992519964"},
+    {file = "flow360_schema-25.10.1b1-py3-none-any.whl", hash = "sha256:2229974c4003138b56c2bb392d1ec09a578cfc0bb73c3a31d63f91febd2eefa6"},
+    {file = "flow360_schema-25.10.1b1.tar.gz", hash = "sha256:41a6440f4295ad93c6591320e461264965a6a69cef8c0280d84abbea4f4e8be0"},
 ]
 
 [package.dependencies]
@@ -6526,4 +6526,4 @@ docs = ["autodoc_pydantic", "cairosvg", "ipython", "jinja2", "jupyter", "myst-pa
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.14"
-content-hash = "3aaf995480733e28ca8f33d2197489f017c762d94cfa35c34cefe2a685608727"
+content-hash = "78042dd058873ceb2f115cddf761b19a995fc4da0e532d0b5991c0b9449236b7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ pydantic = ">=2.8,<2.12"
 # -- Local dev (editable install, schema changes take effect immediately):
 # flow360-schema = { path = "../../../../flex/share/flow360-schema", develop = true }
 # -- CI / release (install from CodeArtifact, swap comments before pushing):
-flow360-schema = { version = "~0.1.24", source = "codeartifact" }
+flow360-schema = { version = "= 25.10.1b1", source = "codeartifact" }
 pytest = "^7.1.2"
 click = "^8.1.3"
 toml = "^0.10.2"

--- a/tests/simulation/service/test_services_v2.py
+++ b/tests/simulation/service/test_services_v2.py
@@ -4,6 +4,7 @@ import re
 from typing import get_args
 
 import pytest
+from flow360_schema import __version__ as _SCHEMA_VERSION
 from flow360_schema.framework.expression import UserVariable
 from unyt import Unit
 
@@ -1712,7 +1713,7 @@ def test_validate_error_location_with_selector():
             }
         ],
         "unit_system": {"name": "SI"},
-        "version": __version__,
+        "version": _SCHEMA_VERSION,
         "private_attribute_asset_cache": {
             "project_entity_info": {
                 "type_name": "VolumeMeshEntityInfo",


### PR DESCRIPTION
## Summary

Pin \`flow360-schema\` to an exact version so the resolved dependency is deterministic for every commit hash.

- \`~0.1.24\` → \`= 25.10.1b1\`
- Aligned with the schema repo's new calendar-based version scheme (flexcompute/flex#11409).

## Why this matters

With \`~0.1.24\` the resolved version is whatever CodeArtifact happens to have at install time. That makes a given compute commit hash nondeterministic — the solver + client combination we ran yesterday may differ from what the same hash installs tomorrow. Exact pinning eliminates that drift.

## Follow-up

A separate PR on \`flexcompute/compute\` will add a CI check that enforces this pin style (no \`~\`/\`^\`/\`>=\`/path dependencies). It will also bump the Flow360 submodule pointer to this PR's merge commit.

## Test Plan

- [ ] CI: \`poetry install\` resolves \`flow360-schema == 25.10.1b1\` from CodeArtifact.
- [ ] CI: \`unit testing\` workflow (\`test.yml\`) green on all matrix combinations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrades and exactly pins the `flow360-schema` dependency, which can change validation/serialization behavior across the client even though code changes are minimal.
> 
> **Overview**
> Pins `flow360-schema` to the exact version `25.10.1b1` (instead of a compatible-range `~0.1.x`) and updates `poetry.lock` accordingly to make dependency resolution deterministic.
> 
> Adjusts a simulation service test to reference the schema package’s `__version__` (`_SCHEMA_VERSION`) when populating the `version` field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9e0b1a9160675ea5695b85d42d944ee1000b687. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->