### PR TITLE
ci(hotfix): cap auto-hotfix fan-out at 25.9, exclude main

### DIFF
--- a/.github/workflows/create-hotfix-pr.yml
+++ b/.github/workflows/create-hotfix-pr.yml
@@ -19,6 +19,11 @@ jobs:
     env:
       BOT_NAME: "flow360-auto-hotfix-bot" # Name for the git committer
       BOT_EMAIL: "flow360-auto-hotfix-bot@users.noreply.github.com" # Email for the git committer
+      # Auto-hotfix is capped at this release-candidate version. Branches above it
+      # (e.g. 25.10, 25.11, 26.x) and main are intentionally NOT targeted.
+      # Bump this when a newer line should start receiving auto-hotfixes.
+      # Format: normalized YY.MM with zero-padded minor (25.9 -> "25.09").
+      MAX_HOTFIX_VERSION: "25.09"
 
     steps:
 
@@ -49,7 +54,7 @@ jobs:
           PR_BASE_BRANCH="${{ steps.get_commit.outputs.base_branch }}"
           echo "PR was merged into: $PR_BASE_BRANCH"
 
-          TARGET_BRANCHES=("main") # Always target main for hotfix
+          TARGET_BRANCHES=() # main is intentionally excluded; only release-candidate branches up to MAX_HOTFIX_VERSION are targeted
 
           # Get all remote 'release-candidate' branches with version pattern as YY.I or YY.II
           ALL_RELEASE_CANDIDATE_BRANCHES=$(git branch -r | grep 'origin/release-candidate/' | sed 's/.*origin\///' | grep -E '^release-candidate/[0-9]{2}\.[0-9]{1,2}$' | sort -V)
@@ -75,10 +80,12 @@ jobs:
                   BRANCH_VERSION=$(echo "$BRANCH_VERSION" | awk '{printf "%s%02d", substr($1,1,3), substr($1,4)}')
                 fi
 
-                # Compare versions
-                if (( $(echo "$BRANCH_VERSION > $PR_BASE_VERSION" | bc -l) )); then
+                # Target branches higher than the PR base but not above the auto-hotfix cap.
+                if (( $(echo "$BRANCH_VERSION > $PR_BASE_VERSION" | bc -l) )) && (( $(echo "$BRANCH_VERSION <= $MAX_HOTFIX_VERSION" | bc -l) )); then
                   TARGET_BRANCHES+=("$branch")
-                  echo "Adding $branch (version $BRANCH_VERSION) as it's higher than $PR_BASE_BRANCH (version $PR_BASE_VERSION)"
+                  echo "Adding $branch (version $BRANCH_VERSION): higher than $PR_BASE_BRANCH ($PR_BASE_VERSION) and within cap $MAX_HOTFIX_VERSION"
+                elif (( $(echo "$BRANCH_VERSION > $MAX_HOTFIX_VERSION" | bc -l) )); then
+                  echo "Skipping $branch (version $BRANCH_VERSION): above auto-hotfix cap $MAX_HOTFIX_VERSION"
                 fi
               fi
             done


### PR DESCRIPTION
Backport of #2064 to `release-candidate/25.9`.

## Why this branch needs it

`pull_request`-triggered workflows run the workflow file from the **base branch** of the PR, not from `main`. So #2064 (into `main`) has no runtime effect on hotfix events — each RC branch runs its own copy. Without this backport, merging a PR into `25.9` still fans out to `main` and `25.10` (both above the intended cap).

With this change, a merge into `25.9` produces no auto-hotfix targets (nothing above it should be hotfixed), and `main` is excluded.

## Change

- `MAX_HOTFIX_VERSION: "25.09"` cap env (bump to extend later).
- Drop `main` from `TARGET_BRANCHES`.
- Target filter `base < branch <= cap`; above-cap branches logged + skipped.

Scope: only `25.9` is backported — older lines (25.2–25.8) are assumed to no longer receive merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only GitHub Actions branch-selection logic changes; no runtime app or security paths are touched.
> 
> **Overview**
> Narrows **Create Hotfix PR** so merges into `release-candidate/*` no longer open auto-hotfixes on **`main`** or on RC lines above a fixed ceiling.
> 
> Adds **`MAX_HOTFIX_VERSION: "25.09"`** (documented for bumping when a newer line should receive hotfixes). **`TARGET_BRANCHES`** starts empty instead of always including `main`. Release-candidate targets must satisfy **base version &lt; branch version ≤ cap**; newer RCs (e.g. 25.10+) are skipped with an explicit log line.
> 
> For a merge into **25.9**, there are typically **no** downstream RC targets, so the workflow should produce **no** auto-hotfix PRs unless a higher-but-capped branch exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f4fea897beca402b47a7ddff9b642a782bfd3cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->