### PR TITLE
[FXC-8849] fix(simulation): stop prepending mock zone name to farfield ghost full_name

### DIFF
--- a/flow360/component/simulation/framework/param_utils.py
+++ b/flow360/component/simulation/framework/param_utils.py
@@ -261,24 +261,6 @@ def _update_zone_boundaries_with_metadata(
                 )
 
 
-def _set_boundary_full_name_with_zone_name(
-    registry: EntityRegistry, naming_pattern: str, give_zone_name: str
-) -> None:
-    """Set the full name of surfaces that does not have full name specified."""
-    if registry.find_by_naming_pattern(naming_pattern):
-        for surface in registry.find_by_naming_pattern(naming_pattern):
-            if surface.private_attribute_full_name is not None:
-                # This indicates that full name has been set by mesh metadata because that and this are the
-                # only two places we set the full name.
-                # mesh meta data takes precedence as it is the most reliable source.
-                # Note: Currently automated farfield assumes zone name to be "fluid" but the other mesher has "1".
-                # Note: We need to figure out how to handle this. Otherwise this may result in wrong
-                # Note: zone name getting prepended.
-                continue
-            with model_attribute_unlock(surface, "private_attribute_full_name"):
-                surface.private_attribute_full_name = f"{give_zone_name}/{surface.name}"
-
-
 def serialize_model_obj_to_id(model_obj: Flow360BaseModel) -> str:
     """Serialize a model object to its id."""
     if hasattr(model_obj, "private_attribute_id"):

--- a/flow360/component/simulation/simulation_params.py
+++ b/flow360/component/simulation/simulation_params.py
@@ -24,7 +24,6 @@ from flow360.component.simulation.framework.boundary_split import (
 from flow360.component.simulation.framework.entity_registry import EntityRegistry
 from flow360.component.simulation.framework.param_utils import (
     AssetCache,
-    _set_boundary_full_name_with_zone_name,
     _update_entity_full_name,
     _update_zone_boundaries_with_metadata,
     register_entity_list,
@@ -34,12 +33,6 @@ from flow360.component.simulation.framework.updater_utils import Flow360Version
 from flow360.component.simulation.meshing_param.params import (
     MeshingParams,
     ModularMeshingWorkflow,
-)
-from flow360.component.simulation.meshing_param.volume_params import (
-    AutomatedFarfield,
-    RotationCylinder,
-    RotationSphere,
-    RotationVolume,
 )
 from flow360.component.simulation.models.surface_models import SurfaceModelTypes
 from flow360.component.simulation.models.volume_models import (
@@ -683,43 +676,6 @@ class SimulationParams(_ParamModelBase):
         register_entity_list(self, registry)
         return registry
 
-    def _update_entity_private_attrs(self, registry: EntityRegistry) -> EntityRegistry:
-        """
-        Once the SimulationParams is set, extract and update information
-        into all used entities by parsing the params.
-        """
-
-        ##::1. Update full names in the Surface entities with zone names
-        # pylint: disable=no-member
-        if self.meshing is not None:
-            volume_zones = None
-            if isinstance(self.meshing, MeshingParams):
-                volume_zones = self.meshing.volume_zones
-            if (
-                isinstance(self.meshing, ModularMeshingWorkflow)
-                and self.meshing.volume_meshing is not None
-            ):
-                volume_zones = self.meshing.zones
-            if volume_zones is not None:
-                for volume in volume_zones:
-                    if isinstance(volume, AutomatedFarfield):
-                        _set_boundary_full_name_with_zone_name(
-                            registry,
-                            "farfield",
-                            volume.private_attribute_entity.name,
-                        )
-                        _set_boundary_full_name_with_zone_name(
-                            registry,
-                            "symmetric*",
-                            volume.private_attribute_entity.name,
-                        )
-                    if isinstance(volume, (RotationCylinder, RotationVolume, RotationSphere)):
-                        # pylint: disable=fixme
-                        # TODO: Implement this
-                        pass
-
-        return registry
-
     @property
     def base_length(self) -> LengthType:
         """Get base length unit for non-dimensionalization"""
@@ -834,7 +790,6 @@ class SimulationParams(_ParamModelBase):
         """
         registry = EntityRegistry()
         registry = self._register_assigned_entities(registry)
-        registry = self._update_entity_private_attrs(registry)
         return registry
 
     def _update_param_with_actual_volume_mesh_meta(self, volume_mesh_meta_data: dict):


### PR DESCRIPTION
## Problem
API-submitted and web-UI-submitted `simulation.json` differ for the AutomatedFarfield ghost surfaces, which changes the case cache key and triggers **spurious case reruns** for API submissions.

The Python client's `SimulationParams.used_entity_registry` runs `_update_entity_private_attrs`, which stamps `private_attribute_full_name = "{zone}/{surface}"` onto the `farfield` / `symmetric*` ghost surfaces using the placeholder zone name `__farfield_zone_name_not_properly_set_yet`. The web UI never runs this Python path, so its submitted JSON omits the field.

## Why removing it is safe
The placeholder value is never consumed downstream. The solver translator reads `full_name` only **post-volume-mesh**, where `_update_entity_info_with_metadata` overwrites it with the real mesh boundary name (keyed on `entity.name`, not the placeholder). Dropping the pre-mesh composition makes API == web UI; `full_name` falls back to the entity name (`"farfield"`).

The `__farfield_zone_name_not_properly_set_yet` **GenericVolume zone name** is unrelated and retained — it is still matched against `stationaryBlock|fluid` in mesh metadata.

## Change (full reduction)
- Remove the now-dead `_update_entity_private_attrs` method + its call in `used_entity_registry`.
- Remove the orphaned `_set_boundary_full_name_with_zone_name` helper.
- Remove the now-unused imports.

## Validation
- 375 tests pass (farfield / translator / service / metadata suites).
- pylint 10.00/10 on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deletes unused pre-mesh logic only; real full names still come from volume-mesh metadata at preprocessing.
> 
> **Overview**
> Stops the Python client from **pre-mesh** stamping `private_attribute_full_name` on AutomatedFarfield ghost surfaces (`farfield`, `symmetric*`) using a placeholder zone name. That path ran inside `used_entity_registry` via `_update_entity_private_attrs` and made API-submitted `simulation.json` differ from the web UI, which **changed case cache keys** and caused spurious reruns.
> 
> The change **removes** `_update_entity_private_attrs`, the `_set_boundary_full_name_with_zone_name` helper, and related imports. `used_entity_registry` now only registers assigned entities. **Post-volume-mesh** updates (`_update_param_with_actual_volume_mesh_meta`, boundary lookup / `_update_entity_full_name`) are unchanged and remain where real boundary full names are set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc897c3706521874de4807d0f5e747261cc4b36a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->