### PR TITLE
ci(*): use OIDC for CodeArtifact auth in offline bundle workflow

### DIFF
--- a/.github/actions/setup-codeartifact-poetry-auth/action.yml
+++ b/.github/actions/setup-codeartifact-poetry-auth/action.yml
@@ -1,12 +1,9 @@
 name: Setup CodeArtifact Poetry Auth
-description: Configure AWS credentials, fetch CodeArtifact token, and set Poetry auth env vars.
+description: Configure AWS credentials via OIDC, fetch CodeArtifact token, and set Poetry auth env vars.
 
 inputs:
-  aws-access-key-id:
-    description: AWS access key id for CodeArtifact access.
-    required: true
-  aws-secret-access-key:
-    description: AWS secret access key for CodeArtifact access.
+  role-to-assume:
+    description: IAM role ARN for OIDC-based auth. Requires id-token:write permission on the job.
     required: true
   aws-region:
     description: AWS region of the CodeArtifact domain.
@@ -32,8 +29,7 @@ runs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        aws-access-key-id: ${{ inputs.aws-access-key-id }}
-        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
+        role-to-assume: ${{ inputs.role-to-assume }}
         aws-region: ${{ inputs.aws-region }}
 
     - name: Get CodeArtifact token and set Poetry env

--- a/.github/workflows/build-offline-bundle.yml
+++ b/.github/workflows/build-offline-bundle.yml
@@ -35,6 +35,7 @@ on:
         default: ""
 
 permissions:
+  actions: write
   contents: read
   id-token: write
 

--- a/.github/workflows/build-offline-bundle.yml
+++ b/.github/workflows/build-offline-bundle.yml
@@ -34,6 +34,10 @@ on:
         type: string
         default: ""
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   resolve-ref:
     runs-on: ubuntu-latest
@@ -202,8 +206,7 @@ jobs:
       - name: Configure CodeArtifact auth
         uses: ./workflow-tooling/.github/actions/setup-codeartifact-poetry-auth
         with:
-          aws-access-key-id: ${{ secrets.AWS_CODEARTIFACT_READ_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.AWS_CODEARTIFACT_READ_ACCESS_SECRET }}
+          role-to-assume: arn:aws:iam::625554095313:role/github-action-codeartifact-readonly
 
       - name: Expose CodeArtifact URL to pip
         shell: bash

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -2,13 +2,12 @@ name: Codestyle checking
 
 on:
   workflow_call:
-    secrets:
-      AWS_CODEARTIFACT_READ_ACCESS_KEY:
-        required: true
-      AWS_CODEARTIFACT_READ_ACCESS_SECRET:
-        required: true
   workflow_dispatch:
-    
+
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   black:
     runs-on: ubuntu-latest
@@ -23,8 +22,7 @@ jobs:
       - name: Setup CodeArtifact auth for Poetry
         uses: ./.github/actions/setup-codeartifact-poetry-auth
         with:
-          aws-access-key-id: ${{ secrets.AWS_CODEARTIFACT_READ_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.AWS_CODEARTIFACT_READ_ACCESS_SECRET }}
+          role-to-assume: arn:aws:iam::625554095313:role/github-action-codeartifact-readonly
       - name: Install black
         run: poetry install
       - name: Run black
@@ -43,12 +41,11 @@ jobs:
       - name: Setup CodeArtifact auth for Poetry
         uses: ./.github/actions/setup-codeartifact-poetry-auth
         with:
-          aws-access-key-id: ${{ secrets.AWS_CODEARTIFACT_READ_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.AWS_CODEARTIFACT_READ_ACCESS_SECRET }}
+          role-to-assume: arn:aws:iam::625554095313:role/github-action-codeartifact-readonly
       - name: Install isort
         run: poetry install
       - name: Check isort version
-        run: poetry run isort --version 
+        run: poetry run isort --version
       - name: Run isort
         run: poetry run isort . --check-only
 
@@ -75,8 +72,7 @@ jobs:
       - name: Setup CodeArtifact auth for Poetry
         uses: ./.github/actions/setup-codeartifact-poetry-auth
         with:
-          aws-access-key-id: ${{ secrets.AWS_CODEARTIFACT_READ_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.AWS_CODEARTIFACT_READ_ACCESS_SECRET }}
+          role-to-assume: arn:aws:iam::625554095313:role/github-action-codeartifact-readonly
       - name: Install dependencies
         run: poetry install
       - name: Run pylint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,14 +30,10 @@ on:
       - release-candidate/25.8
       - release-candidate/25.9
   workflow_call:
-    secrets:
-      AWS_CODEARTIFACT_READ_ACCESS_KEY:
-        required: true
-      AWS_CODEARTIFACT_READ_ACCESS_SECRET:
-        required: true
 
 permissions:
   contents: read
+  id-token: write
   pull-requests: write
 
 jobs:
@@ -82,8 +78,7 @@ jobs:
     - name: Setup CodeArtifact auth for Poetry
       uses: ./.github/actions/setup-codeartifact-poetry-auth
       with:
-        aws-access-key-id: ${{ secrets.AWS_CODEARTIFACT_READ_ACCESS_KEY }}
-        aws-secret-access-key: ${{ secrets.AWS_CODEARTIFACT_READ_ACCESS_SECRET }}
+        role-to-assume: arn:aws:iam::625554095313:role/github-action-codeartifact-readonly
 
     - name: Install dependencies
       run: poetry install


### PR DESCRIPTION
## Summary
- Remove all static AWS access key inputs from `setup-codeartifact-poetry-auth` composite action — OIDC via `role-to-assume` is now the only auth path
- Switch all workflows (`build-offline-bundle`, `codestyle`, `test`) from `AWS_CODEARTIFACT_READ_ACCESS_KEY`/`SECRET` secrets to OIDC with the readonly IAM role
- Add `id-token: write` and `actions: write` permissions

## Context
The offline bundle build ([run #28024983752](https://github.com/flexcompute/Flow360/actions/runs/28024983752)) fails at "Configure CodeArtifact auth" with "The security token included in the request is invalid" — the static AWS credentials are broken.

## IAM Setup (already applied in aws-comm-prod 625554095313)

| Role | Trust | Permissions |
|------|-------|-------------|
| `github-action-codeartifact-readonly` | OIDC for `repo:flexcompute/*:*` | Read from all CodeArtifact repos |
| `github-action-codeartifact-publish` | OIDC for `repo:flexcompute/*:*` | Read + publish to all CodeArtifact repos |

All workflows in this PR use the **readonly** role since they only install dependencies.

## Verified
- [Build passed](https://github.com/flexcompute/Flow360/actions/runs/28042994283) on `lei/codeartifact-oidc` with OIDC auth (offline bundle, linux-x86_64, py3.13)

## Test plan
- [x] Trigger offline bundle workflow on branch — OIDC auth and full build succeeded
- [ ] Verify codestyle/test workflows pass on a release-candidate branch after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how CI obtains AWS credentials for private package installs; misconfigured IAM trust or role permissions would break all Poetry installs in CI, but application runtime code is unaffected.
> 
> **Overview**
> **CodeArtifact access in CI now uses GitHub OIDC** instead of long-lived `AWS_CODEARTIFACT_READ_ACCESS_*` secrets.
> 
> The composite action `setup-codeartifact-poetry-auth` drops static key inputs and **requires** `role-to-assume`, wiring `aws-actions/configure-aws-credentials@v4` to assume that IAM role. **`build-offline-bundle`**, **`codestyle`**, and **`test`** pass `arn:aws:iam::625554095313:role/github-action-codeartifact-readonly` and grant **`id-token: write`** (offline bundle also sets `actions: write` and `contents: read`). Callable workflows no longer declare CodeArtifact secrets on `workflow_call`.
> 
> A trivial whitespace fix in the isort version check step in `codestyle.yml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfee8a663631d2ed191e535764f88b2e997274cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->