### PR TITLE
[FXC-7659] Added user guide ref to run control docstrings

### DIFF
--- a/flow360/component/simulation/run_control/run_control.py
+++ b/flow360/component/simulation/run_control/run_control.py
@@ -13,6 +13,7 @@ from flow360.component.simulation.run_control.stopping_criterion import (
 class RunControl(Flow360BaseModel):
     """
     :class:`RunControl` class for run control settings.
+    For general overview see :ref:`Run Control <runControl>`.
 
     Example
     -------

--- a/flow360/component/simulation/run_control/stopping_criterion.py
+++ b/flow360/component/simulation/run_control/stopping_criterion.py
@@ -37,6 +37,7 @@ class StoppingCriterion(Flow360BaseModel):
     """
 
     :class:`StoppingCriterion` class for :py:attr:`RunControl.stopping_criteria` settings.
+    For general overview of run control see :ref:`Run Control <runControl>`.
 
     Example
     -------


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds cross-references in docstrings; no runtime behavior or validation logic is modified.
> 
> **Overview**
> Adds a user-guide cross-reference (`:ref:\`Run Control <runControl>\``) to the docstrings for `RunControl` and `StoppingCriterion` to make the API docs point readers to the run control overview.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09c3926000c21c0d662c6b3b98274ec5d7adad7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->