### PR TITLE
[FXC-6076] Plumb rotor_disk_names into Custom Volume and Farfield Zone Translation

### DIFF
--- a/flow360/component/simulation/translator/volume_meshing_translator.py
+++ b/flow360/component/simulation/translator/volume_meshing_translator.py
@@ -261,7 +261,7 @@ def rotation_volume_entity_injector(
     return {}
 
 
-def _build_farfield_zone(volume_zones: list):
+def _build_farfield_zone(volume_zones: list, rotor_disk_names=None):
     """Build the farfield zone dict from enclosed_entities on any farfield type supporting it.
 
     CustomVolume entities are unwrapped into their constituent bounding_entities,
@@ -276,9 +276,13 @@ def _build_farfield_zone(volume_zones: list):
             for entity in zone.enclosed_entities.stored_entities:
                 if isinstance(entity, CustomVolume):
                     for child in entity.bounding_entities.stored_entities:
-                        patch_names.add(_translate_enclosed_entity_name(child))
+                        patch_names.add(
+                            _translate_enclosed_entity_name(child, rotor_disk_names)
+                        )
                 else:
-                    patch_names.add(_translate_enclosed_entity_name(entity))
+                    patch_names.add(
+                        _translate_enclosed_entity_name(entity, rotor_disk_names)
+                    )
             return {
                 "name": "farfield",
                 "patches": sorted(patch_names),
@@ -286,7 +290,7 @@ def _build_farfield_zone(volume_zones: list):
     return None
 
 
-def _get_custom_volumes(volume_zones: list):
+def _get_custom_volumes(volume_zones: list, rotor_disk_names=None):
     """Get translated custom volumes from volume zones."""
 
     custom_volumes = []
@@ -299,7 +303,7 @@ def _get_custom_volumes(volume_zones: list):
                         "name": custom_volume.name,
                         "patches": sorted(
                             [
-                                _translate_enclosed_entity_name(entity)
+                                _translate_enclosed_entity_name(entity, rotor_disk_names)
                                 for entity in custom_volume.bounding_entities.stored_entities
                             ]
                         ),
@@ -318,7 +322,7 @@ def _get_custom_volumes(volume_zones: list):
                         }
                     )
 
-    farfield_zone = _build_farfield_zone(volume_zones)
+    farfield_zone = _build_farfield_zone(volume_zones, rotor_disk_names)
     if farfield_zone is not None:
         custom_volumes.append(farfield_zone)
 
@@ -616,7 +620,7 @@ def get_volume_meshing_json(input_params: SimulationParams, mesh_units):
         )
 
     ##::  Step 6: Get custom volumes
-    custom_volumes = _get_custom_volumes(volume_zones)
+    custom_volumes = _get_custom_volumes(volume_zones, rotor_disk_names)
     if custom_volumes:
         translated["zones"] = custom_volumes
 

--- a/flow360/component/simulation/translator/volume_meshing_translator.py
+++ b/flow360/component/simulation/translator/volume_meshing_translator.py
@@ -276,13 +276,9 @@ def _build_farfield_zone(volume_zones: list, rotor_disk_names=None):
             for entity in zone.enclosed_entities.stored_entities:
                 if isinstance(entity, CustomVolume):
                     for child in entity.bounding_entities.stored_entities:
-                        patch_names.add(
-                            _translate_enclosed_entity_name(child, rotor_disk_names)
-                        )
+                        patch_names.add(_translate_enclosed_entity_name(child, rotor_disk_names))
                 else:
-                    patch_names.add(
-                        _translate_enclosed_entity_name(entity, rotor_disk_names)
-                    )
+                    patch_names.add(_translate_enclosed_entity_name(entity, rotor_disk_names))
             return {
                 "name": "farfield",
                 "patches": sorted(patch_names),

--- a/tests/simulation/translator/test_volume_meshing_translator.py
+++ b/tests/simulation/translator/test_volume_meshing_translator.py
@@ -2052,3 +2052,58 @@ def test_farfield_enclosed_entities_mixed_direct_and_custom_volume(get_surface_m
         "slidingInterface-ball",
         "slidingInterface-rotor",
     ]
+
+
+def test_custom_volume_with_rotor_disk_cylinder(get_surface_mesh):
+    """A Cylinder used as AxisymmetricRefinement in a CustomVolume should translate to rotorDisk- prefix."""
+    rotor = Cylinder(
+        name="bet_disk",
+        center=(0, 0, 0) * u.m,
+        axis=(0, 0, 1),
+        height=0.1 * u.m,
+        outer_radius=2 * u.m,
+    )
+    with SI_unit_system:
+        cv = CustomVolume(
+            name="rotor_zone",
+            bounding_entities=[Surface(name="wall"), rotor],
+        )
+        params = SimulationParams(
+            meshing=MeshingParams(
+                defaults=MeshingDefaults(
+                    boundary_layer_first_layer_thickness=1e-4,
+                ),
+                refinements=[
+                    AxisymmetricRefinement(
+                        entities=[rotor],
+                        spacing_axial=0.05 * u.m,
+                        spacing_radial=0.1 * u.m,
+                        spacing_circumferential=0.05 * u.m,
+                    ),
+                ],
+                volume_zones=[
+                    CustomZones(
+                        name="custom",
+                        entities=[cv],
+                    ),
+                    AutomatedFarfield(
+                        enclosed_entities=[Surface(name="outer"), cv],
+                    ),
+                ],
+            ),
+            private_attribute_asset_cache=AssetCache(use_inhouse_mesher=True),
+        )
+
+    translated = get_volume_meshing_json(params, get_surface_mesh.mesh_unit)
+    assert "zones" in translated
+    zones_by_name = {z["name"]: z for z in translated["zones"]}
+
+    # The custom volume zone should have the rotor disk with correct prefix
+    assert "rotor_zone" in zones_by_name
+    assert "rotorDisk-bet_disk" in zones_by_name["rotor_zone"]["patches"]
+    assert "slidingInterface-bet_disk" not in zones_by_name["rotor_zone"]["patches"]
+
+    # The farfield zone should also use the correct prefix
+    assert "farfield" in zones_by_name
+    assert "rotorDisk-bet_disk" in zones_by_name["farfield"]["patches"]
+    assert "slidingInterface-bet_disk" not in zones_by_name["farfield"]["patches"]


### PR DESCRIPTION
# PR: Plumb `rotor_disk_names` into Custom Volume and Farfield Zone Translation
FXC: https://flow360.atlassian.net/browse/FXC-6076

## Summary

`_get_custom_volumes` and `_build_farfield_zone` were calling `_translate_enclosed_entity_name` without `rotor_disk_names`, causing any `Cylinder` entity in a `CustomVolume.bounding_entities` to always translate to `"slidingInterface-<name>"` -- even when it's actually a rotor disk (defined via `AxisymmetricRefinement`). This made the companion C++ fix in `VolumeMultiZoneUtils.h` unreachable, since the patch name mismatch (`"slidingInterface-foo"` vs `"rotorDisk-foo"`) prevented the custom zone exclusion logic from working.

## Changes

### `flow360/component/simulation/translator/volume_meshing_translator.py`

- `_build_farfield_zone(volume_zones)` -> `_build_farfield_zone(volume_zones, rotor_disk_names=None)`: forwards to `_translate_enclosed_entity_name` so that rotor-disk cylinders in farfield `enclosed_entities` get the `"rotorDisk-"` prefix.
- `_get_custom_volumes(volume_zones)` -> `_get_custom_volumes(volume_zones, rotor_disk_names=None)`: forwards to `_translate_enclosed_entity_name` so that rotor-disk cylinders in `CustomVolume.bounding_entities` get the `"rotorDisk-"` prefix.
- Both call sites in `get_volume_meshing_json` now pass the already-computed `rotor_disk_names` list.

### `tests/simulation/translator/test_volume_meshing_translator.py`

Added `test_custom_volume_with_rotor_disk_cylinder` which verifies that when a `Cylinder` is used as an `AxisymmetricRefinement` and also placed inside a `CustomVolume`, both the custom zone and farfield zone patch lists contain `"rotorDisk-bet_disk"` (not `"slidingInterface-bet_disk"`).

## Test Plan

- [x] `test_custom_volume_with_rotor_disk_cylinder` passes
- [x] Existing `test_farfield_enclosed_entities_unwraps_custom_volume_with_cylinder` still passes (this test uses `RotationVolume`, not `AxisymmetricRefinement`, so the cylinder correctly remains `"slidingInterface-"`)
- [x] All other `test_volume_meshing_translator` tests pass unchanged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: narrowly forwards existing `rotor_disk_names` into zone patch-name translation and adds a focused regression test; main impact is patch naming in translated meshing JSON for cylinders used as rotor disks.
> 
> **Overview**
> Fixes volume-meshing translation so cylinders that are rotor disks (from `AxisymmetricRefinement`) are named with the `rotorDisk-` prefix not only in sliding-interface `enclosedObjects`, but also when referenced inside `CustomVolume.bounding_entities` and farfield `enclosed_entities`.
> 
> This threads `rotor_disk_names` through `_get_custom_volumes` and `_build_farfield_zone` to `_translate_enclosed_entity_name`, and adds a regression test asserting both the custom zone and generated `farfield` zone emit `rotorDisk-<name>` patches (and not `slidingInterface-<name>`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edc8bdb62a127180154781b9a6a6ba704a3b84c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->