### PR TITLE
[Hotfix 25.9] fix(translator): skip auto mass-flow controller when user supplies one

### DIFF
--- a/flow360/component/simulation/translator/solver_translator.py
+++ b/flow360/component/simulation/translator/solver_translator.py
@@ -1509,11 +1509,15 @@ def _append_turbulence_quantities_to_dict(model, model_dict, boundary):
     return boundary
 
 
-def _get_default_mass_outflow_udd(entities, mass_flow_rate):
+def _get_default_mass_outflow_udd(entities, mass_flow_rate, controlled_outputs=None):
     """Default mass outflow UDD translator"""
+    controlled_outputs = controlled_outputs or {}
     proportional_coefficient = 1.0e-2
     udd_list = []
     for entity in entities.stored_entities:
+        entity_key = getattr(entity, "full_name", None) or entity.name
+        if "staticPressureRatio" in controlled_outputs.get(entity_key, ()):
+            continue
         udd = UserDefinedDynamic(
             name=f"massOutflowController_{entity.name}",
             input_vars=["massFlowRate", "area", "hasSupersonicFlow"],
@@ -1538,11 +1542,15 @@ def _get_default_mass_outflow_udd(entities, mass_flow_rate):
     return udd_list
 
 
-def _get_default_mass_inflow_udd(entities, mass_flow_rate):
+def _get_default_mass_inflow_udd(entities, mass_flow_rate, controlled_outputs=None):
     """Default mass inflow UDD translator"""
+    controlled_outputs = controlled_outputs or {}
     proportional_coefficient = 1.0e-2
     udd_list = []
     for entity in entities.stored_entities:
+        entity_key = getattr(entity, "full_name", None) or entity.name
+        if "totalPressureRatio" in controlled_outputs.get(entity_key, ()):
+            continue
         udd = UserDefinedDynamic(
             name=f"massInflowController_{entity.name}",
             input_vars=["massFlowRate", "area", "hasSupersonicFlow"],
@@ -1567,17 +1575,29 @@ def _get_default_mass_inflow_udd(entities, mass_flow_rate):
     return udd_list
 
 
+def _udd_controlled_outputs(user_defined_dynamics):
+    """Output variables (keyed by target patch) already driven by user UDDs."""
+    controlled = {}
+    for udd in user_defined_dynamics or []:
+        if udd.output_target is None or udd.output_vars is None:
+            continue
+        key = getattr(udd.output_target, "full_name", None) or udd.output_target.name
+        controlled.setdefault(key, set()).update(udd.output_vars.keys())
+    return controlled
+
+
 def mass_flow_default_udd(models, user_defined_dynamics):
-    """Default mass flow rate translator"""
+    """Generate the stock mass-flow controller, unless a user UDD already drives that patch."""
+    controlled = _udd_controlled_outputs(user_defined_dynamics)
     mass_flow_user_defined_dynamics = []
     for model in models:
         if isinstance(model, Outflow):
             if isinstance(model.spec, MassFlowRate):
-                udd = _get_default_mass_outflow_udd(model.entities, model.spec.value)
+                udd = _get_default_mass_outflow_udd(model.entities, model.spec.value, controlled)
                 mass_flow_user_defined_dynamics.extend(udd)
         elif isinstance(model, Inflow):
             if isinstance(model.spec, MassFlowRate):
-                udd = _get_default_mass_inflow_udd(model.entities, model.spec.value)
+                udd = _get_default_mass_inflow_udd(model.entities, model.spec.value, controlled)
                 mass_flow_user_defined_dynamics.extend(udd)
 
     if len(mass_flow_user_defined_dynamics) == 0:

--- a/tests/simulation/translator/test_mass_flow_controller_translation.py
+++ b/tests/simulation/translator/test_mass_flow_controller_translation.py
@@ -1,0 +1,70 @@
+"""Tests that the stock mass-flow controller is skipped when a user UDD drives the patch."""
+
+from types import SimpleNamespace
+
+import flow360.component.simulation.units as u
+from flow360.component.simulation.models.surface_models import (
+    Inflow,
+    MassFlowRate,
+    Outflow,
+)
+from flow360.component.simulation.primitives import Surface
+from flow360.component.simulation.translator.solver_translator import (
+    mass_flow_default_udd,
+)
+
+
+def _mass_inflow(entity):
+    return Inflow(
+        entities=[entity],
+        total_temperature=300 * u.K,
+        spec=MassFlowRate(value=1.0 * u.kg / u.s),
+    )
+
+
+def _mass_outflow(entity):
+    return Outflow(entities=[entity], spec=MassFlowRate(value=1.0 * u.kg / u.s))
+
+
+def _user_controller(target, output_var):
+    """Stand-in for a user UDD; the skip logic only reads output_target/output_vars."""
+    return SimpleNamespace(
+        name="userController",
+        output_target=target,
+        output_vars={output_var: "state[0];"},
+    )
+
+
+def _names(udds):
+    return [udd.name for udd in (udds or [])]
+
+
+def test_stock_controllers_generated_without_user_udd():
+    inlet, outlet = Surface(name="fluid/inflow"), Surface(name="fluid/outflow")
+    names = _names(mass_flow_default_udd([_mass_inflow(inlet), _mass_outflow(outlet)], None))
+    assert any(n.startswith("massInflowController") for n in names)
+    assert any(n.startswith("massOutflowController") for n in names)
+
+
+def test_stock_inflow_controller_skipped_when_user_controls_patch():
+    inlet, outlet = Surface(name="fluid/inflow"), Surface(name="fluid/outflow")
+    user = _user_controller(inlet, "totalPressureRatio")
+    result = mass_flow_default_udd([_mass_inflow(inlet), _mass_outflow(outlet)], [user])
+    names = _names(result)
+    assert user in result
+    assert not any(n.startswith("massInflowController") for n in names)
+    assert any(n.startswith("massOutflowController") for n in names)
+
+
+def test_stock_outflow_controller_skipped_when_user_controls_patch():
+    outlet = Surface(name="fluid/outflow")
+    user = _user_controller(outlet, "staticPressureRatio")
+    names = _names(mass_flow_default_udd([_mass_outflow(outlet)], [user]))
+    assert not any(n.startswith("massOutflowController") for n in names)
+
+
+def test_stock_controller_kept_when_user_writes_other_variable():
+    inlet = Surface(name="fluid/inflow")
+    user = _user_controller(inlet, "alphaAngle")
+    names = _names(mass_flow_default_udd([_mass_inflow(inlet)], [user]))
+    assert any(n.startswith("massInflowController") for n in names)


### PR DESCRIPTION
25.9-line hotfix for the mass-flow controller, the equivalent of compute#6130 (landed on master; backported to compute `release-candidate/25.10` separately).

On 25.9 the translator still lives in this repo (it was vendored into `compute` only as of 25.10), so the fix is applied here at `flow360/component/simulation/translator/solver_translator.py`.

## What it fixes

The translator auto-generates a fixed-gain proportional controller (UDD) for every MassFlowRate inflow/outflow patch and appends it after the user's UDDs. UDD outputs are assignments (last write wins), so a user-supplied controller on the same patch was always overridden, leaving no way to retune the controller (e.g. to stop the steady limit-cycle on internal low-Mach mass-flow inlets). The fix skips the stock controller for a patch when a user UDD already writes the same control variable (totalPressureRatio for inflow, staticPressureRatio for outflow). No change when the user supplies no such UDD.

## Test plan

- New unit test `tests/simulation/translator/test_mass_flow_controller_translation.py` (stock generated without a user UDD; inflow/outflow stock skipped when the user controls the patch, user UDD preserved; stock kept when the user writes a different variable).
- Identical logic to compute#6130 (verified there, 4/4); CI runs the test here.

## Auto-hotfix note

This repo's create-hotfix-pr workflow caps at `MAX_HOTFIX_VERSION` 25.09 and only forwards to versions above the base, so merging this 25.9 PR forwards to nothing (25.10+ are maintained in compute). No cascade to circumvent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Translator-only change with targeted skip logic and new unit tests; default mass-flow behavior is unchanged when users do not supply conflicting UDDs.
> 
> **Overview**
> The solver translator no longer appends the built-in proportional **mass-flow** UDDs when a user **UDD** on the same patch already writes the matching control variable (**`totalPressureRatio`** on inflow, **`staticPressureRatio`** on outflow). A new **`_udd_controlled_outputs`** helper indexes user dynamics by patch (`full_name` or `name`) and output keys; **`mass_flow_default_udd`** passes that map into the default inflow/outflow generators so they skip only the conflicting stock controllers per entity.
> 
> Behavior is unchanged when there is no user UDD or when the user UDD targets a different output variable. **`tests/simulation/translator/test_mass_flow_controller_translation.py`** covers generation, skip, and preserve cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 859b1eefe839ab90b402fd67f97c2496a1c46262. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->