### PR TITLE
Bump to 25.9.8

### DIFF
--- a/flow360/version.py
+++ b/flow360/version.py
@@ -2,5 +2,5 @@
 version
 """
 
-__version__ = "25.9.7"
+__version__ = "25.9.8"
 __solver_version__ = "release-25.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flow360"
-version = "v25.9.7"
+version = "v25.9.8"
 description = "Flow360 Python Client"
 authors = ["Flexcompute <support@flexcompute.com>"]
 

--- a/tests/test_current_flow360_version.py
+++ b/tests/test_current_flow360_version.py
@@ -2,4 +2,4 @@ from flow360.version import __version__
 
 
 def test_version():
-    assert __version__ == "25.9.7"
+    assert __version__ == "25.9.8"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk version bump only; changes are limited to package metadata and a version assertion test.
> 
> **Overview**
> Bumps the Flow360 client version from `25.9.7` to `25.9.8` in `flow360/version.py` and the Poetry package version in `pyproject.toml`.
> 
> Updates `tests/test_current_flow360_version.py` to assert the new version string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10b299330f7dad92d8fa4421a0a0cf72c7ab772b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->