### PR TITLE
[Hotfix 25.9]: [FXC-7485] Bypass PorousJump interface check for farfield/CV overlapping face pairs

### DIFF
--- a/flow360/component/simulation/models/surface_models.py
+++ b/flow360/component/simulation/models/surface_models.py
@@ -919,9 +919,26 @@ class PorousJump(Flow360BaseModel):
             )
 
         def _is_farfield_custom_volume_interface(surface1, surface2) -> bool:
-            """Check if both surfaces are dual-belonging (farfield enclosed ∩ CustomVolume bounding_entities)."""
+            """Both surfaces are dual-belonging: same single geometry face is referenced
+            in both farfield enclosed_entities and a CustomVolume bounding_entities.
+            The mesher splits that single face into two interface boundaries."""
             dual = param_info.farfield_cv_dual_belonging_ids
             return surface1.private_attribute_id in dual and surface2.private_attribute_id in dual
+
+        def _is_farfield_to_custom_volume_pair(surface1, surface2) -> bool:
+            """Pair spans two overlapping geometry faces: one only in farfield enclosed_entities,
+            the other only in some CustomVolume bounding_entities. The mesher merges them
+            into an interface."""
+            enclosed_ids = set(param_info.farfield_enclosed_entities or {})
+            cv_boundary_ids: set = set()
+            for cv_info in param_info.to_be_generated_custom_volumes.values():
+                cv_boundary_ids |= cv_info.get("boundary_surface_ids", set())
+            s1, s2 = surface1.private_attribute_id, surface2.private_attribute_id
+            s1_farfield_only = s1 in enclosed_ids and s1 not in cv_boundary_ids
+            s1_cv_only = s1 in cv_boundary_ids and s1 not in enclosed_ids
+            s2_farfield_only = s2 in enclosed_ids and s2 not in cv_boundary_ids
+            s2_cv_only = s2 in cv_boundary_ids and s2 not in enclosed_ids
+            return (s1_farfield_only and s2_cv_only) or (s2_farfield_only and s1_cv_only)
 
         for surface_pair in value.items:
             check_deleted_surface_pair(surface_pair, param_info)
@@ -932,8 +949,12 @@ class PorousJump(Flow360BaseModel):
             if _is_cross_custom_volume_interface(surface1, surface2):
                 continue
 
-            # Skip interface check for cross-farfield-CustomVolume bounding_entities
+            # Skip interface check for cross-farfield-CustomVolume bounding_entities (single dual-belonging face)
             if _is_farfield_custom_volume_interface(surface1, surface2):
+                continue
+
+            # Skip interface check for two overlapping faces, one on farfield side and one on CV side
+            if _is_farfield_to_custom_volume_pair(surface1, surface2):
                 continue
 
             for surface in surface_pair.pair:

--- a/tests/simulation/params/test_validators_params.py
+++ b/tests/simulation/params/test_validators_params.py
@@ -1250,6 +1250,68 @@ def test_porousJump_farfield_custom_volume_interface(mock_validation_context):
         )
 
 
+def test_porousJump_farfield_to_custom_volume_pair(mock_validation_context):
+    """PorousJump validation passes when pair spans two overlapping faces:
+    one only in farfield enclosed_entities, the other only in some CustomVolume
+    bounding_entities (mesher merges them into an interface)."""
+    surface_farfield_side = Surface(
+        name="Farfield-Side",
+        private_attribute_is_interface=False,
+        private_attribute_id="id-farfield",
+    )
+    surface_cv_side = Surface(
+        name="CV-Side",
+        private_attribute_is_interface=False,
+        private_attribute_id="id-cv",
+    )
+    surface_other_farfield = Surface(
+        name="Other-Farfield",
+        private_attribute_is_interface=False,
+        private_attribute_id="id-farfield-2",
+    )
+
+    # surface_farfield_side: only in farfield enclosed_entities
+    # surface_cv_side: only in CV bounding_entities
+    mock_validation_context.info.farfield_enclosed_entities = {
+        "id-farfield": "Farfield-Side",
+        "id-farfield-2": "Other-Farfield",
+    }
+    mock_validation_context.info.to_be_generated_custom_volumes = {
+        "CustomVolume1": {
+            "enforce_tetrahedra": False,
+            "boundary_surface_ids": {"id-cv"},
+        },
+    }
+
+    # Cross farfield-CV pair (different ids, exclusive sides): should pass
+    with mock_validation_context:
+        PorousJump(
+            entity_pairs=[(surface_farfield_side, surface_cv_side)],
+            darcy_coefficient=1e6 / (u.m * u.m),
+            forchheimer_coefficient=1e3 / u.m,
+            thickness=0.01 * u.m,
+        )
+
+    # Reverse order: should also pass
+    with mock_validation_context:
+        PorousJump(
+            entity_pairs=[(surface_cv_side, surface_farfield_side)],
+            darcy_coefficient=1e6 / (u.m * u.m),
+            forchheimer_coefficient=1e3 / u.m,
+            thickness=0.01 * u.m,
+        )
+
+    # Two farfield-only surfaces: not a valid interface, should fail
+    error_message = "Boundary `Farfield-Side` is not an interface"
+    with mock_validation_context, pytest.raises(ValueError, match=re.escape(error_message)):
+        PorousJump(
+            entity_pairs=[(surface_farfield_side, surface_other_farfield)],
+            darcy_coefficient=1e6 / (u.m * u.m),
+            forchheimer_coefficient=1e3 / u.m,
+            thickness=0.01 * u.m,
+        )
+
+
 def test_duplicate_entities_in_models():
     entity_generic_volume = GenericVolume(name="Duplicate Volume")
     entity_surface = Surface(name="Duplicate Surface")


### PR DESCRIPTION
## Summary

- PorousJump validation now bypasses the interface check when an `entity_pairs` pair spans **two overlapping geometry faces**, one only in `AutomatedFarfield.enclosed_entities` and the other only in a `CustomVolume.bounding_entities`. The mesher merges them into an interface, so the pair is valid input.
- The existing `_is_farfield_custom_volume_interface` helper only handled a different (and rarer) case: a *single* face referenced in both sides via dual-belonging. The new `_is_farfield_to_custom_volume_pair` helper is added alongside it and the two cases are kept conceptually separate, each with its own docstring explaining the meshing behavior it corresponds to.

### Failing case before this fix

`PorousJump(entity_pairs=[(Intake, inside5)], ...)` where:

- `Intake` is only in farfield `enclosed_entities`
- `inside5` is only in CustomVolume `bounding_entities`
- Both have `private_attribute_is_interface=null` at the params/validation stage

Previously failed with `Boundary 'Intake' is not an interface`. Now passes.

## Test plan

- [x] New unit test `test_porousJump_farfield_to_custom_volume_pair` covering both pair orderings + a negative case (two farfield-only surfaces)
- [x] Existing `test_porousJump_cross_custom_volume_interface` and `test_porousJump_farfield_custom_volume_interface` still pass (negative cases still raise as expected)
- [x] Full `tests/simulation/params/test_validators_params.py` (63 tests) passes locally

(Replaces #2030 — same commit, branch renamed to follow `BenY/` convention.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts `PorousJump` boundary validation to bypass interface enforcement for a new farfield/CustomVolume pairing case, which could allow previously-rejected (and potentially misclassified) surface pairs through; impact is limited to param validation pre-meshing.
> 
> **Overview**
> Updates `PorousJump.ensure_surface_existence` to **skip the interface check** not only for cross-CustomVolume and farfield/CV *dual-belonging* cases, but also when an `entity_pairs` entry spans **two overlapping geometry faces** where one face is *farfield-only* (`AutomatedFarfield.enclosed_entities`) and the other is *CustomVolume-only* (`CustomVolume.bounding_entities`).
> 
> Adds a unit test (`test_porousJump_farfield_to_custom_volume_pair`) covering both orderings of this farfield/CV pair and a negative case to ensure non-interface farfield-only pairs still raise.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12110bcb1c04d87ca873501480532fba05915fd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->