### PR TITLE
[Hotfix 25.9] [FXC-7485] Fix PorousJump BC completeness; warn-only missing-BC for overlap-aware models

### DIFF
--- a/flow360/component/simulation/validation/validation_simulation_params.py
+++ b/flow360/component/simulation/validation/validation_simulation_params.py
@@ -28,7 +28,6 @@ from flow360.component.simulation.models.solver_numerics import (
 from flow360.component.simulation.models.surface_models import (
     Inflow,
     Outflow,
-    PorousJump,
     SurfaceModelTypes,
     Wall,
 )
@@ -515,13 +514,11 @@ def _collect_used_boundary_names(params, param_info: ParamsValidationInfo) -> se
     for model in params.models:
         if not isinstance(model, get_args(SurfaceModelTypes)):
             continue
-        if isinstance(model, PorousJump):
-            continue
 
         # pylint: disable=protected-access
         if hasattr(model, "entities"):
             entities = param_info.expand_entity_list(model.entities)
-        elif hasattr(model, "entity_pairs"):  # Periodic BC
+        elif hasattr(model, "entity_pairs"):  # Periodic / PorousJump BC
             entities = [
                 pair for surface_pair in model.entity_pairs.items for pair in surface_pair.pair
             ]

--- a/flow360/component/simulation/validation/validation_simulation_params.py
+++ b/flow360/component/simulation/validation/validation_simulation_params.py
@@ -35,6 +35,7 @@ from flow360.component.simulation.models.surface_models import (
 from flow360.component.simulation.models.volume_models import (
     ActuatorDisk,
     Fluid,
+    PorousMedium,
     Rotation,
     Solid,
 )
@@ -543,6 +544,40 @@ def _collect_used_boundary_names(
     return used_boundaries
 
 
+def _has_models_implying_potential_overlap(
+    params, param_info: ParamsValidationInfo
+) -> bool:
+    """Detect models whose presence implies the input geometry/surface mesh may
+    have overlapping faces that the mesher will turn into zone-to-zone
+    interfaces.
+
+    The Python client cannot detect such overlap at validation time, so for
+    these models we cannot assert that a missing-BC face is genuinely missing
+    — it may end up consumed by an auto-generated interface. Used to downgrade
+    the missing-BC error to a warning.
+
+    Volume-mesh workflows are excluded: meshing has already finished, so any
+    boundary in `VolumeMeshEntityInfo.boundaries` that doesn't have a BC is
+    genuinely missing and the original strict error must be preserved.
+
+    Returns True if root is geometry/surface_mesh AND any of:
+    - A PorousJump model is present (its surface_pairs imply overlap).
+    - A PorousMedium model is present whose entities include a CustomVolume
+      (the CustomVolume bounding faces may overlap with farfield/other faces).
+    """
+    if param_info.root_asset_type == "volume_mesh":
+        return False
+
+    for model in params.models:
+        if isinstance(model, PorousJump):
+            return True
+        if isinstance(model, PorousMedium):
+            for entity in model.entities.stored_entities:
+                if isinstance(entity, CustomVolume):
+                    return True
+    return False
+
+
 def _validate_boundary_completeness(  # pylint:disable=too-many-arguments
     *,
     asset_boundaries: set,
@@ -552,6 +587,7 @@ def _validate_boundary_completeness(  # pylint:disable=too-many-arguments
     entity_transformation_detected: bool,
     has_missing_private_attributes: bool = False,
     use_geometry_AI: bool = False,
+    has_potential_overlap: bool = False,
 ) -> None:
     """Validate missing/unknown boundary references with error/warning policy."""
     missing_boundaries = asset_boundaries - used_boundaries - potential_zone_zone_interfaces
@@ -559,7 +595,12 @@ def _validate_boundary_completeness(  # pylint:disable=too-many-arguments
 
     if missing_boundaries and not snappy_multizone:
         missing_list = ", ".join(sorted(missing_boundaries))
-        if entity_transformation_detected or has_missing_private_attributes or use_geometry_AI:
+        if (
+            entity_transformation_detected
+            or has_missing_private_attributes
+            or use_geometry_AI
+            or has_potential_overlap
+        ):
             message = (
                 f"The following boundaries do not have a boundary condition: {missing_list}. "
                 "If these boundaries are valid, please add them to a boundary condition model in the `models` section."
@@ -619,6 +660,7 @@ def _check_complete_boundary_condition_and_unknown_surface(
         entity_transformation_detected=param_info.entity_transformation_detected,
         has_missing_private_attributes=has_missing_private_attributes,
         use_geometry_AI=param_info.use_geometry_AI,
+        has_potential_overlap=_has_models_implying_potential_overlap(params, param_info),
     )
 
     return params

--- a/flow360/component/simulation/validation/validation_simulation_params.py
+++ b/flow360/component/simulation/validation/validation_simulation_params.py
@@ -28,6 +28,7 @@ from flow360.component.simulation.models.solver_numerics import (
 from flow360.component.simulation.models.surface_models import (
     Inflow,
     Outflow,
+    PorousJump,
     SurfaceModelTypes,
     Wall,
 )
@@ -504,7 +505,9 @@ def _collect_farfield_custom_volume_interfaces(*, param_info: ParamsValidationIn
     }
 
 
-def _collect_used_boundary_names(params, param_info: ParamsValidationInfo) -> set:
+def _collect_used_boundary_names(
+    params, param_info: ParamsValidationInfo, asset_boundaries: set[str]
+) -> set:
     """Collect all boundary names referenced in Surface BC models."""
     if len(params.models) == 1 and isinstance(params.models[0], Fluid):
         raise ValueError("No boundary conditions are defined in the `models` section.")
@@ -526,6 +529,15 @@ def _collect_used_boundary_names(params, param_info: ParamsValidationInfo) -> se
             entities = []
 
         for entity in entities:
+            # PorousJump pairs are zone-to-zone interfaces in volume-mesh
+            # workflows (filtered out of `asset_boundaries` by
+            # VolumeMeshEntityInfo.get_boundaries) and don't need a BC of
+            # their own. In geometry workflows the surfaces are real
+            # boundaries and must be counted to satisfy completeness.
+            # Filter against asset_boundaries to handle both correctly
+            # without flagging true interfaces as unknown.
+            if isinstance(model, PorousJump) and entity.name not in asset_boundaries:
+                continue
             used_boundaries.add(entity.name)
 
     return used_boundaries
@@ -596,7 +608,7 @@ def _check_complete_boundary_condition_and_unknown_surface(
     potential_zone_zone_interfaces |= _collect_farfield_custom_volume_interfaces(
         param_info=param_info
     )
-    used_boundaries = _collect_used_boundary_names(params, param_info)
+    used_boundaries = _collect_used_boundary_names(params, param_info, asset_boundaries)
 
     # Step 4: Validate set differences with policy
     _validate_boundary_completeness(

--- a/flow360/component/simulation/validation/validation_simulation_params.py
+++ b/flow360/component/simulation/validation/validation_simulation_params.py
@@ -544,9 +544,7 @@ def _collect_used_boundary_names(
     return used_boundaries
 
 
-def _has_models_implying_potential_overlap(
-    params, param_info: ParamsValidationInfo
-) -> bool:
+def _has_models_implying_potential_overlap(params, param_info: ParamsValidationInfo) -> bool:
     """Detect models whose presence implies the input geometry/surface mesh may
     have overlapping faces that the mesher will turn into zone-to-zone
     interfaces.

--- a/tests/simulation/params/test_validators_params.py
+++ b/tests/simulation/params/test_validators_params.py
@@ -3898,6 +3898,62 @@ def test_incomplete_BC_without_geometry_AI():
     )
 
 
+def test_porousJump_surfaces_count_as_having_boundary_condition():
+    """PorousJump surface_pairs should satisfy the BC-completeness check.
+
+    Regression: previously the validator skipped PorousJump entirely when collecting
+    boundaries that have a BC, causing all surfaces in surface_pairs to be falsely
+    reported as missing a boundary condition.
+    """
+    wall = Surface(name="wall", private_attribute_is_interface=False, private_attribute_id="wall")
+    pj_left = Surface(
+        name="pj_left", private_attribute_is_interface=True, private_attribute_id="pj_left"
+    )
+    pj_right = Surface(
+        name="pj_right", private_attribute_is_interface=True, private_attribute_id="pj_right"
+    )
+
+    asset_cache = AssetCache(
+        project_length_unit="m",
+        project_entity_info=VolumeMeshEntityInfo(boundaries=[wall, pj_left, pj_right]),
+        use_geometry_AI=False,
+    )
+
+    with SI_unit_system:
+        params = SimulationParams(
+            meshing=MeshingParams(
+                defaults=MeshingDefaults(
+                    boundary_layer_first_layer_thickness=1e-10,
+                    surface_max_edge_length=1e-10,
+                )
+            ),
+            models=[
+                Fluid(),
+                Wall(entities=[wall]),
+                PorousJump(
+                    entity_pairs=[(pj_left, pj_right)],
+                    darcy_coefficient=1e6 / (u.m * u.m),
+                    forchheimer_coefficient=1e3 / u.m,
+                    thickness=0.01 * u.m,
+                ),
+            ],
+            private_attribute_asset_cache=asset_cache,
+        )
+
+    _, errors, _ = validate_model(
+        params_as_dict=params.model_dump(mode="json"),
+        validated_by=ValidationCalledBy.LOCAL,
+        root_item_type="VolumeMesh",
+        validation_level="All",
+    )
+
+    if errors:
+        for err in errors:
+            assert "do not have a boundary condition" not in err.get(
+                "msg", ""
+            ), f"PorousJump surfaces wrongly reported as missing BC: {err}"
+
+
 def test_automated_farfield_with_custom_zones():
     """AutomatedFarfield + CustomZones: enclosed_entities is required when CustomVolumes exist."""
 

--- a/tests/simulation/params/test_validators_params.py
+++ b/tests/simulation/params/test_validators_params.py
@@ -3898,12 +3898,14 @@ def test_incomplete_BC_without_geometry_AI():
     )
 
 
-def test_porousJump_surfaces_count_as_having_boundary_condition():
-    """PorousJump surface_pairs should satisfy the BC-completeness check.
+def test_porousJump_volume_mesh_pairs_not_flagged_as_unknown():
+    """In volume-mesh workflows, PorousJump surface_pairs are zone-to-zone interfaces
+    (private_attribute_is_interface=True) and are filtered out of asset_boundaries.
 
-    Regression: previously the validator skipped PorousJump entirely when collecting
-    boundaries that have a BC, causing all surfaces in surface_pairs to be falsely
-    reported as missing a boundary condition.
+    Regression guard: counting these in `used_boundaries` unconditionally would make
+    `unknown_boundaries = used_boundaries - asset_boundaries` flag them as unknown.
+    They should be silently ignored for completeness purposes since they aren't
+    boundaries that need a BC.
     """
     wall = Surface(name="wall", private_attribute_is_interface=False, private_attribute_id="wall")
     pj_left = Surface(
@@ -3947,11 +3949,7 @@ def test_porousJump_surfaces_count_as_having_boundary_condition():
         validation_level="All",
     )
 
-    if errors:
-        for err in errors:
-            assert "do not have a boundary condition" not in err.get(
-                "msg", ""
-            ), f"PorousJump surfaces wrongly reported as missing BC: {err}"
+    assert errors is None or len(errors) == 0, f"Unexpected errors: {errors}"
 
 
 def test_automated_farfield_with_custom_zones():

--- a/tests/simulation/params/test_validators_params.py
+++ b/tests/simulation/params/test_validators_params.py
@@ -3898,6 +3898,206 @@ def test_incomplete_BC_without_geometry_AI():
     )
 
 
+def test_has_models_implying_potential_overlap_porous_jump(mock_validation_context):
+    """`_has_models_implying_potential_overlap` returns True for PorousJump on
+    geometry/surface_mesh workflows and False on volume_mesh (preserve original
+    behavior since meshing is already done).
+    """
+    # pylint: disable=import-outside-toplevel
+    from flow360.component.simulation.validation.validation_simulation_params import (
+        _has_models_implying_potential_overlap,
+    )
+
+    pj_left = Surface(
+        name="pj_left", private_attribute_is_interface=True, private_attribute_id="pj_left"
+    )
+    pj_right = Surface(
+        name="pj_right", private_attribute_is_interface=True, private_attribute_id="pj_right"
+    )
+
+    with mock_validation_context:
+        pj = PorousJump(
+            entity_pairs=[(pj_left, pj_right)],
+            darcy_coefficient=1e6 / (u.m * u.m),
+            forchheimer_coefficient=1e3 / u.m,
+            thickness=0.01 * u.m,
+        )
+
+    class _MockParams:
+        models = [Fluid(), pj]
+
+    for root_type in ("geometry", "surface_mesh"):
+        info = ParamsValidationInfo({}, [])
+        info.root_asset_type = root_type
+        assert _has_models_implying_potential_overlap(_MockParams(), info) is True, root_type
+
+    info = ParamsValidationInfo({}, [])
+    info.root_asset_type = "volume_mesh"
+    assert _has_models_implying_potential_overlap(_MockParams(), info) is False
+
+
+def test_has_models_implying_potential_overlap_porous_media():
+    """`_has_models_implying_potential_overlap` returns True for PorousMedium
+    only when the volumes include a CustomVolume (Box-only doesn't trigger).
+    Volume-mesh workflow is excluded regardless.
+    """
+    # pylint: disable=import-outside-toplevel
+    from flow360.component.simulation.validation.validation_simulation_params import (
+        _has_models_implying_potential_overlap,
+    )
+
+    cv = CustomVolume(
+        name="cv",
+        bounding_entities=[Surface(name="s1", private_attribute_id="s1")],
+    )
+    box = Box.from_principal_axes(
+        name="box",
+        axes=[(1, 0, 0), (0, 1, 0)],
+        center=(0, 0, 0) * u.m,
+        size=(1, 1, 1) * u.m,
+    )
+
+    pm_with_cv = PorousMedium(
+        volumes=[cv],
+        darcy_coefficient=(1e6, 0, 0) / u.m**2,
+        forchheimer_coefficient=(1, 0, 0) / u.m,
+    )
+    pm_box_only = PorousMedium(
+        volumes=[box],
+        darcy_coefficient=(1e6, 0, 0) / u.m**2,
+        forchheimer_coefficient=(1, 0, 0) / u.m,
+    )
+
+    class _ParamsWithCV:
+        models = [Fluid(), pm_with_cv]
+
+    class _ParamsBoxOnly:
+        models = [Fluid(), pm_box_only]
+
+    geo_info = ParamsValidationInfo({}, [])
+    geo_info.root_asset_type = "geometry"
+
+    assert _has_models_implying_potential_overlap(_ParamsWithCV(), geo_info) is True
+    assert _has_models_implying_potential_overlap(_ParamsBoxOnly(), geo_info) is False
+
+    vm_info = ParamsValidationInfo({}, [])
+    vm_info.root_asset_type = "volume_mesh"
+    assert _has_models_implying_potential_overlap(_ParamsWithCV(), vm_info) is False
+
+
+def test_missing_bc_with_porous_jump_downgraded_to_warning_on_surface_mesh():
+    """Non-VolumeMesh + PorousJump: missing-BC becomes a warning since the
+    input geometry may have overlapping faces not visible to the Python client.
+    """
+    wall = Surface(name="wall", private_attribute_is_interface=False, private_attribute_id="wall")
+    no_bc = Surface(
+        name="no_bc", private_attribute_is_interface=False, private_attribute_id="no_bc"
+    )
+    pj_left = Surface(
+        name="pj_left", private_attribute_is_interface=True, private_attribute_id="pj_left"
+    )
+    pj_right = Surface(
+        name="pj_right", private_attribute_is_interface=True, private_attribute_id="pj_right"
+    )
+
+    asset_cache = AssetCache(
+        project_length_unit="m",
+        project_entity_info=SurfaceMeshEntityInfo(
+            boundaries=[wall, no_bc, pj_left, pj_right],
+        ),
+    )
+
+    with SI_unit_system:
+        params = SimulationParams(
+            meshing=MeshingParams(
+                defaults=MeshingDefaults(
+                    boundary_layer_first_layer_thickness=1e-10,
+                    surface_max_edge_length=1e-10,
+                )
+            ),
+            models=[
+                Fluid(),
+                Wall(entities=[wall]),
+                PorousJump(
+                    entity_pairs=[(pj_left, pj_right)],
+                    darcy_coefficient=1e6 / (u.m * u.m),
+                    forchheimer_coefficient=1e3 / u.m,
+                    thickness=0.01 * u.m,
+                ),
+            ],
+            private_attribute_asset_cache=asset_cache,
+        )
+
+    _, errors, warnings = validate_model(
+        params_as_dict=params.model_dump(mode="json"),
+        validated_by=ValidationCalledBy.LOCAL,
+        root_item_type="SurfaceMesh",
+        validation_level="All",
+    )
+
+    assert errors is None or len(errors) == 0, f"Expected no errors, got: {errors}"
+    assert any(
+        "no_bc" in w.get("msg", "") and "do not have a boundary condition" in w.get("msg", "")
+        for w in warnings
+    ), f"Expected missing-BC warning for no_bc, got: {warnings}"
+
+
+def test_missing_bc_with_porous_jump_still_errors_on_volume_mesh():
+    """VolumeMesh + PorousJump: missing-BC remains a hard error since meshing
+    has already finished and any face without a BC is genuinely missing.
+    """
+    wall = Surface(name="wall", private_attribute_is_interface=False, private_attribute_id="wall")
+    no_bc = Surface(
+        name="no_bc", private_attribute_is_interface=False, private_attribute_id="no_bc"
+    )
+    pj_left = Surface(
+        name="pj_left", private_attribute_is_interface=True, private_attribute_id="pj_left"
+    )
+    pj_right = Surface(
+        name="pj_right", private_attribute_is_interface=True, private_attribute_id="pj_right"
+    )
+
+    asset_cache = AssetCache(
+        project_length_unit="m",
+        project_entity_info=VolumeMeshEntityInfo(
+            boundaries=[wall, no_bc, pj_left, pj_right],
+        ),
+    )
+
+    with SI_unit_system:
+        params = SimulationParams(
+            meshing=MeshingParams(
+                defaults=MeshingDefaults(
+                    boundary_layer_first_layer_thickness=1e-10,
+                    surface_max_edge_length=1e-10,
+                )
+            ),
+            models=[
+                Fluid(),
+                Wall(entities=[wall]),
+                PorousJump(
+                    entity_pairs=[(pj_left, pj_right)],
+                    darcy_coefficient=1e6 / (u.m * u.m),
+                    forchheimer_coefficient=1e3 / u.m,
+                    thickness=0.01 * u.m,
+                ),
+            ],
+            private_attribute_asset_cache=asset_cache,
+        )
+
+    _, errors, _ = validate_model(
+        params_as_dict=params.model_dump(mode="json"),
+        validated_by=ValidationCalledBy.LOCAL,
+        root_item_type="VolumeMesh",
+        validation_level="All",
+    )
+
+    assert errors and any(
+        "no_bc" in e.get("msg", "") and "do not have a boundary condition" in e.get("msg", "")
+        for e in errors
+    ), f"Expected missing-BC error for no_bc, got: {errors}"
+
+
 def test_collect_used_boundary_names_porous_jump_filtered_against_asset_boundaries(
     mock_validation_context,
 ):

--- a/tests/simulation/params/test_validators_params.py
+++ b/tests/simulation/params/test_validators_params.py
@@ -3898,6 +3898,57 @@ def test_incomplete_BC_without_geometry_AI():
     )
 
 
+def test_collect_used_boundary_names_porous_jump_filtered_against_asset_boundaries(
+    mock_validation_context,
+):
+    """Direct test of `_collect_used_boundary_names` PorousJump branch.
+
+    The fix counts a PorousJump pair surface as "having a BC" iff that surface
+    is in asset_boundaries:
+    - Geometry workflow: pair surfaces are real boundaries (present in
+      asset_boundaries) -> counted, so BC-completeness no longer falsely flags
+      them as missing.
+    - VolumeMesh workflow: pair surfaces are zone-to-zone interfaces and are
+      filtered out of asset_boundaries -> ignored, so they don't get falsely
+      flagged as unknown surfaces.
+    """
+    # pylint: disable=import-outside-toplevel
+    from flow360.component.simulation.validation.validation_simulation_params import (
+        _collect_used_boundary_names,
+    )
+
+    pj_left = Surface(
+        name="pj_left", private_attribute_is_interface=True, private_attribute_id="pj_left"
+    )
+    pj_right = Surface(
+        name="pj_right", private_attribute_is_interface=True, private_attribute_id="pj_right"
+    )
+
+    with mock_validation_context:
+        pj_model = PorousJump(
+            entity_pairs=[(pj_left, pj_right)],
+            darcy_coefficient=1e6 / (u.m * u.m),
+            forchheimer_coefficient=1e3 / u.m,
+            thickness=0.01 * u.m,
+        )
+
+    class _MockParams:
+        models = [Fluid(), pj_model]
+
+    param_info = ParamsValidationInfo({}, [])
+
+    # Geometry workflow: surfaces present in asset_boundaries -> counted
+    used = _collect_used_boundary_names(
+        _MockParams(), param_info, asset_boundaries={"pj_left", "pj_right"}
+    )
+    assert {"pj_left", "pj_right"} <= used
+
+    # VolumeMesh workflow: surfaces filtered out of asset_boundaries -> ignored
+    used = _collect_used_boundary_names(_MockParams(), param_info, asset_boundaries=set())
+    assert "pj_left" not in used
+    assert "pj_right" not in used
+
+
 def test_porousJump_volume_mesh_pairs_not_flagged_as_unknown():
     """In volume-mesh workflows, PorousJump surface_pairs are zone-to-zone interfaces
     (private_attribute_is_interface=True) and are filtered out of asset_boundaries.


### PR DESCRIPTION
## Summary

Two related fixes to the boundary-condition completeness validator:

### 1. Recognize PorousJump in `_collect_used_boundary_names`

The validator previously skipped `PorousJump` entirely, so any surface whose only BC was `PorousJump.surface_pairs` was falsely reported as missing a BC. After the fix, pair surfaces are counted — but only when they're present in `asset_boundaries`:

- **Geometry / SurfaceMesh workflow**: pair surfaces are real boundaries (in `asset_boundaries`) → counted; no false-missing-BC error.
- **VolumeMesh workflow**: pair surfaces are zone-to-zone interfaces (filtered out of `asset_boundaries` by `VolumeMeshEntityInfo.get_boundaries`) → not counted; original behavior preserved (no false-unknown-boundary error).

### 2. Warn (not error) on missing-BC for overlap-aware models

When the input is a Geometry/SurfaceMesh, the Python client cannot detect overlapping faces that the mesher will turn into zone-to-zone interfaces at runtime. So when the params include "overlap-aware" models, demote the missing-BC error to a warning:

- A `PorousJump` model is present, **OR**
- A `PorousMedium` model is present whose `entities` include a `CustomVolume`.

VolumeMesh workflow is **explicitly excluded** — meshing has already finished and any face without a BC is genuinely missing.

## Reproduction

User script with `MODEL = "porous_jump"`:
```
ERROR: The following boundaries do not have a boundary condition: Exhaust, Intake, inside5, inside6.
```
After fix: draft submitted, no error.

User script with `MODEL = "porous_media"` (uses `CustomVolume`-backed PorousMedium):
```
ERROR: The following boundaries do not have a boundary condition: Exhaust, Intake.
```
After fix: warning emitted, draft submitted.

## Test plan

- [x] `pytest tests/simulation/params/test_validators_params.py` — 69 passed (5 new tests added)
- [x] Unit tests on `_collect_used_boundary_names` and `_has_models_implying_potential_overlap` cover both branches (overlap-aware vs not, geometry/surface_mesh vs volume_mesh)
- [x] End-to-end tests via `validate_model` cover SurfaceMesh-warns and VolumeMesh-still-errors cases
- [x] Re-ran user script end-to-end with both `MODEL = "porous_jump"` and `MODEL = "porous_media"`; both succeed with appropriate severity

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core boundary-condition completeness validation and its error/warning policy, which can affect whether cases pass local validation. Risk is mitigated by targeted filtering for volume-mesh workflows and extensive new regression tests.
> 
> **Overview**
> **Boundary-condition completeness validation now treats `PorousJump` correctly.** `_collect_used_boundary_names` no longer implicitly ignores `PorousJump` pairs; instead it counts pair surfaces *only if* they exist in `asset_boundaries`, preventing geometry workflows from flagging them as missing while avoiding volume-mesh workflows incorrectly flagging them as unknown interfaces.
> 
> **Missing-BC severity is downgraded to warnings when overlap is plausible.** A new `_has_models_implying_potential_overlap` hook (triggered for `PorousJump`, and `PorousMedium` when it references a `CustomVolume`, but *not* for `volume_mesh`) feeds into `_validate_boundary_completeness` to warn rather than error when missing faces may be consumed by mesher-generated zone-to-zone interfaces.
> 
> **Adds focused test coverage** to lock in the new behavior across geometry/surface-mesh vs volume-mesh roots (PorousJump counted, no unknown-interface regressions, and warning-vs-error expectations).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1d0b8afc56026366df70bb48fa626426394a6a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->