### PR TITLE
[Hotfix 25.9] feat(s3): support credential-scoped endpoint and OSS storage provider

### DIFF
--- a/flow360/cloud/s3_utils.py
+++ b/flow360/cloud/s3_utils.py
@@ -8,6 +8,7 @@ import urllib
 from abc import ABCMeta, abstractmethod
 from datetime import datetime
 from enum import Enum
+from typing import Optional
 
 # pylint: disable=unused-import
 from pydantic.v1 import BaseModel, Field
@@ -115,6 +116,8 @@ class _UserCredential(BaseModel):
     secret_access_key: str = Field(alias="secretAccessKey")
     session_token: str = Field(alias="sessionToken")
     region: str
+    endpoint: Optional[str] = None
+    storage_provider: Optional[str] = Field(alias="storageProvider", default=None)
 
 
 class _S3STSToken(BaseModel):
@@ -149,7 +152,13 @@ class _S3STSToken(BaseModel):
 
         # pylint: disable=no-member
         config_kwargs = {"max_pool_connections": MAX_POOL}
-        if Env.current.s3_endpoint_url is not None:
+        if (self.user_credential.storage_provider or "").upper() == "OSS":
+            # OSS does not support aws integrity check
+            config_kwargs["request_checksum_calculation"] = "when_required"
+            config_kwargs["response_checksum_validation"] = "when_required"
+            # OSS recommends virtual-hosted style addressing (http://bucket.host/key).
+            config_kwargs["s3"] = {"addressing_style": "virtual"}
+        elif Env.current.s3_endpoint_url is not None:
             # S3-compatible stores (s3proxy, MinIO) may not implement the
             # checksum headers that newer boto3 versions send by default.
             config_kwargs["request_checksum_calculation"] = "when_required"
@@ -174,6 +183,9 @@ class _S3STSToken(BaseModel):
             "aws_session_token": self.user_credential.session_token,
             "config": config,
         }
+
+        if self.user_credential.endpoint is not None:
+            kwargs["endpoint_url"] = self.user_credential.endpoint
 
         if Env.current.s3_endpoint_url is not None:
             kwargs["endpoint_url"] = Env.current.s3_endpoint_url


### PR DESCRIPTION
Hotfix port of #2019 (merged to main as 45677bdd) onto `release-candidate/25.9`.

## Summary
- Add `endpoint` and `storageProvider` fields to `_UserCredential`, letting the STS response redirect the S3 client to a non-AWS backend.
- When `storageProvider == OSS`, disable AWS integrity-check headers and switch to virtual-hosted addressing; preserves existing path-style behavior for other S3-compatible stores (s3proxy, MinIO) via `Env.current.s3_endpoint_url`.
- Apply `user_credential.endpoint` to the boto3 client. `Env.current.s3_endpoint_url` remains the highest-priority override (manual user setting).

## Cherry-pick
- Source: main @ 45677bdd
- Conflicts: none

## Test plan
- [ ] Default AWS flow (no `storageProvider`, no `endpoint`) still builds client unchanged.
- [ ] `storageProvider=OSS` path: virtual-hosted addressing + checksums disabled.
- [ ] S3-compatible dev path (`Env.current.s3_endpoint_url` set, no `storageProvider`): path-style + checksums disabled.
- [ ] `user_credential.endpoint` set: client uses that `endpoint_url` unless env override is also set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches S3 client construction (endpoint selection, addressing style, checksum behavior), which can impact all upload/download flows if provider detection or endpoint precedence is wrong.
> 
> **Overview**
> Adds `endpoint` and `storageProvider` fields to the STS-derived `_UserCredential` so backend-issued credentials can direct the client to a specific S3-compatible endpoint.
> 
> Updates `_S3STSToken.get_client()` to apply the credential-scoped `endpoint_url` (while keeping `Env.current.s3_endpoint_url` as the highest-priority override) and to special-case `storageProvider==OSS` by disabling checksum validation and using **virtual-hosted** addressing; other non-AWS endpoints continue using **path-style** addressing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcf46e17b022f9a33c676ed0317604bddf3c2ef7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->