### PR TITLE
ci(hotfix): cap auto-hotfix fan-out at 25.9, exclude main

### DIFF
--- a/.github/workflows/create-hotfix-pr.yml
+++ b/.github/workflows/create-hotfix-pr.yml
@@ -39,6 +39,11 @@ jobs:
     env:
       BOT_NAME: "flow360-auto-hotfix-bot" # Name for the git committer
       BOT_EMAIL: "flow360-auto-hotfix-bot@users.noreply.github.com" # Email for the git committer
+      # Auto-hotfix is capped at this release-candidate version. Branches above it
+      # (e.g. 25.10, 25.11, 26.x) and main are intentionally NOT targeted.
+      # Bump this when a newer line should start receiving auto-hotfixes.
+      # Format: normalized YY.MM with zero-padded minor (25.9 -> "25.09").
+      MAX_HOTFIX_VERSION: "25.09"
 
     steps:
 
@@ -69,7 +74,7 @@ jobs:
           PR_BASE_BRANCH="${{ steps.get_commit.outputs.base_branch }}"
           echo "PR was merged into: $PR_BASE_BRANCH"
 
-          TARGET_BRANCHES=("main") # Always target main for hotfix
+          TARGET_BRANCHES=() # main is intentionally excluded; only release-candidate branches up to MAX_HOTFIX_VERSION are targeted
 
           # Get all remote 'release-candidate' branches with version pattern as YY.I or YY.II
           ALL_RELEASE_CANDIDATE_BRANCHES=$(git branch -r | grep 'origin/release-candidate/' | sed 's/.*origin\///' | grep -E '^release-candidate/[0-9]{2}\.[0-9]{1,2}$' | sort -V)
@@ -95,10 +100,12 @@ jobs:
                   BRANCH_VERSION=$(echo "$BRANCH_VERSION" | awk '{printf "%s%02d", substr($1,1,3), substr($1,4)}')
                 fi
 
-                # Compare versions
-                if (( $(echo "$BRANCH_VERSION > $PR_BASE_VERSION" | bc -l) )); then
+                # Target branches higher than the PR base but not above the auto-hotfix cap.
+                if (( $(echo "$BRANCH_VERSION > $PR_BASE_VERSION" | bc -l) )) && (( $(echo "$BRANCH_VERSION <= $MAX_HOTFIX_VERSION" | bc -l) )); then
                   TARGET_BRANCHES+=("$branch")
-                  echo "Adding $branch (version $BRANCH_VERSION) as it's higher than $PR_BASE_BRANCH (version $PR_BASE_VERSION)"
+                  echo "Adding $branch (version $BRANCH_VERSION): higher than $PR_BASE_BRANCH ($PR_BASE_VERSION) and within cap $MAX_HOTFIX_VERSION"
+                elif (( $(echo "$BRANCH_VERSION > $MAX_HOTFIX_VERSION" | bc -l) )); then
+                  echo "Skipping $branch (version $BRANCH_VERSION): above auto-hotfix cap $MAX_HOTFIX_VERSION"
                 fi
               fi
             done


### PR DESCRIPTION
## What

Restrict the **Create Hotfix PR** workflow so the highest auto-hotfix target is `release-candidate/25.9`. `main` and any branch above the cap (`25.10`, `25.11`, `26.x`, …) are no longer targeted.

## Why

The fan-out previously seeded `TARGET_BRANCHES=("main")` and added **every** release-candidate branch with a version higher than the merged PR's base. `release-candidate/25.10` now exists on remote, so a hotfix merged into e.g. `25.8` would auto-create PRs into `25.10` and `main` — no longer desired.

Note: `on:` already limits which base branches *trigger* the workflow (≤25.9). This PR complements that by also capping the *targets* the fan-out creates.

## How

- New job-level env `MAX_HOTFIX_VERSION: "25.09"` (normalized `YY.MM`, zero-padded minor). Bump it to extend the cap to a newer line later.
- `TARGET_BRANCHES` no longer seeds `main`.
- Target filter now requires `base < branch <= cap`; branches above the cap are logged and skipped.

## Verified

- Boundary checks via `bc`: `25.09` included, `25.10`/`25.11`/`26.x` excluded.
- Empty target set (PR merged into the cap branch itself) degrades safely — no hotfix PRs created.
- YAML parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to hotfix target selection; reduces unintended fan-out rather than altering runtime or security behavior.
> 
> **Overview**
> **Caps auto-hotfix fan-out** in `create-hotfix-pr.yml` so merged fixes only propagate to `release-candidate` branches **above the PR base and up to `25.9`**, not to `main` or newer lines (`25.10+`, `26.x`, etc.).
> 
> Adds job env **`MAX_HOTFIX_VERSION: "25.09"`** (normalized `YY.MM`) with comments to bump when a newer line should receive auto-hotfixes. **`TARGET_BRANCHES` no longer seeds `main`**. The branch-selection loop now requires `PR_BASE < branch <= cap` and logs when a candidate is skipped for exceeding the cap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17a1421f29ec266accc4c975ee0164b9416d2863. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->