### PR TITLE
[FXC-6350] feat: expose surface mesh statistics on SurfaceMeshV2

### DIFF
--- a/flow360/component/surface_mesh_v2.py
+++ b/flow360/component/surface_mesh_v2.py
@@ -33,7 +33,11 @@ from flow360.component.utils import (
     SurfaceMeshFile,
     shared_account_confirm_proceed,
 )
-from flow360.exceptions import Flow360FileError, Flow360ValueError
+from flow360.exceptions import (
+    Flow360FileError,
+    Flow360RuntimeError,
+    Flow360ValueError,
+)
 from flow360.log import log
 
 from .simulation.primitives import Surface
@@ -388,8 +392,14 @@ class SurfaceMeshV2(AssetBase):
         SurfaceMeshStats
             return SurfaceMeshStats object
         """
-        # pylint: disable=protected-access
-        data = self._webapi._parse_json_from_cloud(self._mesh_stats_file)
+        try:
+            # pylint: disable=protected-access
+            data = self._webapi._parse_json_from_cloud(self._mesh_stats_file)
+        except Exception as exc:
+            raise Flow360RuntimeError(
+                "Could not retrieve surface mesh stats. The surface mesh may not be ready yet "
+                f"(status={self._webapi.status.value})."
+            ) from exc
         return SurfaceMeshStats(**data)
 
     @classmethod

--- a/flow360/component/surface_mesh_v2.py
+++ b/flow360/component/surface_mesh_v2.py
@@ -392,9 +392,13 @@ class SurfaceMeshV2(AssetBase):
             # pylint: disable=protected-access
             data = self._webapi._parse_json_from_cloud(self._mesh_stats_file)
         except Exception as exc:
+            try:
+                status_str = self._webapi.status.value
+            except Exception:  # pylint: disable=broad-exception-caught
+                status_str = "unknown"
             raise Flow360RuntimeError(
                 "Could not retrieve surface mesh stats. The surface mesh may not be ready yet "
-                f"(status={self._webapi.status.value})."
+                f"(status={status_str})."
             ) from exc
         return SurfaceMeshStats(**data)
 

--- a/flow360/component/surface_mesh_v2.py
+++ b/flow360/component/surface_mesh_v2.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import os
 import threading
 from enum import Enum
+from functools import cached_property
 from typing import Any, List, Optional
 
 import pydantic as pd
@@ -81,6 +82,17 @@ class SurfaceMeshMetaV2(AssetMetaBaseModelV2):
     file_name: Optional[str] = pd.Field(None, alias="fileName")
     status: SurfaceMeshStatusV2 = pd.Field()  # Overshadowing to ensure correct is_final() method
     dependency: bool = pd.Field(False)
+
+
+class SurfaceMeshStats(pd.BaseModel):
+    """
+    Surface mesh stats
+    """
+
+    n_nodes: int = pd.Field(..., alias="nNodes")
+    n_triangles: int = pd.Field(..., alias="nTriangles")
+    n_quadrilaterals: int = pd.Field(..., alias="nQuadrilaterals")
+    version: Optional[str] = pd.Field(None)
 
 
 class SurfaceMeshDraftV2(ResourceDraft):
@@ -363,10 +375,22 @@ class SurfaceMeshV2(AssetBase):
     _meta_class = SurfaceMeshMetaV2
     _draft_class = SurfaceMeshDraftV2
     _web_api_class = Flow360Resource
+    _mesh_stats_file = "metadata/surfaceMeshMetaData.json"
     _cloud_resource_type_name = "SurfaceMesh"
 
-    # pylint: disable=fixme
-    # TODO: add _mesh_stats_file = "meshStats.json" like in VolumeMeshV2
+    @cached_property
+    def stats(self) -> SurfaceMeshStats:
+        """
+        Get surface mesh stats
+
+        Returns
+        -------
+        SurfaceMeshStats
+            return SurfaceMeshStats object
+        """
+        # pylint: disable=protected-access
+        data = self._webapi._parse_json_from_cloud(self._mesh_stats_file)
+        return SurfaceMeshStats(**data)
 
     @classmethod
     # pylint: disable=redefined-builtin

--- a/flow360/component/surface_mesh_v2.py
+++ b/flow360/component/surface_mesh_v2.py
@@ -33,11 +33,7 @@ from flow360.component.utils import (
     SurfaceMeshFile,
     shared_account_confirm_proceed,
 )
-from flow360.exceptions import (
-    Flow360FileError,
-    Flow360RuntimeError,
-    Flow360ValueError,
-)
+from flow360.exceptions import Flow360FileError, Flow360RuntimeError, Flow360ValueError
 from flow360.log import log
 
 from .simulation.primitives import Surface

--- a/flow360/component/surface_mesh_v2.py
+++ b/flow360/component/surface_mesh_v2.py
@@ -89,9 +89,9 @@ class SurfaceMeshStats(pd.BaseModel):
     Surface mesh stats
     """
 
-    n_nodes: int = pd.Field(..., alias="nNodes")
-    n_triangles: int = pd.Field(..., alias="nTriangles")
-    n_quadrilaterals: int = pd.Field(..., alias="nQuadrilaterals")
+    n_nodes: int = pd.Field(alias="nNodes")
+    n_triangles: int = pd.Field(alias="nTriangles")
+    n_quadrilaterals: int = pd.Field(alias="nQuadrilaterals")
     version: Optional[str] = pd.Field(None)
 
 

--- a/flow360/component/volume_mesh.py
+++ b/flow360/component/volume_mesh.py
@@ -831,14 +831,14 @@ class VolumeMeshStats(pd_v2.BaseModel):
     Mesh stats
     """
 
-    n_nodes: int = pd_v2.Field(..., alias="nNodes")
-    n_triangles: int = pd_v2.Field(..., alias="nTriangles")
-    n_quadrilaterals: int = pd_v2.Field(..., alias="nQuadrilaterals")
-    n_tetrahedron: int = pd_v2.Field(..., alias="nTetrahedron")
-    n_prism: int = pd_v2.Field(..., alias="nPrism")
-    n_pyramid: int = pd_v2.Field(..., alias="nPyramid")
-    n_hexahedron: int = pd_v2.Field(..., alias="nHexahedron")
-    n_tet_wedge: int = pd_v2.Field(..., alias="nTetWedge")
+    n_nodes: int = pd_v2.Field(alias="nNodes")
+    n_triangles: int = pd_v2.Field(alias="nTriangles")
+    n_quadrilaterals: int = pd_v2.Field(alias="nQuadrilaterals")
+    n_tetrahedron: int = pd_v2.Field(alias="nTetrahedron")
+    n_prism: int = pd_v2.Field(alias="nPrism")
+    n_pyramid: int = pd_v2.Field(alias="nPyramid")
+    n_hexahedron: int = pd_v2.Field(alias="nHexahedron")
+    n_tet_wedge: int = pd_v2.Field(alias="nTetWedge")
 
 
 class VolumeMeshBoundingBox(PerEntityResultCSVModel):


### PR DESCRIPTION
## Summary

Adds a `stats` property on `SurfaceMeshV2` returning a `SurfaceMeshStats` pydantic model with `n_nodes`, `n_triangles`, `n_quadrilaterals`, and `version` — mirroring the existing `VolumeMeshV2.stats` / `VolumeMeshStats` pattern.

The webui already exposes these values (via `projectApi.getSurfaceMeshStatistics` in `flex/frontend/flow360-ui-next/src/apis/endpoints/project.ts`), reading the same `metadata/surfaceMeshMetaData.json` artifact this PR consumes.

Replaces the TODO at `flow360/component/surface_mesh_v2.py:369` (now removed) noting this was missing.

Jira: https://flow360.atlassian.net/browse/FXC-6350

## Use case

> One use case is to report the number of nodes in the report of Flow360's service test. — FXC-6350

```python
sm = SurfaceMeshV2.from_cloud(surface_mesh_id)
print(sm.stats.n_nodes)
```

## Test plan

- [x] `black --check` clean
- [x] `isort --check` clean
- [x] `pylint -e C0301` (line length) clean, 10.00/10
- [x] Smoke test: `SurfaceMeshStats` parses a real-shaped JSON dict (nNodes, nTriangles, nQuadrilaterals, version, plus `boundaries` extras silently ignored by pydantic v2 default)
- [ ] End-to-end: fetch a real `SurfaceMeshV2` from cloud and call `.stats` (tester to confirm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a read-only `stats` accessor for surface meshes and slightly relaxes `VolumeMeshStats` field declarations without changing runtime behavior for valid responses.
> 
> **Overview**
> Adds a cached `SurfaceMeshV2.stats` property that fetches and parses `metadata/surfaceMeshMetaData.json` into a new `SurfaceMeshStats` model (`n_nodes`, `n_triangles`, `n_quadrilaterals`, optional `version`), raising `Flow360RuntimeError` when the stats artifact can’t be retrieved (e.g., mesh not ready).
> 
> Aligns `VolumeMeshStats` field definitions by removing explicit required markers (`...`) while keeping the same JSON aliases for all count fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79a2750d13295f003a160081690404d7a66cf22e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->