### PR TITLE
feat(client): re-export VoxelGrid for direct volume rendering

### DIFF
--- a/flow360/_public_namespace.py
+++ b/flow360/_public_namespace.py
@@ -189,6 +189,7 @@ from flow360.component.simulation.primitives import (
     ReferenceGeometry,
     SeedpointVolume,
     Sphere,
+    VoxelGrid,
 )
 from flow360.component.simulation.run_control.run_control import RunControl
 from flow360.component.simulation.run_control.stopping_criterion import (
@@ -347,6 +348,7 @@ __all__ = [
     "PointArray",
     "AngleExpression",
     "Box",
+    "VoxelGrid",
     "GenericReferenceCondition",
     "TransitionModelSolver",
     "TurbulenceModelControls",

--- a/flow360/component/simulation/primitives.py
+++ b/flow360/component/simulation/primitives.py
@@ -27,7 +27,10 @@ from flow360_schema.models.entities.surface_entities import (
     _MirroredEntityBase,
     compute_bbox_tolerance,
 )
-from flow360_schema.models.entities.volume_entities import (
+
+# VoxelGrid lands in flow360_schema alongside the schema-side flex PR; drop
+# the inline pylint disable once the new flow360_schema release is pinned.
+from flow360_schema.models.entities.volume_entities import (  # pylint: disable=no-name-in-module
     AxisymmetricBody,
     AxisymmetricSegment,
     Box,
@@ -37,5 +40,6 @@ from flow360_schema.models.entities.volume_entities import (
     GenericVolume,
     SeedpointVolume,
     Sphere,
+    VoxelGrid,
 )
 from flow360_schema.models.reference_geometry import ReferenceGeometry


### PR DESCRIPTION
## Summary

Replacement for closed #2026. Pairs with the new flex VoxelGrid PR (flexcompute/flex#12290).

- Adds `VoxelGrid` to the primitives relay (`flow360/component/simulation/primitives.py`).
- Adds `VoxelGrid` to `flow360._public_namespace` import + `__all__` so `fl.VoxelGrid` is reachable from the top level.

`VoxelGrid` is a strict-AABB sibling of `Box`; both extend the new `_BoxRegionBase` on the schema side, so this PR is purely re-export plumbing.

## CI status

`code-style/{black,isort,lint,json-key-order}` and `Analyze (python)` pass.

The `test` matrix will fail with `ImportError: cannot import name 'VoxelGrid' from 'flow360_schema.models.entities.volume_entities'` until flex#12290 lands and a new flow360_schema package is published — `VoxelGrid` doesn't exist in the published schema dep yet. CI will turn green automatically once the schema dep ships. The pylint disable on the new import is gated on the same publication.

## Paired PRs

- **flex (schema):** flexcompute/flex#12290
- **compute (consumer):** flexcompute/compute#4988 — uses `from flow360.component.simulation.primitives import VoxelGrid` in its translator test; submodule pointer already bumped to this branch's head.

## Test plan

- [ ] (after flex#12290 lands) `from flow360 import VoxelGrid` works
- [ ] (after flex#12290 lands) Round-trip a `fl.VoxelGrid(...)` through a `fl.RenderOutputGroup(volumes=[...])`

🤖 Generated with [Claude Code](https://claude.com/claude-code)