### PR TITLE
feat(outputs): expose Volume entity for render output

### DIFF
--- a/flow360/__init__.py
+++ b/flow360/__init__.py
@@ -154,6 +154,7 @@ from flow360.component.simulation.outputs.output_entities import (
     PointArray,
     PointArray2D,
     Slice,
+    Volume,
 )
 from flow360.component.simulation.outputs.outputs import (
     AeroAcousticOutput,
@@ -323,6 +324,7 @@ __all__ = [
     "SolidMaterial",
     "Slice",
     "Isosurface",
+    "Volume",
     "TurbulenceQuantities",
     "UserDefinedDynamic",
     "Translational",

--- a/flow360/component/simulation/outputs/output_entities.py
+++ b/flow360/component/simulation/outputs/output_entities.py
@@ -10,5 +10,6 @@ from flow360_schema.models.entities.output_entities import (  # noqa: F401
     PointArray,
     PointArray2D,
     Slice,
+    Volume,
     _OutputItemBase,
 )


### PR DESCRIPTION
## Summary
- Re-exports the new `Volume` entity from `flow360_schema.models.entities.output_entities` so it's reachable as `flow360.Volume`.
- Adds `Volume` to `flow360.__all__` next to `Slice` and `Isosurface`.

## Why
Pairs with the matching `flow360-schema` PR (https://github.com/flexcompute/flex/pull/12099) and the C++-side volume rendering on the compute side. After all three PRs land, `fl.Volume(...)` resolves and can be used in `RenderOutputGroup.volumes`.

## Test Plan
- [x] `python -c "import flow360 as fl; print(fl.Volume)"` resolves to the schema's Volume class once the dependent flow360-schema PR lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a pure API surface/export change with no behavioral logic changes, mainly affecting import paths and `__all__` exposure.
> 
> **Overview**
> Exposes the new `Volume` output entity by re-exporting it from `flow360_schema.models.entities.output_entities` and making it available as `flow360.Volume`.
> 
> Updates `flow360.__all__` and the `output_entities` relay module so `Volume` is treated alongside `Slice`/`Isosurface` for render/output configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf82310b7c29436f4f81519424d48c8ec0ab4a75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->