### PR TITLE
ci: limit legacy checks to old release candidates

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,12 +13,31 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "main" ]
+    branches:
+      - release-candidate/21.0
+      - release-candidate/23.3.2.0
+      - release-candidate/24.2
+      - release-candidate/24.7
+      - release-candidate/24.11
+      - release-candidate/25.2
+      - release-candidate/25.5
+      - release-candidate/25.6
+      - release-candidate/25.7
+      - release-candidate/25.8
+      - release-candidate/25.9
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ "main" ]
-  schedule:
-    - cron: '22 8 * * 4'
+    branches:
+      - release-candidate/21.0
+      - release-candidate/23.3.2.0
+      - release-candidate/24.2
+      - release-candidate/24.7
+      - release-candidate/24.11
+      - release-candidate/25.2
+      - release-candidate/25.5
+      - release-candidate/25.6
+      - release-candidate/25.7
+      - release-candidate/25.8
+      - release-candidate/25.9
 
 jobs:
   analyze:

--- a/.github/workflows/create-hotfix-pr.yml
+++ b/.github/workflows/create-hotfix-pr.yml
@@ -5,7 +5,17 @@ on:
     types:
       - closed # Trigger when a PR is closed
     branches:
-      - 'release-candidate/*' # Trigger for any branch starting with 'release-candidate/'
+      - release-candidate/21.0
+      - release-candidate/23.3.2.0
+      - release-candidate/24.2
+      - release-candidate/24.7
+      - release-candidate/24.11
+      - release-candidate/25.2
+      - release-candidate/25.5
+      - release-candidate/25.6
+      - release-candidate/25.7
+      - release-candidate/25.8
+      - release-candidate/25.9
 
 jobs:
   skip_auto_hotfix_pr:

--- a/.github/workflows/hotfix-tracking-guard.yml
+++ b/.github/workflows/hotfix-tracking-guard.yml
@@ -10,8 +10,17 @@ on:
       - unlabeled
       - ready_for_review
     branches:
-      - main
-      - 'release-candidate/*'
+      - release-candidate/21.0
+      - release-candidate/23.3.2.0
+      - release-candidate/24.2
+      - release-candidate/24.7
+      - release-candidate/24.11
+      - release-candidate/25.2
+      - release-candidate/25.5
+      - release-candidate/25.6
+      - release-candidate/25.7
+      - release-candidate/25.8
+      - release-candidate/25.9
 
 jobs:
   block_placeholder_merge:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,9 +3,32 @@ name: unit testing
 on:
   workflow_dispatch:
   push:
-    branches: [ main, develop, release-candidate/* ]
+    branches:
+      - release-candidate/21.0
+      - release-candidate/23.3.2.0
+      - release-candidate/24.2
+      - release-candidate/24.7
+      - release-candidate/24.11
+      - release-candidate/25.2
+      - release-candidate/25.5
+      - release-candidate/25.6
+      - release-candidate/25.7
+      - release-candidate/25.8
+      - release-candidate/25.9
   pull_request:
     types: [ opened, synchronize, reopened, ready_for_review ]
+    branches:
+      - release-candidate/21.0
+      - release-candidate/23.3.2.0
+      - release-candidate/24.2
+      - release-candidate/24.7
+      - release-candidate/24.11
+      - release-candidate/25.2
+      - release-candidate/25.5
+      - release-candidate/25.6
+      - release-candidate/25.7
+      - release-candidate/25.8
+      - release-candidate/25.9
   workflow_call:
     secrets:
       AWS_CODEARTIFACT_READ_ACCESS_KEY:


### PR DESCRIPTION
## Summary
- stop legacy Flow360 CI from running on mirrored `main`
- replace broad `release-candidate/*` triggers with the existing legacy release-candidate branches through `release-candidate/25.9`
- limit CodeQL automatic triggers to the same legacy release-candidate set

## Validation
- parsed changed workflow YAML files with Ruby YAML
- `git diff --check` passed
- confirmed the changed workflow triggers no longer contain `main`, `develop`, or `release-candidate/*`

## Copybara overwrite note
This change is in `.github/**` on `flexcompute/Flow360`. The compute external mirror keeps `.github/**` excluded in stage 2 (`DESTINATION_EXCLUDES = [".github/**"]`), so future Copybara syncs should preserve these workflow changes.