### PR TITLE
Fix description for observer_time_step_size

### DIFF
--- a/flow360/component/simulation/outputs/outputs.py
+++ b/flow360/component/simulation/outputs/outputs.py
@@ -1483,7 +1483,8 @@ class AeroAcousticOutput(Flow360BaseModel):
         None,
         description="Time step size for aeroacoustic output. "
         + "A valid value is larger than or equal to the time step size of the CFD simulation. "
-        + "Defaults to time step size of CFD.",
+        + "Defaults to time step size of CFD. "
+        + "Cannot be changed when a case is forked unless `force_clean_start` is true.",
     )
     aeroacoustic_solver_start_time: TimeType.NonNegative = pd.Field(
         0 * u.s,

--- a/flow360/component/simulation/outputs/outputs.py
+++ b/flow360/component/simulation/outputs/outputs.py
@@ -1482,7 +1482,7 @@ class AeroAcousticOutput(Flow360BaseModel):
     observer_time_step_size: Optional[TimeType.Positive] = pd.Field(
         None,
         description="Time step size for aeroacoustic output. "
-        + "A valid value is smaller than or equal to the time step size of the CFD simulation. "
+        + "A valid value is larger than or equal to the time step size of the CFD simulation. "
         + "Defaults to time step size of CFD.",
     )
     aeroacoustic_solver_start_time: TimeType.NonNegative = pd.Field(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change to a field description in `outputs.py`; no runtime or validation logic is modified in this diff.
> 
> **Overview**
> Updates the **`AeroAcousticOutput.observer_time_step_size`** Pydantic field description so it matches actual constraints: a valid value must be **greater than or equal to** the CFD time step (replacing the incorrect “smaller than or equal” wording).
> 
> The description also documents that this setting **cannot be changed on forked cases** unless **`force_clean_start`** is enabled, aligning user-facing docs with fork/restart behavior next to the existing `force_clean_start` field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4274e44b78054ae63d9947227a7e35a463563e64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->