### PR TITLE
[FXC-7032] Add info about supersonic case to Outflow docstring 

### DIFF
--- a/flow360/component/simulation/models/surface_models.py
+++ b/flow360/component/simulation/models/surface_models.py
@@ -484,6 +484,11 @@ class Outflow(BoundaryBase):
     """
     :class:`Outflow` defines the outflow boundary condition based on the input :py:attr:`spec`.
 
+    .. warning::
+
+       For supersonic cases the :class:`Pressure` :py:attr:`spec` should be used; other specifications
+       may give unexpected results.
+
     Example
     -------
     - Define outflow boundary condition with pressure:
@@ -517,7 +522,8 @@ class Outflow(BoundaryBase):
     spec: Union[Pressure, MassFlowRate, Mach] = pd.Field(
         discriminator="type_name",
         description="Specify the static pressure, mass flow rate, or Mach number parameters at"
-        + " the `Outflow` boundary.",
+        + " the `Outflow` boundary. For supersonic cases the `Pressure` spec should be used;"
+        + " other specifications may give unexpected results.",
     )
 
 


### PR DESCRIPTION
The core ticket that comes out of is: https://flow360.atlassian.net/browse/FXC-6759

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes that add guidance/warnings, with no behavior or API changes.
> 
> **Overview**
> Updates `Outflow` boundary documentation to **warn that supersonic cases should use the `Pressure` spec**, since `Mach`/`MassFlowRate` specs may produce unexpected results.
> 
> Also extends the `spec` field description on `Outflow` to repeat this supersonic guidance in the generated schema/docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc530922b0050d7ffe836b88b8147ab7c7d29991. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->