### PR TITLE
[Hotfix 25.9]: [FXC-7096] Disable target_surface_node_count for beta mesher

### DIFF
--- a/flow360/component/simulation/meshing_param/meshing_specs.py
+++ b/flow360/component/simulation/meshing_param/meshing_specs.py
@@ -355,13 +355,13 @@ class MeshingDefaults(Flow360BaseModel):
     def ensure_target_surface_node_count_mesher(cls, value, param_info: ParamsValidationInfo):
         """Validate that target_surface_node_count is only used with geometry AI.
 
-        FXC-7096: temporarily ignored (with warning) for the beta mesher in 25.9; re-enable in 25.10.
+        Temporarily ignored (with warning) for the beta mesher in 25.9; re-enable in 25.10.
         """
         if value is None:
             return value
         if param_info.use_geometry_AI:
             return value
-        # FXC-7096: temporarily disabled for the beta mesher in 25.9; re-enable in 25.10.
+        # Temporarily disabled for the beta mesher in 25.9; re-enable in 25.10.
         if param_info.is_beta_mesher:
             add_validation_warning(
                 "`target_surface_node_count` is temporarily disabled for the beta mesher "

--- a/flow360/component/simulation/meshing_param/meshing_specs.py
+++ b/flow360/component/simulation/meshing_param/meshing_specs.py
@@ -353,10 +353,22 @@ class MeshingDefaults(Flow360BaseModel):
     @contextual_field_validator("target_surface_node_count", mode="after")
     @classmethod
     def ensure_target_surface_node_count_mesher(cls, value, param_info: ParamsValidationInfo):
-        """Validate that target_surface_node_count is only used with geometry AI or beta mesher."""
-        if value is not None and not (param_info.use_geometry_AI or param_info.is_beta_mesher):
-            raise ValueError("target_surface_node_count is not supported by the legacy mesher.")
-        return value
+        """Validate that target_surface_node_count is only used with geometry AI.
+
+        FXC-7096: temporarily ignored (with warning) for the beta mesher in 25.9; re-enable in 25.10.
+        """
+        if value is None:
+            return value
+        if param_info.use_geometry_AI:
+            return value
+        # FXC-7096: temporarily disabled for the beta mesher in 25.9; re-enable in 25.10.
+        if param_info.is_beta_mesher:
+            add_validation_warning(
+                "`target_surface_node_count` is temporarily disabled for the beta mesher "
+                "in 25.9 and the value will be ignored. It will be re-enabled in 25.10."
+            )
+            return None
+        raise ValueError("target_surface_node_count is not supported by the legacy mesher.")
 
     @contextual_field_validator("octree_spacing", mode="after")
     @classmethod

--- a/tests/simulation/translator/test_surface_meshing_translator.py
+++ b/tests/simulation/translator/test_surface_meshing_translator.py
@@ -1931,7 +1931,7 @@ def test_gai_target_surface_node_count_absent():
 
 
 def test_beta_mesher_target_surface_node_count_stripped(get_om6wing_geometry):
-    """FXC-7096: target_surface_node_count is stripped with a warning for the beta mesher in 25.9."""
+    """target_surface_node_count is stripped with a warning for the beta mesher in 25.9."""
     my_geometry = TempGeometry("om6wing.csm")
     with SI_unit_system:
         params = SimulationParams(

--- a/tests/simulation/translator/test_surface_meshing_translator.py
+++ b/tests/simulation/translator/test_surface_meshing_translator.py
@@ -1930,8 +1930,8 @@ def test_gai_target_surface_node_count_absent():
     assert "target_surface_node_count" not in translated["meshing"]["defaults"]
 
 
-def test_beta_mesher_target_surface_node_count_set(get_om6wing_geometry):
-    """target_surface_node_count is accepted and translated when using the beta surface mesher."""
+def test_beta_mesher_target_surface_node_count_stripped(get_om6wing_geometry):
+    """FXC-7096: target_surface_node_count is stripped with a warning for the beta mesher in 25.9."""
     my_geometry = TempGeometry("om6wing.csm")
     with SI_unit_system:
         params = SimulationParams(
@@ -1952,8 +1952,12 @@ def test_beta_mesher_target_surface_node_count_set(get_om6wing_geometry):
 
     params, err, warnings = validate_params_with_context(params, "Geometry", "SurfaceMesh")
     assert err is None, f"Unexpected validation error: {err}"
+    assert params.meshing.defaults.target_surface_node_count is None
+    assert any(
+        "target_surface_node_count" in w["msg"] for w in warnings
+    ), f"Expected a warning about target_surface_node_count, got: {warnings}"
     translated = get_surface_meshing_json(params, mesh_unit=get_om6wing_geometry.mesh_unit)
-    assert translated["target_surface_node_count"] == 50000
+    assert "target_surface_node_count" not in translated
 
 
 def test_legacy_target_surface_node_count_rejected(get_om6wing_geometry):


### PR DESCRIPTION
## Summary

Hot-fix for FXC-7096: the beta surface mesher produces wildly oversized meshes when `target_surface_node_count` is set on multibody geometries (one customer log: 28 bodies × ~4M tris ≈ 121M tris when the user requested ~500K nodes). The underlying mesher fix is too invasive for the 25.9 RC.

This PR re-narrows the validator gate back to GAI-only for 25.9 (reverting the widening from #1902 / FXC-5958). The field will be re-enabled for the beta mesher in 25.10 once the underlying mesher fix lands.

### Backward compatibility

For existing cases that already have `target_surface_node_count` set with the beta mesher, the validator now **auto-strips with a warning** rather than rejecting outright:

- `use_geometry_AI`: allowed (unchanged).
- `is_beta_mesher` (no GAI): emit `add_validation_warning(...)` and return `None` — translator already no-ops on `None`.
- Legacy mesher: still rejected with `ValueError` (unchanged).

Test renamed `test_beta_mesher_target_surface_node_count_set` → `test_beta_mesher_target_surface_node_count_stripped` and assertions flipped to verify the strip + warning behaviour.

### Companion changes

- WebUI gates (React `v25_9` codec/panel + Angular legacy `getMeshingConfigV259`/`updateMeshingData`): separate flex PR off `main`.
- compute `release-candidate/25.9` Flow360 submodule SHA bump: handled separately.

## Test plan

- [x] `pytest tests/simulation/translator/test_surface_meshing_translator.py` — 25/25 pass, including the renamed `_stripped` test
- [x] `black --check`, `isort --check`, `pylint --enable=C0301` clean on the two modified files
- [x] Self-review with `/simplify` — addressed docstring drift and over-paranoid `warnings is not None` check
- [ ] Manual: load an existing 25.9 case with `target_surface_node_count` + beta mesher, verify warning surfaces and the value is dropped from the translated JSON

## 25.10 re-enable

Grep for `FXC-7096` to find the temporary branch in `ensure_target_surface_node_count_mesher`; remove the `is_beta_mesher` strip-and-warn block and revert the test rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior changes for beta-mesher surface meshing: existing configs with `target_surface_node_count` will now be silently dropped (with a warning), which can change resulting mesh sizes. Scope is small and isolated to validation/tests, with legacy behavior unchanged.
> 
> **Overview**
> Disables `target_surface_node_count` for the **beta surface mesher** in 25.9: validation now *strips the value and emits a warning* unless Geometry AI is enabled, while the legacy mesher continues to raise a `ValueError`.
> 
> Updates the surface meshing translator test to assert the new strip-and-warn behavior and that `target_surface_node_count` no longer appears in the translated JSON for beta-mesher runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5aa04522d7b0654829edf16dc57de6236d23b13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->