### PR TITLE
feat(s3): support credential-scoped endpoint and OSS storage provider

### DIFF
--- a/flow360/cloud/s3_utils.py
+++ b/flow360/cloud/s3_utils.py
@@ -8,6 +8,7 @@ import urllib
 from abc import ABCMeta, abstractmethod
 from datetime import datetime
 from enum import Enum
+from typing import Optional
 
 # pylint: disable=unused-import
 from pydantic.v1 import BaseModel, Field
@@ -115,6 +116,8 @@ class _UserCredential(BaseModel):
     secret_access_key: str = Field(alias="secretAccessKey")
     session_token: str = Field(alias="sessionToken")
     region: str
+    endpoint: Optional[str] = None
+    storage_provider: Optional[str] = Field(alias="storageProvider", default=None)
 
 
 class _S3STSToken(BaseModel):
@@ -149,7 +152,13 @@ class _S3STSToken(BaseModel):
 
         # pylint: disable=no-member
         config_kwargs = {"max_pool_connections": MAX_POOL}
-        if Env.current.s3_endpoint_url is not None:
+        if (self.user_credential.storage_provider or "").upper() == "OSS":
+            # OSS does not support aws integrity check
+            config_kwargs["request_checksum_calculation"] = "when_required"
+            config_kwargs["response_checksum_validation"] = "when_required"
+            # OSS recommends virtual-hosted style addressing (http://bucket.host/key).
+            config_kwargs["s3"] = {"addressing_style": "virtual"}
+        elif Env.current.s3_endpoint_url is not None:
             # S3-compatible stores (s3proxy, MinIO) may not implement the
             # checksum headers that newer boto3 versions send by default.
             config_kwargs["request_checksum_calculation"] = "when_required"
@@ -174,6 +183,9 @@ class _S3STSToken(BaseModel):
             "aws_session_token": self.user_credential.session_token,
             "config": config,
         }
+
+        if self.user_credential.endpoint is not None:
+            kwargs["endpoint_url"] = self.user_credential.endpoint
 
         if Env.current.s3_endpoint_url is not None:
             kwargs["endpoint_url"] = Env.current.s3_endpoint_url


### PR DESCRIPTION
## Summary
- Add `endpoint` and `storageProvider` fields to `_UserCredential`, letting the STS response redirect the S3 client to a non-AWS backend.
- When `storageProvider == OSS`, disable AWS integrity-check headers and switch to virtual-hosted addressing; preserves existing path-style behavior for other S3-compatible stores (s3proxy, MinIO) via `Env.current.s3_endpoint_url`.
- Apply `user_credential.endpoint` to the boto3 client; `Env.current.s3_endpoint_url` still takes precedence when set.

## Test plan
- [ ] Default AWS flow (no `storageProvider`, no `endpoint`) still builds client unchanged.
- [ ] `storageProvider=OSS` path: virtual-hosted addressing + checksums disabled.
- [ ] S3-compatible dev path (`Env.current.s3_endpoint_url` set, no `storageProvider`): path-style + checksums disabled.
- [ ] `user_credential.endpoint` set: client uses that `endpoint_url`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how the boto3 S3 client is configured (endpoint selection, checksum behavior, and addressing style), which can impact all uploads/downloads and compatibility with different S3 backends.
> 
> **Overview**
> Adds optional `endpoint` and `storageProvider` fields to the STS `userCredentials` payload (`_UserCredential`) and threads them into S3 client construction.
> 
> When `storageProvider` is `OSS`, the client now disables AWS checksum/integrity behavior and switches to *virtual-hosted* bucket addressing; other S3-compatible endpoints configured via `Env.current.s3_endpoint_url` keep the existing path-style + checksum-disabled behavior.
> 
> If a credential-scoped `endpoint` is provided, it is used as the boto3 `endpoint_url` unless `Env.current.s3_endpoint_url` is set (which still overrides).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26fc6aa0ba7e8b7bb9dd2a75ef306f840610b120. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->