### PR TITLE
[FXC-6759] Explicitly state that the outflow BC is meant for subsonic conditions

### DIFF
--- a/flow360/component/simulation/models/surface_models.py
+++ b/flow360/component/simulation/models/surface_models.py
@@ -507,6 +507,11 @@ class Outflow(BoundaryBase):
     """
     :class:`Outflow` defines the outflow boundary condition based on the input :py:attr:`spec`.
 
+    .. warning::
+
+       For supersonic cases the :class:`Pressure` :py:attr:`spec` should be used; other specifications
+       may give unexpected results.
+
     Example
     -------
     - Define outflow boundary condition with pressure:
@@ -540,7 +545,8 @@ class Outflow(BoundaryBase):
     spec: Union[Pressure, MassFlowRate, Mach] = pd.Field(
         discriminator="type_name",
         description="Specify the static pressure, mass flow rate, or Mach number parameters at"
-        + " the `Outflow` boundary.",
+        + " the `Outflow` boundary. For supersonic cases the `Pressure` spec should be used;"
+        + " other specifications may give unexpected results.",
     )
 
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change that adds guidance on using `Pressure` spec for supersonic outflow; no runtime logic or validation behavior is modified.
> 
> **Overview**
> Adds an explicit **warning** to the `Outflow` boundary-condition docs and `spec` field description stating it is intended for subsonic conditions, and that supersonic cases should use the `Pressure` specification (other specs may behave unexpectedly).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 623f61b8aeb1f68f034e1353acbcf14410f7374e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->