### PR TITLE
[FXC-6076] [Hotfix 25.9] Support Rotor Disks in Custom Volumes : Allow them in schema validators 

### DIFF
--- a/flow360/component/simulation/meshing_param/params.py
+++ b/flow360/component/simulation/meshing_param/params.py
@@ -118,10 +118,8 @@ def _collect_rotation_entity_names(zones, param_info, zone_types):
     return names
 
 
-def _validate_farfield_enclosed_entities(
-    zones, rotation_entity_names, has_custom_volumes, param_info
-):
-    """Validate farfield enclosed_entities: require CustomVolumes and rotation-volume association.
+def _validate_farfield_enclosed_entities_structure(zones, has_custom_volumes):
+    """Validate structural requirements for farfield enclosed_entities.
     Only applies to farfield types that support enclosed_entities (Automated, WindTunnel).
     """
     for zone in zones:
@@ -142,14 +140,25 @@ def _validate_farfield_enclosed_entities(
                 "`CustomVolume` entities are present in volume zones."
             )
 
+
+def _validate_farfield_enclosed_entities_association(zones, allowed_entity_names, param_info):
+    """Validate that Cylinder/AxisymmetricBody/Sphere in farfield enclosed_entities
+    are associated with a RotationVolume, RotationSphere, or AxisymmetricRefinement."""
+    for zone in zones:
+        if not isinstance(zone, _FarfieldAllowingEnclosedEntities):
+            continue
+        if zone.enclosed_entities is None:
+            continue
+
         for entity in param_info.expand_entity_list(zone.enclosed_entities):
             if (
                 isinstance(entity, (Cylinder, AxisymmetricBody, Sphere))
-                and entity.name not in rotation_entity_names
+                and entity.name not in allowed_entity_names
             ):
                 raise ValueError(
                     f"`{type(entity).__name__}` entity `{entity.name}` in "
-                    f"`enclosed_entities` must be associated with a `RotationVolume` or `RotationSphere`."
+                    f"`enclosed_entities` must be associated with a "
+                    f"`RotationVolume`, `RotationSphere`, or `AxisymmetricRefinement`."
                 )
 
 
@@ -164,9 +173,19 @@ def _collect_all_custom_volumes(zones):
     return custom_volumes
 
 
+def _collect_axisymmetric_refinement_entity_names(refinements, param_info):
+    """Collect entity names associated with AxisymmetricRefinement."""
+    names: set[str] = set()
+    for refinement in refinements or []:
+        if isinstance(refinement, AxisymmetricRefinement):
+            for entity in param_info.expand_entity_list(refinement.entities):
+                names.add(entity.name)
+    return names
+
+
 def _validate_custom_volume_rotation_association(custom_volumes, rotation_entity_names, param_info):
     """Validate that Cylinder/AxisymmetricBody/Sphere in CustomVolume.bounding_entities
-    are associated with a RotationVolume or RotationSphere."""
+    are associated with a RotationVolume, RotationSphere, or AxisymmetricRefinement."""
     for cv in custom_volumes:
         for entity in param_info.expand_entity_list(cv.bounding_entities):
             if (
@@ -176,7 +195,7 @@ def _validate_custom_volume_rotation_association(custom_volumes, rotation_entity
                 raise ValueError(
                     f"`{type(entity).__name__}` entity `{entity.name}` in "
                     f"`CustomVolume` `{cv.name}` `bounding_entities` must be "
-                    f"associated with a `RotationVolume` or `RotationSphere`."
+                    f"associated with a `RotationVolume`, `RotationSphere`, or `AxisymmetricRefinement`."
                 )
 
 
@@ -321,31 +340,45 @@ class MeshingParams(Flow360BaseModel):
 
     @contextual_field_validator("volume_zones", mode="after")
     @classmethod
-    def _check_enclosed_entities_rotation_volume_association(
-        cls, v, param_info: ParamsValidationInfo
-    ):
+    def _check_enclosed_entities_farfield_structure(cls, v):
         """
         Ensure that:
         - enclosed_entities on any farfield requires at least one CustomZone
-        - Cylinder, AxisymmetricBody, and Sphere entities in enclosed_entities
-          are associated with a RotationVolume or RotationSphere
+        - CustomZones require enclosed_entities on farfield
         """
         if v is None:
             return v
 
-        rotation_entity_names = _collect_rotation_entity_names(
-            v, param_info, (RotationVolume, RotationCylinder, RotationSphere)
-        )
         custom_volumes = _collect_all_custom_volumes(v)
         has_custom_volumes = len(custom_volumes) > 0
-        _validate_farfield_enclosed_entities(
-            v, rotation_entity_names, has_custom_volumes, param_info
-        )
-        _validate_custom_volume_rotation_association(
-            custom_volumes, rotation_entity_names, param_info
-        )
+        _validate_farfield_enclosed_entities_structure(v, has_custom_volumes)
 
         return v
+
+    @contextual_model_validator(mode="after")
+    def _check_rotation_association(self, param_info: ParamsValidationInfo) -> Self:
+        """Validate that Cylinder/AxisymmetricBody/Sphere in enclosed_entities and
+        CustomVolume.bounding_entities are associated with a RotationVolume,
+        RotationSphere, or AxisymmetricRefinement."""
+        if self.volume_zones is None:
+            return self
+
+        rotation_entity_names = _collect_rotation_entity_names(
+            self.volume_zones, param_info, (RotationVolume, RotationCylinder, RotationSphere)
+        )
+        axisymmetric_entity_names = _collect_axisymmetric_refinement_entity_names(
+            self.refinements, param_info
+        )
+        allowed_names = rotation_entity_names | axisymmetric_entity_names
+
+        _validate_farfield_enclosed_entities_association(
+            self.volume_zones, allowed_names, param_info
+        )
+
+        custom_volumes = _collect_all_custom_volumes(self.volume_zones)
+        _validate_custom_volume_rotation_association(custom_volumes, allowed_names, param_info)
+
+        return self
 
     @contextual_field_validator("volume_zones", mode="after")
     @classmethod
@@ -678,29 +711,44 @@ class ModularMeshingWorkflow(Flow360BaseModel):
 
     @contextual_field_validator("zones", mode="after")
     @classmethod
-    def _check_enclosed_entities_rotation_volume_association(
-        cls, v, param_info: ParamsValidationInfo
-    ):
+    def _check_enclosed_entities_farfield_structure(cls, v):
         """
         Ensure that:
         - enclosed_entities on any farfield requires at least one CustomZone
-        - Cylinder, AxisymmetricBody, and Sphere entities in enclosed_entities
-          are associated with a RotationVolume or RotationSphere
+        - CustomZones require enclosed_entities on farfield
         """
         if v is None:
             return v
 
         has_custom_zones = any(isinstance(zone, CustomZones) for zone in v)
-        rotation_entity_names = _collect_rotation_entity_names(
-            v, param_info, (RotationVolume, RotationSphere)
-        )
-        _validate_farfield_enclosed_entities(v, rotation_entity_names, has_custom_zones, param_info)
-        custom_volumes = _collect_all_custom_volumes(v)
-        _validate_custom_volume_rotation_association(
-            custom_volumes, rotation_entity_names, param_info
-        )
+        _validate_farfield_enclosed_entities_structure(v, has_custom_zones)
 
         return v
+
+    @contextual_model_validator(mode="after")
+    def _check_rotation_association(self, param_info: ParamsValidationInfo) -> Self:
+        """Validate that Cylinder/AxisymmetricBody/Sphere in enclosed_entities and
+        CustomVolume.bounding_entities are associated with a RotationVolume,
+        RotationSphere, or AxisymmetricRefinement."""
+        if self.zones is None:
+            return self
+
+        rotation_entity_names = _collect_rotation_entity_names(
+            self.zones, param_info, (RotationVolume, RotationSphere)
+        )
+        # pylint: disable=no-member
+        refinements = self.volume_meshing.refinements if self.volume_meshing is not None else []
+        axisymmetric_entity_names = _collect_axisymmetric_refinement_entity_names(
+            refinements, param_info
+        )
+        allowed_names = rotation_entity_names | axisymmetric_entity_names
+
+        _validate_farfield_enclosed_entities_association(self.zones, allowed_names, param_info)
+
+        custom_volumes = _collect_all_custom_volumes(self.zones)
+        _validate_custom_volume_rotation_association(custom_volumes, allowed_names, param_info)
+
+        return self
 
     @pd.model_validator(mode="after")
     def _check_snappy_zones(self) -> Self:

--- a/tests/simulation/params/test_farfield_enclosed_entities.py
+++ b/tests/simulation/params/test_farfield_enclosed_entities.py
@@ -114,7 +114,10 @@ def test_enclosed_entities_beta_mesher_positive(farfield_cls):
                     _make_custom_zones_with_volume(),
                     _make_farfield(
                         farfield_cls,
-                        enclosed_entities=[Surface(name="face1"), Surface(name="face2")],
+                        enclosed_entities=[
+                            Surface(name="face1"),
+                            Surface(name="face2"),
+                        ],
                     ),
                 ],
             ),
@@ -280,7 +283,10 @@ def test_enclosed_entities_surfaces_only_no_rotation_volume_needed():
                 volume_zones=[
                     _make_custom_zones_with_volume(),
                     AutomatedFarfield(
-                        enclosed_entities=[Surface(name="face1"), Surface(name="face2")],
+                        enclosed_entities=[
+                            Surface(name="face1"),
+                            Surface(name="face2"),
+                        ],
                     ),
                 ],
             ),
@@ -507,3 +513,135 @@ def test_farfield_custom_volume_no_intersection_negative():
     assert errors is not None
     assert any("shares bounding entities" in e["msg"] for e in errors)
     assert any("shared" in e["msg"] for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# Group: AxisymmetricRefinement association tests
+# ---------------------------------------------------------------------------
+
+
+def _make_bet_cylinder():
+    return Cylinder(
+        name="bet_disk",
+        axis=(0, 0, 1),
+        center=(0, 0, 0) * u.m,
+        height=1 * u.m,
+        inner_radius=0.1 * u.m,
+        outer_radius=2 * u.m,
+    )
+
+
+def test_custom_volume_with_axisymmetric_refinement_passes():
+    """Cylinder in CustomVolume.bounding_entities associated with AxisymmetricRefinement should pass."""
+    from flow360.component.simulation.meshing_param.volume_params import (
+        AxisymmetricRefinement,
+    )
+
+    bet = _make_bet_cylinder()
+    with SI_unit_system:
+        cv = CustomVolume(name="vol1", bounding_entities=[Surface(name="s1"), bet])
+        params = SimulationParams(
+            meshing=MeshingParams(
+                defaults=MeshingDefaults(boundary_layer_first_layer_thickness=1e-4),
+                refinements=[
+                    AxisymmetricRefinement(
+                        entities=[bet],
+                        spacing_axial=0.1 * u.m,
+                        spacing_radial=0.05 * u.m,
+                        spacing_circumferential=0.1 * u.m,
+                    ),
+                ],
+                volume_zones=[
+                    UserDefinedFarfield(),
+                    CustomZones(name="z1", entities=[cv]),
+                ],
+            ),
+            private_attribute_asset_cache=AssetCache(use_inhouse_mesher=True),
+        )
+    _, errors, _ = _validate(params)
+    assert errors is None
+
+
+def test_custom_volume_without_any_association_fails():
+    """Cylinder in CustomVolume.bounding_entities without any association should fail."""
+    orphan = Cylinder(
+        name="orphan",
+        axis=(0, 0, 1),
+        center=(0, 0, 0) * u.m,
+        height=1 * u.m,
+        outer_radius=1 * u.m,
+    )
+    with SI_unit_system:
+        cv = CustomVolume(name="vol1", bounding_entities=[Surface(name="s1"), orphan])
+        params = SimulationParams(
+            meshing=MeshingParams(
+                defaults=MeshingDefaults(boundary_layer_first_layer_thickness=1e-4),
+                volume_zones=[
+                    UserDefinedFarfield(),
+                    CustomZones(name="z1", entities=[cv]),
+                ],
+            ),
+            private_attribute_asset_cache=AssetCache(use_inhouse_mesher=True),
+        )
+    _, errors, _ = _validate(params)
+    assert errors is not None
+    assert any("must be associated" in e["msg"] for e in errors)
+
+
+@pytest.mark.parametrize("farfield_cls", FARFIELD_TYPES_WITH_ENCLOSED, ids=lambda c: c.__name__)
+def test_enclosed_entities_axisymmetric_refinement_passes(farfield_cls):
+    """Cylinder in enclosed_entities associated with AxisymmetricRefinement should pass."""
+    from flow360.component.simulation.meshing_param.volume_params import (
+        AxisymmetricRefinement,
+    )
+
+    bet = _make_bet_cylinder()
+    with SI_unit_system:
+        cv = CustomVolume(name="vol1", bounding_entities=[Surface(name="s1")])
+        params = SimulationParams(
+            meshing=MeshingParams(
+                defaults=_make_defaults(farfield_cls),
+                refinements=[
+                    AxisymmetricRefinement(
+                        entities=[bet],
+                        spacing_axial=0.1 * u.m,
+                        spacing_radial=0.05 * u.m,
+                        spacing_circumferential=0.1 * u.m,
+                    ),
+                ],
+                volume_zones=[
+                    CustomZones(name="z1", entities=[cv]),
+                    _make_farfield(farfield_cls, enclosed_entities=[cv, bet]),
+                ],
+            ),
+            private_attribute_asset_cache=_make_asset_cache(farfield_cls),
+        )
+    _, errors, _ = _validate(params)
+    assert errors is None
+
+
+@pytest.mark.parametrize("farfield_cls", FARFIELD_TYPES_WITH_ENCLOSED, ids=lambda c: c.__name__)
+def test_enclosed_entities_unassociated_cylinder_fails(farfield_cls):
+    """Cylinder in enclosed_entities without any association should fail."""
+    orphan = Cylinder(
+        name="orphan",
+        axis=(0, 0, 1),
+        center=(0, 0, 0) * u.m,
+        height=1 * u.m,
+        outer_radius=1 * u.m,
+    )
+    with SI_unit_system:
+        cv = CustomVolume(name="vol1", bounding_entities=[Surface(name="s1")])
+        params = SimulationParams(
+            meshing=MeshingParams(
+                defaults=_make_defaults(farfield_cls),
+                volume_zones=[
+                    CustomZones(name="z1", entities=[cv]),
+                    _make_farfield(farfield_cls, enclosed_entities=[cv, orphan]),
+                ],
+            ),
+            private_attribute_asset_cache=_make_asset_cache(farfield_cls),
+        )
+    _, errors, _ = _validate(params)
+    assert errors is not None
+    assert any("must be associated" in e["msg"] for e in errors)

--- a/tests/simulation/translator/test_volume_meshing_translator.py
+++ b/tests/simulation/translator/test_volume_meshing_translator.py
@@ -157,7 +157,12 @@ def get_test_param():
                 name="cone_mm_curve",
                 axis=(1, 0, 1),
                 center=(0, 1, 0) * u.cm,
-                profile_curve=[(-1, 0) * u.mm, (-1, 1) * u.mm, (1, 2) * u.mm, (1, 0) * u.mm],
+                profile_curve=[
+                    (-1, 0) * u.mm,
+                    (-1, 1) * u.mm,
+                    (1, 2) * u.mm,
+                    (1, 0) * u.mm,
+                ],
             )
 
             porous_medium = Box.from_principal_axes(
@@ -276,7 +281,12 @@ def get_test_param():
                     spacing_axial=40 * u.cm,
                     spacing_radial=0.4,
                     spacing_circumferential=40 * u.cm,
-                    enclosed_entities=[mid_cylinder, rotor_disk_cylinder, cylinder_2, cylinder_3],
+                    enclosed_entities=[
+                        mid_cylinder,
+                        rotor_disk_cylinder,
+                        cylinder_2,
+                        cylinder_3,
+                    ],
                 )
             )
             if beta_mesher:
@@ -405,7 +415,12 @@ def get_test_param_modular():
             center=(0, 5, 0),
         )
         cylinder_3 = Cylinder(
-            name="3", inner_radius=1.5, outer_radius=2, height=2, axis=(0, 1, 0), center=(0, -5, 0)
+            name="3",
+            inner_radius=1.5,
+            outer_radius=2,
+            height=2,
+            axis=(0, 1, 0),
+            center=(0, -5, 0),
         )
         cylinder_outer = Cylinder(
             name="outer",
@@ -425,7 +440,12 @@ def get_test_param_modular():
             name="cone_mm_curve",
             axis=(1, 0, 1),
             center=(0, 1, 0) * u.cm,
-            profile_curve=[(-1, 0) * u.mm, (-1, 1) * u.mm, (1, 2) * u.mm, (1, 0) * u.mm],
+            profile_curve=[
+                (-1, 0) * u.mm,
+                (-1, 1) * u.mm,
+                (1, 2) * u.mm,
+                (1, 0) * u.mm,
+            ],
         )
 
         porous_medium = Box.from_principal_axes(
@@ -848,7 +868,10 @@ def test_user_defined_farfield_ghost_symmetry_requires_gai_and_beta(use_gai, use
             "meshing": {
                 "type_name": "MeshingParams",
                 "volume_zones": [
-                    {"type": "UserDefinedFarfield", "domain_type": "half_body_positive_y"}
+                    {
+                        "type": "UserDefinedFarfield",
+                        "domain_type": "half_body_positive_y",
+                    }
                 ],
             },
             "private_attribute_asset_cache": {
@@ -878,7 +901,10 @@ def test_user_defined_farfield_ghost_symmetry_passes_with_gai_and_beta():
             "meshing": {
                 "type_name": "MeshingParams",
                 "volume_zones": [
-                    {"type": "UserDefinedFarfield", "domain_type": "half_body_positive_y"}
+                    {
+                        "type": "UserDefinedFarfield",
+                        "domain_type": "half_body_positive_y",
+                    }
                 ],
             },
             "private_attribute_asset_cache": {
@@ -1145,7 +1171,8 @@ def test_farfield_relative_size():
         param = SimulationParams(
             meshing=MeshingParams(
                 defaults=MeshingDefaults(
-                    boundary_layer_first_layer_thickness=1e-3, boundary_layer_growth_rate=1.25
+                    boundary_layer_first_layer_thickness=1e-3,
+                    boundary_layer_growth_rate=1.25,
                 ),
                 volume_zones=[AutomatedFarfield(method="quasi-3d", relative_size=100.0)],
             )
@@ -1328,7 +1355,12 @@ def test_uniform_refinement_box_cylinder_axisymm_body(get_surface_mesh):
     assert axisymm_ref["type"] == "Axisymmetric"
     assert axisymm_ref["axisOfRotation"] == [0.0, 1.0, 0.0]
     assert axisymm_ref["center"] == [5.0, 6.0, 7.0]
-    assert axisymm_ref["profileCurve"] == [[0.0, 0.0], [0.0, 0.5], [1.0, 1.0], [1.0, 0.0]]
+    assert axisymm_ref["profileCurve"] == [
+        [0.0, 0.0],
+        [0.0, 0.5],
+        [1.0, 1.0],
+        [1.0, 0.0],
+    ]
     assert axisymm_ref["spacing"] == 0.1
 
 
@@ -1406,7 +1438,9 @@ def test_edge_split_layers_explicit_translation(get_surface_mesh, edge_split_lay
     assert translated["volume"]["numEdgeSplitLayers"] == expected
 
 
-def test_windtunnel_ghost_surface_supported_in_volume_face_refinements(get_surface_mesh):
+def test_windtunnel_ghost_surface_supported_in_volume_face_refinements(
+    get_surface_mesh,
+):
     with SI_unit_system:
         wind_tunnel = WindTunnelFarfield()
         param = SimulationParams(
@@ -1480,7 +1514,8 @@ def test_sphere_rotation_volume_translator(get_surface_mesh):
 
     # Find the inner sphere interface
     inner_interface = next(
-        (si for si in translated["slidingInterfaces"] if si["name"] == "sphereInterface"), None
+        (si for si in translated["slidingInterfaces"] if si["name"] == "sphereInterface"),
+        None,
     )
     assert inner_interface is not None
     assert inner_interface["type"] == "Sphere"
@@ -1492,7 +1527,8 @@ def test_sphere_rotation_volume_translator(get_surface_mesh):
 
     # Find the outer sphere interface
     outer_interface = next(
-        (si for si in translated["slidingInterfaces"] if si["name"] == "outerSphere"), None
+        (si for si in translated["slidingInterfaces"] if si["name"] == "outerSphere"),
+        None,
     )
     assert outer_interface is not None
     assert outer_interface["type"] == "Sphere"
@@ -1628,7 +1664,10 @@ def test_farfield_enclosed_entities_with_cylinder(get_surface_mesh):
     assert "zones" in translated
     zones_by_name = {z["name"]: z for z in translated["zones"]}
     assert "farfield" in zones_by_name
-    assert sorted(zones_by_name["farfield"]["patches"]) == ["face1", "slidingInterface-rotor"]
+    assert sorted(zones_by_name["farfield"]["patches"]) == [
+        "face1",
+        "slidingInterface-rotor",
+    ]
 
 
 class TestTranslateEnclosedEntityName:
@@ -1649,7 +1688,12 @@ class TestTranslateEnclosedEntityName:
                 name="cone",
                 center=(0, 0, 0) * u.m,
                 axis=(1, 0, 0),
-                profile_curve=[(-1, 0) * u.m, (-1, 1) * u.m, (1, 1) * u.m, (1, 0) * u.m],
+                profile_curve=[
+                    (-1, 0) * u.m,
+                    (-1, 1) * u.m,
+                    (1, 1) * u.m,
+                    (1, 0) * u.m,
+                ],
             )
             self.sphere = Sphere(
                 name="sph",
@@ -1747,7 +1791,10 @@ def test_farfield_enclosed_entities_with_sphere(get_surface_mesh):
     assert "zones" in translated
     zones_by_name = {z["name"]: z for z in translated["zones"]}
     assert "farfield" in zones_by_name
-    assert sorted(zones_by_name["farfield"]["patches"]) == ["face1", "slidingInterface-sph"]
+    assert sorted(zones_by_name["farfield"]["patches"]) == [
+        "face1",
+        "slidingInterface-sph",
+    ]
 
 
 def test_farfield_enclosed_entities_with_axisymmetric_body(get_surface_mesh):
@@ -1793,7 +1840,10 @@ def test_farfield_enclosed_entities_with_axisymmetric_body(get_surface_mesh):
     assert "zones" in translated
     zones_by_name = {z["name"]: z for z in translated["zones"]}
     assert "farfield" in zones_by_name
-    assert sorted(zones_by_name["farfield"]["patches"]) == ["face1", "slidingInterface-cone"]
+    assert sorted(zones_by_name["farfield"]["patches"]) == [
+        "face1",
+        "slidingInterface-cone",
+    ]
 
 
 def test_farfield_enclosed_entities_unwraps_custom_volume(get_surface_mesh):
@@ -1832,7 +1882,9 @@ def test_farfield_enclosed_entities_unwraps_custom_volume(get_surface_mesh):
     ]
 
 
-def test_farfield_enclosed_entities_unwraps_custom_volume_with_cylinder(get_surface_mesh):
+def test_farfield_enclosed_entities_unwraps_custom_volume_with_cylinder(
+    get_surface_mesh,
+):
     """CustomVolume containing a Cylinder should unwrap with slidingInterface- prefix."""
     rotor = Cylinder(
         name="rotor",
@@ -2107,3 +2159,83 @@ def test_custom_volume_with_rotor_disk_cylinder(get_surface_mesh):
     assert "farfield" in zones_by_name
     assert "rotorDisk-bet_disk" in zones_by_name["farfield"]["patches"]
     assert "slidingInterface-bet_disk" not in zones_by_name["farfield"]["patches"]
+
+
+def test_custom_volume_with_rotor_disk_user_defined_farfield(get_surface_mesh):
+    """Replicates real user scenario: BET disk cylinder in a CustomVolume with UserDefinedFarfield."""
+    bet_cylinder = Cylinder(
+        name="bet_cylinder_Disk",
+        axis=(-0.13052611474477474, 0.0, 0.991444871573621),
+        center=(-0.8368284, 0.0, 1.4052296) * u.m,
+        height=0.64008 * u.m,
+        inner_radius=0.50673 * u.m,
+        outer_radius=6.4008 * u.m,
+    )
+    wake_box = Cylinder(
+        name="wake_box",
+        axis=(-0.13052611474477474, 0.0, 0.991444871573621),
+        center=(-0.289, 0.0, -2.909) * u.m,
+        height=8.0 * u.m,
+        outer_radius=8.0 * u.m,
+    )
+    with SI_unit_system:
+        volume1 = CustomVolume(
+            name="Volume1",
+            bounding_entities=[
+                Surface(name="blk1-wall"),
+                Surface(name="blk1-farfield"),
+                bet_cylinder,
+            ],
+        )
+        volume2 = CustomVolume(
+            name="Volume2",
+            bounding_entities=[
+                Surface(name="blk2-wall"),
+                Surface(name="blk2-outlet"),
+            ],
+        )
+        params = SimulationParams(
+            meshing=MeshingParams(
+                defaults=MeshingDefaults(
+                    boundary_layer_first_layer_thickness=0.1e-3,
+                ),
+                refinements=[
+                    AxisymmetricRefinement(
+                        name="Axisymmetric refinement",
+                        entities=[bet_cylinder],
+                        spacing_axial=0.032004 * u.m,
+                        spacing_radial=0.011853 * u.m,
+                        spacing_circumferential=0.074477 * u.m,
+                    ),
+                    UniformRefinement(
+                        name="Uniform refinement",
+                        entities=[wake_box],
+                        spacing=1 * u.m,
+                    ),
+                ],
+                volume_zones=[
+                    UserDefinedFarfield(),
+                    CustomZones(name="VolumeZone1", entities=[volume1]),
+                    CustomZones(name="VolumeZone2", entities=[volume2]),
+                ],
+            ),
+            private_attribute_asset_cache=AssetCache(use_inhouse_mesher=True),
+        )
+
+    translated = get_volume_meshing_json(params, get_surface_mesh.mesh_unit)
+    assert "zones" in translated
+    zones_by_name = {z["name"]: z for z in translated["zones"]}
+
+    # Volume1 should contain the rotor disk with correct prefix
+    assert "Volume1" in zones_by_name
+    assert "rotorDisk-bet_cylinder_Disk" in zones_by_name["Volume1"]["patches"]
+    assert "slidingInterface-bet_cylinder_Disk" not in zones_by_name["Volume1"]["patches"]
+
+    # Volume2 should not contain the rotor disk
+    assert "Volume2" in zones_by_name
+    assert "rotorDisk-bet_cylinder_Disk" not in zones_by_name["Volume2"]["patches"]
+
+    # Rotor disk should be in the translated rotorDisks section
+    assert "rotorDisks" in translated
+    rotor_names = [rd["name"] for rd in translated["rotorDisks"]]
+    assert "bet_cylinder_Disk" in rotor_names


### PR DESCRIPTION
# PR: Support Rotor Disks in Custom Volumes (Python Client)

FXC ticket: https://flow360.atlassian.net/browse/FXC-6076

## Summary

Companion fix to C++ PR #4977. Enables `AxisymmetricRefinement` (BET/rotor disk) cylinders to be placed in `CustomVolume.bounding_entities` without validation errors, and ensures they translate to the correct `"rotorDisk-"` prefix in the Flynn360 JSON.

## Notes

- `StructuredBoxRefinement` (`Box` entities) is unaffected -- the validator only gates `Cylinder`, `AxisymmetricBody`, and `Sphere`. `Box` entities already pass through without any association requirement, and the translator already maps them to `"structuredBox-"` correctly.

## Changes

### `flow360/component/simulation/translator/volume_meshing_translator.py`

- `_get_custom_volumes` and `_build_farfield_zone` now accept and forward `rotor_disk_names` to `_translate_enclosed_entity_name`, ensuring rotor-disk cylinders get the `"rotorDisk-"` prefix instead of `"slidingInterface-"`.

### `flow360/component/simulation/meshing_param/params.py`

- **Validation fix**: Cylinders associated with `AxisymmetricRefinement` are now recognized as valid in `CustomVolume.bounding_entities` and farfield `enclosed_entities`.
- Added `_collect_axisymmetric_refinement_entity_names()` helper to gather entity names from `AxisymmetricRefinement` in the refinements list.
- Split `_validate_farfield_enclosed_entities` into `_validate_farfield_enclosed_entities_structure` (structural checks in field validator) and `_validate_farfield_enclosed_entities_association` (entity-type checks in model validator).
- Moved entity-type association checks from `contextual_field_validator` to `contextual_model_validator` on both `MeshingParams` and `ModularMeshingWorkflow`, since model validators have access to `self.refinements` / `self.volume_meshing.refinements`.
- Updated error messages to include `AxisymmetricRefinement` as a valid association.

### `tests/simulation/translator/test_volume_meshing_translator.py`

- `test_custom_volume_with_rotor_disk_cylinder`: verifies correct `"rotorDisk-"` prefix in custom volume and farfield zone patches.
- `test_custom_volume_with_rotor_disk_user_defined_farfield`: replicates the user's exact scenario (BET disk cylinder + `UserDefinedFarfield` + multiple custom volumes).

### `tests/simulation/params/test_farfield_enclosed_entities.py`

- `test_custom_volume_with_axisymmetric_refinement_passes`: cylinder in `CustomVolume` with `AxisymmetricRefinement` passes.
- `test_custom_volume_without_any_association_fails`: unassociated cylinder is still rejected.
- `test_enclosed_entities_axisymmetric_refinement_passes`: cylinder in farfield `enclosed_entities` with `AxisymmetricRefinement` passes.
- `test_enclosed_entities_unassociated_cylinder_fails`: unassociated cylinder in `enclosed_entities` is still rejected.

## Test Plan

- [x] `poetry run pytest tests/simulation/params/test_farfield_enclosed_entities.py` (25 passed)
- [x] `poetry run pytest tests/simulation/translator/test_volume_meshing_translator.py` (50 passed)
- [x] `poetry run pytest tests/simulation/params/test_validators_params.py` (passed)
- [x] `poetry run pytest tests/simulation/params/test_validators_solid.py` (passed)
- [x] `poetry run pytest tests/simulation/params/meshing_validation/test_meshing_param_validation.py` (passed)
- [x] `poetry run pytest tests/simulation/params/meshing_validation/test_refinements_validation.py` (passed)
- [x] `poetry run pytest tests/simulation/translator/test_surface_meshing_translator.py` (passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts meshing schema validation and JSON translation around `enclosed_entities`/`CustomVolume.bounding_entities`, which can change which configurations are accepted or rejected and how patch names are emitted for volume meshing.
> 
> **Overview**
> Adds support for treating `AxisymmetricRefinement` cylinders (rotor disks/BET disks) as valid associations when used inside `CustomVolume.bounding_entities` and farfield `enclosed_entities`, instead of requiring only `RotationVolume`/`RotationSphere`.
> 
> Refactors the farfield validation into separate *structure* vs *association* checks and moves the association logic into `contextual_model_validator`s so it can reference refinements; error messages now explicitly allow `AxisymmetricRefinement`.
> 
> Updates the volume meshing translator so cylinders that correspond to rotor disks are emitted with the `rotorDisk-` prefix (including inside custom volume patches and farfield zone patches), and adds tests covering the new validator behavior and a real-world multi-custom-volume + `UserDefinedFarfield` scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d055a408c629aa43bb24cf13e0e9d530c7c5c5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->