### PR TITLE
Fix duplicate slash URL handling for 25.9

### DIFF
--- a/flow360/component/folder.py
+++ b/flow360/component/folder.py
@@ -197,7 +197,7 @@ class Folder(Flow360Resource):
                 "expandFields": ["contentInfo"],
             }
 
-            data = RestApi("/v2/items").get(params=payload)
+            data = RestApi("v2/items").get(params=payload)
             records = data.get("records", [])
             all_records.extend(records)
             total_record_count = data.get("total", 0)
@@ -265,7 +265,7 @@ class Folder(Flow360Resource):
             "page": 0,
             "size": 1000,
         }  # it assumes user will not have more than 1000 folders
-        data = RestApi("/v2/folders").get(params=payload)
+        data = RestApi("v2/folders").get(params=payload)
         folder_tree = self._build_folder_tree(data["records"])
         return folder_tree
 

--- a/flow360/component/simulation/folder.py
+++ b/flow360/component/simulation/folder.py
@@ -247,7 +247,7 @@ class Folder(Flow360Resource):
                 "expandFields": ["contentInfo"],
             }
 
-            data = RestApi("/v2/items").get(params=payload)
+            data = RestApi("v2/items").get(params=payload)
             records = data.get("records", [])
             all_records.extend(records)
             total_record_count = data.get("total", 0)
@@ -315,7 +315,7 @@ class Folder(Flow360Resource):
             "page": 0,
             "size": 1000,
         }  # it assumes user will not have more than 1000 folders
-        data = RestApi("/v2/folders").get(params=payload)
+        data = RestApi("v2/folders").get(params=payload)
         folder_tree = self._build_folder_tree(data["records"])
         return folder_tree
 

--- a/flow360/environment.py
+++ b/flow360/environment.py
@@ -73,7 +73,7 @@ class EnvironmentConfig(BaseModel):
         :param path:
         :return:
         """
-        return "/".join([self.web_api_endpoint, path])
+        return self.web_api_endpoint.rstrip("/") + "/" + path.lstrip("/")
 
     def get_portal_real_url(self, path: str):
         """
@@ -81,7 +81,7 @@ class EnvironmentConfig(BaseModel):
         :param path:
         :return:
         """
-        return "/".join([self.portal_web_api_endpoint, path])
+        return self.portal_web_api_endpoint.rstrip("/") + "/" + path.lstrip("/")
 
     def get_web_real_url(self, path: str):
         """
@@ -89,7 +89,7 @@ class EnvironmentConfig(BaseModel):
         :param path:
         :return:
         """
-        return "/".join([self.web_url, path])
+        return self.web_url.rstrip("/") + "/" + path.lstrip("/")
 
     @classmethod
     def from_config(cls, env_config_name: str):

--- a/flow360/version.py
+++ b/flow360/version.py
@@ -2,5 +2,5 @@
 version
 """
 
-__version__ = "25.9.8"
+__version__ = "25.9.9"
 __solver_version__ = "release-25.9"

--- a/poetry.lock
+++ b/poetry.lock
@@ -6487,4 +6487,4 @@ docs = ["autodoc_pydantic", "cairosvg", "ipython", "jinja2", "jupyter", "myst-pa
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.14"
-content-hash = "789bc664b22914a4c4e4190068e73952827e861504c5224d84bc31c92fd985be"
+content-hash = "abd755399f335ef1fea125d532af4ccb69c6292d252e95cf138a0b55a4b3970d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flow360"
-version = "v25.9.8"
+version = "v25.9.9"
 description = "Flow360 Python Client"
 authors = ["Flexcompute <support@flexcompute.com>"]
 
@@ -10,7 +10,7 @@ pydantic = ">=2.8,<2.12"
 pytest = "^7.1.2"
 click = "^8.1.3"
 toml = "^0.10.2"
-requests = "^2.32.4"
+requests = ">=2.32.4,<2.33.0"
 boto3 = "^1.24.63"
 numpy = [
     { python = "^3.10", version = ">=2.0,<3.0.0" },

--- a/tests/test_current_flow360_version.py
+++ b/tests/test_current_flow360_version.py
@@ -2,4 +2,4 @@ from flow360.version import __version__
 
 
 def test_version():
-    assert __version__ == "25.9.8"
+    assert __version__ == "25.9.9"

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,4 +1,6 @@
 from flow360 import Env
+from flow360.cloud.rest_api import RestApi
+from flow360.environment import EnvironmentConfig
 
 
 def test_version():
@@ -6,3 +8,37 @@ def test_version():
     print(Env.current)
     assert Env.current.name == "dev"
     Env.prod.active()
+
+
+def test_environment_urls_normalize_path_slashes():
+    env = EnvironmentConfig(
+        name="test",
+        domain="example.com",
+        web_api_endpoint="https://api.example.com/",
+        web_url="https://web.example.com/",
+        portal_web_api_endpoint="https://portal.example.com/",
+        apikey_profile="default",
+    )
+
+    for path in ("v2/folders", "/v2/folders"):
+        assert env.get_real_url(path) == "https://api.example.com/v2/folders"
+        assert env.get_portal_real_url(path) == "https://portal.example.com/v2/folders"
+        assert env.get_web_real_url(path) == "https://web.example.com/v2/folders"
+
+
+def test_rest_api_url_normalizes_with_environment():
+    env = EnvironmentConfig(
+        name="test",
+        domain="example.com",
+        web_api_endpoint="https://api.example.com",
+        web_url="https://web.example.com",
+        portal_web_api_endpoint="https://portal.example.com",
+        apikey_profile="default",
+    )
+
+    assert env.get_real_url(RestApi("/v2/folders")._url(None)) == (
+        "https://api.example.com/v2/folders"
+    )
+    assert env.get_real_url(RestApi("v2/folders")._url(None)) == (
+        "https://api.example.com/v2/folders"
+    )


### PR DESCRIPTION
## Summary
- Normalize Flow360 environment URL construction so leading path slashes do not create duplicate slash API paths.
- Remove known leading slash folder API paths.
- Constrain Requests to the 2.32 patch line.
- Bump the client version to `v25.9.9` / `25.9.9` for release.
- Add focused URL normalization tests.

## Verification
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=/tmp/Flow360-25.9 /disk2/ben/Flow360/.venv/bin/python -m pytest tests/test_environment.py tests/test_current_flow360_version.py tests/simulation/test_updater.py -q -p no:cacheprovider`
- Forced local repro with `requests==2.34.2`: prod and preprod folder requests used single-slash URLs and `RestApi.get` succeeded.

Note: `poetry check --lock` still fails on the existing unrelated `pyswarms` docs extra issue, but no longer reports stale lock metadata.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted URL joining and path string tweaks with regression tests; no auth or data-model changes.
> 
> **Overview**
> This release fixes **API URL construction** so folder and item calls no longer produce paths with **double slashes** when environment base URLs end with `/` and REST paths start with `/`.
> 
> `EnvironmentConfig` now joins base URLs and paths by trimming extra slashes on both sides (`get_real_url`, `get_portal_real_url`, `get_web_real_url`). Folder code uses **`v2/items`** and **`v2/folders`** without a leading slash on `RestApi`. **`requests`** is capped to the **2.32.x** line, and the client is bumped to **`25.9.9`** with new tests for slash normalization and `RestApi` paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2122477700b6146e30b909844acc8a3c30d54768. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->